### PR TITLE
Add transform_mut method to objects

### DIFF
--- a/embedded-graphics/src/fonts/font12x16.rs
+++ b/embedded-graphics/src/fonts/font12x16.rs
@@ -72,7 +72,9 @@ impl<'a> Iterator for Font12x16Iterator<'a> {
             // + Character row offset (row 0 = 0, row 1 = (192 * 8) = 1536)
             // + X offset for the pixel block that comprises this char
             // + Y offset for pixel block
-            let bitmap_bit_index = char_x + (FONT_IMAGE_WIDTH * char_y) + self.char_walk_x
+            let bitmap_bit_index = char_x
+                + (FONT_IMAGE_WIDTH * char_y)
+                + self.char_walk_x
                 + (self.char_walk_y * FONT_IMAGE_WIDTH);
 
             let bitmap_byte = bitmap_bit_index / 8;
@@ -107,14 +109,13 @@ impl<'a> Iterator for Font12x16Iterator<'a> {
 impl<'a> Drawable for Font12x16<'a> {}
 
 impl<'a> Transform for Font12x16<'a> {
-    /// Translate the image from its current position to a new position by (x, y) pixels, returning
-    /// a new `Font12x16`.
+    /// Translate the font origin from its current position to a new position by (x, y) pixels,
+    /// returning a new `Font12x16`. For a mutating transform, see `translate_mut`.
     ///
     /// ```
     /// # use embedded_graphics::fonts::{ Font, Font12x16 };
     /// # use embedded_graphics::transform::Transform;
     ///
-    /// // 8px x 1px test image
     /// let text = Font12x16::render_str("Hello world");
     /// let moved = text.translate((25, 30));
     ///
@@ -126,5 +127,22 @@ impl<'a> Transform for Font12x16<'a> {
             pos: (self.pos.0 + by.0, self.pos.1 + by.1),
             ..*self
         }
+    }
+
+    /// Translate the font origin from its current position to a new position by (x, y) pixels.
+    ///
+    /// ```
+    /// # use embedded_graphics::fonts::{ Font, Font12x16 };
+    /// # use embedded_graphics::transform::Transform;
+    ///
+    /// let mut text = Font12x16::render_str("Hello world");
+    /// text.translate_mut((25, 30));
+    ///
+    /// assert_eq!(text.pos, (25, 30));
+    /// ```
+    fn translate_mut(&mut self, by: Coord) -> &mut Self {
+        self.pos = (self.pos.0 + by.0, self.pos.1 + by.1);
+
+        self
     }
 }

--- a/embedded-graphics/src/fonts/font6x12.rs
+++ b/embedded-graphics/src/fonts/font6x12.rs
@@ -72,7 +72,9 @@ impl<'a> Iterator for Font6x12Iterator<'a> {
             // + Character row offset (row 0 = 0, row 1 = (192 * 8) = 1536)
             // + X offset for the pixel block that comprises this char
             // + Y offset for pixel block
-            let bitmap_bit_index = char_x + (FONT_IMAGE_WIDTH * char_y) + self.char_walk_x
+            let bitmap_bit_index = char_x
+                + (FONT_IMAGE_WIDTH * char_y)
+                + self.char_walk_x
                 + (self.char_walk_y * FONT_IMAGE_WIDTH);
 
             let bitmap_byte = bitmap_bit_index / 8;
@@ -107,14 +109,13 @@ impl<'a> Iterator for Font6x12Iterator<'a> {
 impl<'a> Drawable for Font6x12<'a> {}
 
 impl<'a> Transform for Font6x12<'a> {
-    /// Translate the image from its current position to a new position by (x, y) pixels, returning
-    /// a new `Font6x8`.
+    /// Translate the font origin from its current position to a new position by (x, y) pixels,
+    /// returning a new `Font6x8`. For a mutating transform, see `translate_mut`.
     ///
     /// ```
     /// # use embedded_graphics::fonts::{ Font, Font6x8 };
     /// # use embedded_graphics::transform::Transform;
     ///
-    /// // 8px x 1px test image
     /// let text = Font6x8::render_str("Hello world");
     /// let moved = text.translate((25, 30));
     ///
@@ -126,5 +127,23 @@ impl<'a> Transform for Font6x12<'a> {
             pos: (self.pos.0 + by.0, self.pos.1 + by.1),
             ..*self
         }
+    }
+
+    /// Translate the font origin from its current position to a new position by (x, y) pixels.
+    ///
+    /// ```
+    /// # use embedded_graphics::fonts::{ Font, Font6x12 };
+    /// # use embedded_graphics::transform::Transform;
+    ///
+    /// // 8px x 1px test image
+    /// let mut text = Font6x12::render_str("Hello world");
+    /// text.translate_mut((25, 30));
+    ///
+    /// assert_eq!(text.pos, (25, 30));
+    /// ```
+    fn translate_mut(&mut self, by: Coord) -> &mut Self {
+        self.pos = (self.pos.0 + by.0, self.pos.1 + by.1);
+
+        self
     }
 }

--- a/embedded-graphics/src/fonts/font6x8.rs
+++ b/embedded-graphics/src/fonts/font6x8.rs
@@ -72,7 +72,9 @@ impl<'a> Iterator for Font6x8Iterator<'a> {
             // + Character row offset (row 0 = 0, row 1 = (192 * 8) = 1536)
             // + X offset for the pixel block that comprises this char
             // + Y offset for pixel block
-            let bitmap_bit_index = char_x + (FONT_IMAGE_WIDTH * char_y) + self.char_walk_x
+            let bitmap_bit_index = char_x
+                + (FONT_IMAGE_WIDTH * char_y)
+                + self.char_walk_x
                 + (self.char_walk_y * FONT_IMAGE_WIDTH);
 
             let bitmap_byte = bitmap_bit_index / 8;
@@ -108,7 +110,7 @@ impl<'a> Drawable for Font6x8<'a> {}
 
 impl<'a> Transform for Font6x8<'a> {
     /// Translate the image from its current position to a new position by (x, y) pixels, returning
-    /// a new `Font6x8`.
+    /// a new `Font6x8`. For a mutating transform, see `translate_mut`.
     ///
     /// ```
     /// # use embedded_graphics::fonts::{ Font, Font6x8 };
@@ -126,5 +128,22 @@ impl<'a> Transform for Font6x8<'a> {
             pos: (self.pos.0 + by.0, self.pos.1 + by.1),
             ..*self
         }
+    }
+
+    /// Translate the font origin from its current position to a new position by (x, y) pixels.
+    ///
+    /// ```
+    /// # use embedded_graphics::fonts::{ Font, Font6x8 };
+    /// # use embedded_graphics::transform::Transform;
+    ///
+    /// let mut text = Font6x8::render_str("Hello world");
+    /// text.translate_mut((25, 30));
+    ///
+    /// assert_eq!(text.pos, (25, 30));
+    /// ```
+    fn translate_mut(&mut self, by: Coord) -> &mut Self {
+        self.pos = (self.pos.0 + by.0, self.pos.1 + by.1);
+
+        self
     }
 }

--- a/embedded-graphics/src/fonts/font8x16.rs
+++ b/embedded-graphics/src/fonts/font8x16.rs
@@ -72,7 +72,9 @@ impl<'a> Iterator for Font8x16Iterator<'a> {
             // + Character row offset (row 0 = 0, row 1 = (192 * 8) = 1536)
             // + X offset for the pixel block that comprises this char
             // + Y offset for pixel block
-            let bitmap_bit_index = char_x + (FONT_IMAGE_WIDTH * char_y) + self.char_walk_x
+            let bitmap_bit_index = char_x
+                + (FONT_IMAGE_WIDTH * char_y)
+                + self.char_walk_x
                 + (self.char_walk_y * FONT_IMAGE_WIDTH);
 
             let bitmap_byte = bitmap_bit_index / 8;
@@ -108,7 +110,7 @@ impl<'a> Drawable for Font8x16<'a> {}
 
 impl<'a> Transform for Font8x16<'a> {
     /// Translate the image from its current position to a new position by (x, y) pixels, returning
-    /// a new `Font8x16`.
+    /// a new `Font8x16`. For a mutating transform, see `translate_mut`.
     ///
     /// ```
     /// # use embedded_graphics::fonts::{ Font, Font8x16 };
@@ -126,5 +128,22 @@ impl<'a> Transform for Font8x16<'a> {
             pos: (self.pos.0 + by.0, self.pos.1 + by.1),
             ..*self
         }
+    }
+
+    /// Translate the font origin from its current position to a new position by (x, y) pixels.
+    ///
+    /// ```
+    /// # use embedded_graphics::fonts::{ Font, Font6x8 };
+    /// # use embedded_graphics::transform::Transform;
+    ///
+    /// let mut text = Font6x8::render_str("Hello world");
+    /// text.translate_mut((25, 30));
+    ///
+    /// assert_eq!(text.pos, (25, 30));
+    /// ```
+    fn translate_mut(&mut self, by: Coord) -> &mut Self {
+        self.pos = (self.pos.0 + by.0, self.pos.1 + by.1);
+
+        self
     }
 }

--- a/embedded-graphics/src/image/image1bpp.rs
+++ b/embedded-graphics/src/image/image1bpp.rs
@@ -104,7 +104,7 @@ impl<'a> Drawable for Image1BPP<'a> {}
 
 impl<'a> Transform for Image1BPP<'a> {
     /// Translate the image from its current position to a new position by (x, y) pixels, returning
-    /// a new `Image1BPP`.
+    /// a new `Image1BPP`. For a mutating transform, see `translate_mut`.
     ///
     /// ```
     /// # use embedded_graphics::image::{ Image, Image1BPP };
@@ -122,5 +122,22 @@ impl<'a> Transform for Image1BPP<'a> {
             offset: (self.offset.0 + by.0, self.offset.1 + by.1),
             ..*self
         }
+    }
+
+    /// Translate the image from its current position to a new position by (x, y) pixels.
+    ///
+    /// ```
+    /// # use embedded_graphics::image::{ Image, Image1BPP };
+    /// # use embedded_graphics::transform::Transform;
+    ///
+    /// let mut image = Image1BPP::new(&[ 0xff ], 8, 1);
+    /// image.translate_mut((25, 30));
+    ///
+    /// assert_eq!(image.offset, (25, 30));
+    /// ```
+    fn translate_mut(&mut self, by: Coord) -> &mut Self {
+        self.offset = (self.offset.0 + by.0, self.offset.1 + by.1);
+
+        self
     }
 }

--- a/embedded-graphics/src/image/image8bpp.rs
+++ b/embedded-graphics/src/image/image8bpp.rs
@@ -99,14 +99,14 @@ impl<'a> Drawable for Image8BPP<'a> {}
 
 impl<'a> Transform for Image8BPP<'a> {
     /// Translate the image from its current position to a new position by (x, y) pixels, returning
-    /// a new `Image8BPP`.
+    /// a new `Image8BPP`. For a mutating transform, see `translate_mut`.
     ///
     /// ```
     /// # use embedded_graphics::image::{ Image, Image8BPP };
     /// # use embedded_graphics::transform::Transform;
     ///
-    /// // 8px x 1px test image
-    /// let image = Image8BPP::new(&[ 0xff ], 8, 1);
+    /// // 1px x 1px test image
+    /// let image = Image8BPP::new(&[ 0xff ], 1, 1);
     /// let moved = image.translate((25, 30));
     ///
     /// assert_eq!(image.offset, (0, 0));
@@ -117,5 +117,23 @@ impl<'a> Transform for Image8BPP<'a> {
             offset: (self.offset.0 + by.0, self.offset.1 + by.1),
             ..*self
         }
+    }
+
+    /// Translate the image from its current position to a new position by (x, y) pixels.
+    ///
+    /// ```
+    /// # use embedded_graphics::image::{ Image, Image8BPP };
+    /// # use embedded_graphics::transform::Transform;
+    ///
+    /// // 1px x 1px test image
+    /// let mut image = Image8BPP::new(&[ 0xff ], 1, 1);
+    /// image.translate_mut((25, 30));
+    ///
+    /// assert_eq!(image.offset, (25, 30));
+    /// ```
+    fn translate_mut(&mut self, by: Coord) -> &mut Self {
+        self.offset = (self.offset.0 + by.0, self.offset.1 + by.1);
+
+        self
     }
 }

--- a/embedded-graphics/src/lib.rs
+++ b/embedded-graphics/src/lib.rs
@@ -6,9 +6,9 @@
 //! * 1 bit-per-pixel images
 //! * 8 bit-per-pixel images (downsampled to 1BPP currently)
 //! * Primitives
-//! 	* Lines
-//! 	* Rectangles (and squares)
-//! 	* Circles
+//!     * Lines
+//!     * Rectangles (and squares)
+//!     * Circles
 //! * Text with a 6x8 pixel font
 //!
 //! A core goal is to do the above without using any buffers; the crate should work without a

--- a/embedded-graphics/src/primitives/circle.rs
+++ b/embedded-graphics/src/primitives/circle.rs
@@ -111,7 +111,7 @@ impl Drawable for Circle {}
 
 impl Transform for Circle {
     /// Translate the circle center from its current position to a new position by (x, y) pixels,
-    /// returning a new `Circle`.
+    /// returning a new `Circle`. For a mutating transform, see `translate_mut`.
     ///
     /// ```
     /// # use embedded_graphics::primitives::Circle;
@@ -127,5 +127,22 @@ impl Transform for Circle {
             center: (self.center.0 + by.0, self.center.1 + by.1),
             ..*self
         }
+    }
+
+    /// Translate the circle center from its current position to a new position by (x, y) pixels.
+    ///
+    /// ```
+    /// # use embedded_graphics::primitives::Circle;
+    /// # use embedded_graphics::transform::Transform;
+    ///
+    /// let mut circle = Circle::new((5, 10), 10, 1);
+    /// circle.translate_mut((10, 10));
+    ///
+    /// assert_eq!(circle.center, (15, 20));
+    /// ```
+    fn translate_mut(&mut self, by: Coord) -> &mut Self {
+        self.center = (self.center.0 + by.0, self.center.1 + by.1);
+
+        self
     }
 }

--- a/embedded-graphics/src/primitives/line.rs
+++ b/embedded-graphics/src/primitives/line.rs
@@ -143,7 +143,7 @@ impl Drawable for Line {}
 
 impl Transform for Line {
     /// Translate the line from its current position to a new position by (x, y) pixels, returning
-    /// a new `Line`.
+    /// a new `Line`. For a mutating transform, see `translate_mut`.
     ///
     /// ```
     /// # use embedded_graphics::primitives::Line;
@@ -161,6 +161,25 @@ impl Transform for Line {
             end: (self.end.0 + by.0, self.end.1 + by.1),
             ..*self
         }
+    }
+
+    /// Translate the line from its current position to a new position by (x, y) pixels.
+    ///
+    /// ```
+    /// # use embedded_graphics::primitives::Line;
+    /// # use embedded_graphics::transform::Transform;
+    ///
+    /// let mut line = Line::new((5, 10), (15, 20), 1);
+    /// line.translate_mut((10, 10));
+    ///
+    /// assert_eq!(line.start, (15, 20));
+    /// assert_eq!(line.end, (25, 30));
+    /// ```
+    fn translate_mut(&mut self, by: Coord) -> &mut Self {
+        self.start = (self.start.0 + by.0, self.start.1 + by.1);
+        self.end = (self.end.0 + by.0, self.end.1 + by.1);
+
+        self
     }
 }
 

--- a/embedded-graphics/src/primitives/rect.rs
+++ b/embedded-graphics/src/primitives/rect.rs
@@ -87,7 +87,7 @@ impl Drawable for Rect {}
 
 impl Transform for Rect {
     /// Translate the rect from its current position to a new position by (x, y) pixels, returning
-    /// a new `Rect`.
+    /// a new `Rect`. For a mutating transform, see `translate_mut`.
     ///
     /// ```
     /// # use embedded_graphics::primitives::Rect;
@@ -105,5 +105,24 @@ impl Transform for Rect {
             bottom_right: (self.bottom_right.0 + by.0, self.bottom_right.1 + by.1),
             ..*self
         }
+    }
+
+    /// Translate the rect from its current position to a new position by (x, y) pixels.
+    ///
+    /// ```
+    /// # use embedded_graphics::primitives::Rect;
+    /// # use embedded_graphics::transform::Transform;
+    ///
+    /// let mut rect = Rect::new((5, 10), (15, 20), 1);
+    /// rect.translate_mut((10, 10));
+    ///
+    /// assert_eq!(rect.top_left, (15, 20));
+    /// assert_eq!(rect.bottom_right, (25, 30));
+    /// ```
+    fn translate_mut(&mut self, by: Coord) -> &mut Self {
+        self.top_left = (self.top_left.0 + by.0, self.top_left.1 + by.1);
+        self.bottom_right = (self.bottom_right.0 + by.0, self.bottom_right.1 + by.1);
+
+        self
     }
 }

--- a/embedded-graphics/src/transform.rs
+++ b/embedded-graphics/src/transform.rs
@@ -4,6 +4,10 @@ use super::drawable::Coord;
 
 /// Transform operations
 pub trait Transform {
-    /// Move the origin of an object by a given number of (x, y) pixels
+    /// Move the origin of an object by a given number of (x, y) pixels, returning a new object
     fn translate(&self, by: Coord) -> Self;
+
+    /// Move the origin of an object by a given number of (x, y) pixels, mutating the object
+    /// in place
+    fn translate_mut(&mut self, by: Coord) -> &mut Self;
 }


### PR DESCRIPTION
This allows one to transform an object in place instead of `transform()` returning a copied object.

There's also some `rustfmt` noise.

Closes #32