### PR TITLE
Optional Nalgebra support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -86,10 +86,9 @@ install:
   - rustup override set nightly
 
 script:
-  - cargo build -p embedded-graphics
   - cargo build --release -p embedded-graphics
-  - cargo test -p embedded-graphics
   - cargo test --release -p embedded-graphics
+  - cargo test --release --all-features -p embedded-graphics
   - cargo doc --release -p embedded-graphics
 
 after_success:

--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ fn main() {
 }
 ```
 
+## Features
+
+* `nalgebra_support` - use the [Nalgebra](https://crates.io/crates/nalgebra) crate with `no_std` support to use as the `Coord` type. This should allow you to use most Nalgebra methods on objects rendered by embedded_graphics.
+
 ## TODO
 
 * [ ] General matrix transforms

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ following:
     * Lines
     * Rectangles (and squares)
     * Circles
-* Text with a 6x8 pixel font
+* Text with [multiple bitmap fonts](src/fonts)
 
 A core goal is to do the above without using any buffers; the crate should work without a
 dynamic memory allocator and without pre-allocating large chunks of memory. To achieve this, it
@@ -72,7 +72,7 @@ fn main() {
         &mut rcc.apb1,
     );
 
-    let im = Image1BPP::new(include_bytes!("./rust.raw"), 64, 64).translate((32, 0));
+    let im = Image1BPP::new(include_bytes!("./rust.raw"), 64, 64).translate(Coord::new(32, 0));
     let mut disp: GraphicsMode<_> = Builder::new().connect_i2c(i2c).into();
 
     disp.init().unwrap();

--- a/embedded-graphics/Cargo.toml
+++ b/embedded-graphics/Cargo.toml
@@ -19,3 +19,8 @@ exclude = [
 travis-ci = { repository = "jamwaffles/embedded-graphics", branch = "master" }
 
 [dependencies]
+nalgebra = { version = "0.16.0", optional = true, default-features = false }
+
+[features]
+default = []
+nalgebra_support = [ "nalgebra" ]

--- a/embedded-graphics/src/coord.rs
+++ b/embedded-graphics/src/coord.rs
@@ -4,7 +4,7 @@
 mod internal_coord {
     use core::ops::{Add, AddAssign, Index, Sub, SubAssign};
 
-    /// 2D coordinate type (without Nalgebra support)
+    /// 2D coordinate type
     #[derive(Debug, Copy, Clone, Eq, PartialEq)]
     pub struct Coord(pub u32, pub u32);
 

--- a/embedded-graphics/src/coord.rs
+++ b/embedded-graphics/src/coord.rs
@@ -1,0 +1,99 @@
+//! 2D coordinate in screen space
+
+#[cfg(not(feature = "nalgebra_support"))]
+mod internal_coord {
+    use core::ops::{Add, AddAssign, Index, Sub, SubAssign};
+
+    /// 2D coordinate type (without Nalgebra support)
+    #[derive(Debug, Copy, Clone, Eq, PartialEq)]
+    pub struct Coord(pub u32, pub u32);
+
+    impl Coord {
+        /// Create a new coordinate with X and Y values
+        pub fn new(x: u32, y: u32) -> Self {
+            Coord(x, y)
+        }
+    }
+
+    impl Add for Coord {
+        type Output = Coord;
+
+        fn add(self, other: Coord) -> Coord {
+            Coord::new(self.0 + other.0, self.1 + other.1)
+        }
+    }
+
+    impl AddAssign for Coord {
+        fn add_assign(&mut self, other: Coord) {
+            self.0 += other.0;
+            self.1 += other.1;
+        }
+    }
+
+    impl Sub for Coord {
+        type Output = Coord;
+
+        fn sub(self, other: Coord) -> Coord {
+            Coord::new(self.0 - other.0, self.1 - other.1)
+        }
+    }
+
+    impl SubAssign for Coord {
+        fn sub_assign(&mut self, other: Coord) {
+            self.0 -= other.0;
+            self.1 -= other.1;
+        }
+    }
+
+    impl Index<usize> for Coord {
+        type Output = u32;
+
+        fn index(&self, idx: usize) -> &u32 {
+            match idx {
+                0 => &self.0,
+                1 => &self.1,
+                _ => panic!("Unreachable index {}", idx),
+            }
+        }
+    }
+}
+
+#[cfg(not(feature = "nalgebra_support"))]
+pub use self::internal_coord::Coord;
+
+#[cfg(feature = "nalgebra_support")]
+use nalgebra;
+
+#[cfg(feature = "nalgebra_support")]
+/// 2D coordinate type with Nalgebra support
+pub type Coord = nalgebra::Vector2<u32>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn coords_can_be_added() {
+        let left = Coord::new(10, 20);
+        let right = Coord::new(30, 40);
+
+        assert_eq!(left + right, Coord::new(40, 60));
+    }
+
+    #[test]
+    fn coords_can_be_subtracted() {
+        let left = Coord::new(30, 40);
+        let right = Coord::new(10, 20);
+
+        assert_eq!(left - right, Coord::new(20, 20));
+    }
+
+    #[test]
+    #[cfg(feature = "nalgebra_support")]
+    fn nalgebra_support() {
+        let left = nalgebra::Vector2::new(30, 40);
+        let right = nalgebra::Vector2::new(10, 20);
+
+        assert_eq!(left - right, Coord::new(20, 20));
+    }
+}

--- a/embedded-graphics/src/drawable.rs
+++ b/embedded-graphics/src/drawable.rs
@@ -1,74 +1,6 @@
 //! `Drawable` trait and helpers
 
-#[cfg(not(feature = "nalgebra_support"))]
-use core::ops::{Add, AddAssign, Index, Sub, SubAssign};
-
-#[cfg(feature = "nalgebra_support")]
-use nalgebra;
-
-/// 2D coordinate type
-#[cfg(not(feature = "nalgebra_support"))]
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
-pub struct Coord(pub u32, pub u32);
-
-#[cfg(not(feature = "nalgebra_support"))]
-impl Coord {
-    /// Create a new coordinate with X and Y values
-    pub fn new(x: u32, y: u32) -> Self {
-        Coord(x, y)
-    }
-}
-
-#[cfg(not(feature = "nalgebra_support"))]
-impl Add for Coord {
-    type Output = Coord;
-
-    fn add(self, other: Coord) -> Coord {
-        Coord::new(self.0 + other.0, self.1 + other.1)
-    }
-}
-
-#[cfg(not(feature = "nalgebra_support"))]
-impl AddAssign for Coord {
-    fn add_assign(&mut self, other: Coord) {
-        self.0 += other.0;
-        self.1 += other.1;
-    }
-}
-
-#[cfg(not(feature = "nalgebra_support"))]
-impl Sub for Coord {
-    type Output = Coord;
-
-    fn sub(self, other: Coord) -> Coord {
-        Coord::new(self.0 - other.0, self.1 - other.1)
-    }
-}
-
-#[cfg(not(feature = "nalgebra_support"))]
-impl SubAssign for Coord {
-    fn sub_assign(&mut self, other: Coord) {
-        self.0 -= other.0;
-        self.1 -= other.1;
-    }
-}
-
-#[cfg(not(feature = "nalgebra_support"))]
-impl Index<usize> for Coord {
-    type Output = u32;
-
-    fn index(&self, idx: usize) -> &u32 {
-        match idx {
-            0 => &self.0,
-            1 => &self.1,
-            _ => panic!("Unreachable index {}", idx),
-        }
-    }
-}
-
-/// 2D coordinate type
-#[cfg(feature = "nalgebra_support")]
-pub type Coord = nalgebra::Vector2<u32>;
+use super::coord::Coord;
 
 // TODO: Refactor to use both with monochrome and multicolour displays
 /// Monochrome colour type
@@ -79,33 +11,3 @@ pub type Pixel = (Coord, Color);
 
 /// Marks an object as "drawable". Must be implemented for all graphics objects
 pub trait Drawable {}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn coords_can_be_added() {
-        let left = Coord::new(10, 20);
-        let right = Coord::new(30, 40);
-
-        assert_eq!(left + right, Coord::new(40, 60));
-    }
-
-    #[test]
-    fn coords_can_be_subtracted() {
-        let left = Coord::new(30, 40);
-        let right = Coord::new(10, 20);
-
-        assert_eq!(left - right, Coord::new(20, 20));
-    }
-
-    #[test]
-    #[cfg(feature = "nalgebra_support")]
-    fn nalgebra_support() {
-        let left = nalgebra::Vector2::new(30, 40);
-        let right = nalgebra::Vector2::new(10, 20);
-
-        assert_eq!(left - right, Coord::new(20, 20));
-    }
-}

--- a/embedded-graphics/src/drawable.rs
+++ b/embedded-graphics/src/drawable.rs
@@ -1,6 +1,7 @@
 //! `Drawable` trait and helpers
 
-use core::ops::{Add, AddAssign, Sub, SubAssign};
+#[cfg(not(feature = "nalgebra_support"))]
+use core::ops::{Add, AddAssign, Index, Sub, SubAssign};
 
 #[cfg(feature = "nalgebra_support")]
 use nalgebra;
@@ -10,6 +11,7 @@ use nalgebra;
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub struct Coord(pub u32, pub u32);
 
+#[cfg(not(feature = "nalgebra_support"))]
 impl Coord {
     /// Create a new coordinate with X and Y values
     pub fn new(x: u32, y: u32) -> Self {
@@ -17,6 +19,7 @@ impl Coord {
     }
 }
 
+#[cfg(not(feature = "nalgebra_support"))]
 impl Add for Coord {
     type Output = Coord;
 
@@ -25,6 +28,7 @@ impl Add for Coord {
     }
 }
 
+#[cfg(not(feature = "nalgebra_support"))]
 impl AddAssign for Coord {
     fn add_assign(&mut self, other: Coord) {
         self.0 += other.0;
@@ -32,6 +36,7 @@ impl AddAssign for Coord {
     }
 }
 
+#[cfg(not(feature = "nalgebra_support"))]
 impl Sub for Coord {
     type Output = Coord;
 
@@ -40,10 +45,24 @@ impl Sub for Coord {
     }
 }
 
+#[cfg(not(feature = "nalgebra_support"))]
 impl SubAssign for Coord {
     fn sub_assign(&mut self, other: Coord) {
         self.0 -= other.0;
         self.1 -= other.1;
+    }
+}
+
+#[cfg(not(feature = "nalgebra_support"))]
+impl Index<usize> for Coord {
+    type Output = u32;
+
+    fn index(&self, idx: usize) -> &u32 {
+        match idx {
+            0 => &self.0,
+            1 => &self.1,
+            _ => panic!("Unreachable index {}", idx),
+        }
     }
 }
 
@@ -77,6 +96,15 @@ mod tests {
     fn coords_can_be_subtracted() {
         let left = Coord::new(30, 40);
         let right = Coord::new(10, 20);
+
+        assert_eq!(left - right, Coord::new(20, 20));
+    }
+
+    #[test]
+    #[cfg(feature = "nalgebra_support")]
+    fn nalgebra_support() {
+        let left = nalgebra::Vector2::new(30, 40);
+        let right = nalgebra::Vector2::new(10, 20);
 
         assert_eq!(left - right, Coord::new(20, 20));
     }

--- a/embedded-graphics/src/drawable.rs
+++ b/embedded-graphics/src/drawable.rs
@@ -1,5 +1,7 @@
 //! `Drawable` trait and helpers
 
+use core::ops::{Add, AddAssign, Sub, SubAssign};
+
 #[cfg(feature = "nalgebra_support")]
 use nalgebra;
 
@@ -12,6 +14,36 @@ impl Coord {
     /// Create a new coordinate with X and Y values
     pub fn new(x: u32, y: u32) -> Self {
         Coord(x, y)
+    }
+}
+
+impl Add for Coord {
+    type Output = Coord;
+
+    fn add(self, other: Coord) -> Coord {
+        Coord::new(self.0 + other.0, self.1 + other.1)
+    }
+}
+
+impl AddAssign for Coord {
+    fn add_assign(&mut self, other: Coord) {
+        self.0 += other.0;
+        self.1 += other.1;
+    }
+}
+
+impl Sub for Coord {
+    type Output = Coord;
+
+    fn sub(self, other: Coord) -> Coord {
+        Coord::new(self.0 - other.0, self.1 - other.1)
+    }
+}
+
+impl SubAssign for Coord {
+    fn sub_assign(&mut self, other: Coord) {
+        self.0 -= other.0;
+        self.1 -= other.1;
     }
 }
 
@@ -28,3 +60,24 @@ pub type Pixel = (Coord, Color);
 
 /// Marks an object as "drawable". Must be implemented for all graphics objects
 pub trait Drawable {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn coords_can_be_added() {
+        let left = Coord::new(10, 20);
+        let right = Coord::new(30, 40);
+
+        assert_eq!(left + right, Coord::new(40, 60));
+    }
+
+    #[test]
+    fn coords_can_be_subtracted() {
+        let left = Coord::new(30, 40);
+        let right = Coord::new(10, 20);
+
+        assert_eq!(left - right, Coord::new(20, 20));
+    }
+}

--- a/embedded-graphics/src/drawable.rs
+++ b/embedded-graphics/src/drawable.rs
@@ -1,7 +1,23 @@
 //! `Drawable` trait and helpers
 
+#[cfg(feature = "nalgebra_support")]
+use nalgebra;
+
 /// 2D coordinate type
-pub type Coord = (u32, u32);
+#[cfg(not(feature = "nalgebra_support"))]
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub struct Coord(pub u32, pub u32);
+
+impl Coord {
+    /// Create a new coordinate with X and Y values
+    pub fn new(x: u32, y: u32) -> Self {
+        Coord(x, y)
+    }
+}
+
+/// 2D coordinate type
+#[cfg(feature = "nalgebra_support")]
+pub type Coord = nalgebra::Vector2<u32>;
 
 // TODO: Refactor to use both with monochrome and multicolour displays
 /// Monochrome colour type

--- a/embedded-graphics/src/fonts/font12x16.rs
+++ b/embedded-graphics/src/fonts/font12x16.rs
@@ -23,7 +23,10 @@ pub struct Font12x16<'a> {
 
 impl<'a> Font<'a> for Font12x16<'a> {
     fn render_str(text: &'a str) -> Font12x16<'a> {
-        Self { pos: (0, 0), text }
+        Self {
+            pos: Coord::new(0, 0),
+            text,
+        }
     }
 }
 
@@ -99,7 +102,7 @@ impl<'a> Iterator for Font12x16Iterator<'a> {
             let x = self.pos.0 + (CHAR_WIDTH * self.idx as u32) + self.char_walk_x;
             let y = self.pos.1 + self.char_walk_y;
 
-            Some(((x, y), bit_value))
+            Some((Coord::new(x, y), bit_value))
         } else {
             None
         }
@@ -115,16 +118,17 @@ impl<'a> Transform for Font12x16<'a> {
     /// ```
     /// # use embedded_graphics::fonts::{ Font, Font12x16 };
     /// # use embedded_graphics::transform::Transform;
+    /// # use embedded_graphics::drawable::Coord;
     ///
     /// let text = Font12x16::render_str("Hello world");
-    /// let moved = text.translate((25, 30));
+    /// let moved = text.translate(Coord::new(25, 30));
     ///
-    /// assert_eq!(text.pos, (0, 0));
-    /// assert_eq!(moved.pos, (25, 30));
+    /// assert_eq!(text.pos, Coord::new(0, 0));
+    /// assert_eq!(moved.pos, Coord::new(25, 30));
     /// ```
     fn translate(&self, by: Coord) -> Self {
         Self {
-            pos: (self.pos.0 + by.0, self.pos.1 + by.1),
+            pos: Coord::new(self.pos.0 + by.0, self.pos.1 + by.1),
             ..*self
         }
     }
@@ -134,14 +138,15 @@ impl<'a> Transform for Font12x16<'a> {
     /// ```
     /// # use embedded_graphics::fonts::{ Font, Font12x16 };
     /// # use embedded_graphics::transform::Transform;
+    /// # use embedded_graphics::drawable::Coord;
     ///
     /// let mut text = Font12x16::render_str("Hello world");
-    /// text.translate_mut((25, 30));
+    /// text.translate_mut(Coord::new(25, 30));
     ///
-    /// assert_eq!(text.pos, (25, 30));
+    /// assert_eq!(text.pos, Coord::new(25, 30));
     /// ```
     fn translate_mut(&mut self, by: Coord) -> &mut Self {
-        self.pos = (self.pos.0 + by.0, self.pos.1 + by.1);
+        self.pos = Coord::new(self.pos.0 + by.0, self.pos.1 + by.1);
 
         self
     }

--- a/embedded-graphics/src/fonts/font12x16.rs
+++ b/embedded-graphics/src/fonts/font12x16.rs
@@ -99,8 +99,8 @@ impl<'a> Iterator for Font12x16Iterator<'a> {
                 }
             }
 
-            let x = self.pos.0 + (CHAR_WIDTH * self.idx as u32) + self.char_walk_x;
-            let y = self.pos.1 + self.char_walk_y;
+            let x = self.pos[0] + (CHAR_WIDTH * self.idx as u32) + self.char_walk_x;
+            let y = self.pos[1] + self.char_walk_y;
 
             Some((Coord::new(x, y), bit_value))
         } else {

--- a/embedded-graphics/src/fonts/font12x16.rs
+++ b/embedded-graphics/src/fonts/font12x16.rs
@@ -3,6 +3,7 @@
 use super::super::drawable::*;
 use super::super::transform::*;
 use super::Font;
+use coord::Coord;
 
 const FONT_IMAGE: &[u8] = include_bytes!("../../data/font12x16_1bpp.raw");
 const CHAR_HEIGHT: u32 = 16;
@@ -118,7 +119,7 @@ impl<'a> Transform for Font12x16<'a> {
     /// ```
     /// # use embedded_graphics::fonts::{ Font, Font12x16 };
     /// # use embedded_graphics::transform::Transform;
-    /// # use embedded_graphics::drawable::Coord;
+    /// # use embedded_graphics::coord::Coord;
     ///
     /// let text = Font12x16::render_str("Hello world");
     /// let moved = text.translate(Coord::new(25, 30));
@@ -138,7 +139,7 @@ impl<'a> Transform for Font12x16<'a> {
     /// ```
     /// # use embedded_graphics::fonts::{ Font, Font12x16 };
     /// # use embedded_graphics::transform::Transform;
-    /// # use embedded_graphics::drawable::Coord;
+    /// # use embedded_graphics::coord::Coord;
     ///
     /// let mut text = Font12x16::render_str("Hello world");
     /// text.translate_mut(Coord::new(25, 30));

--- a/embedded-graphics/src/fonts/font12x16.rs
+++ b/embedded-graphics/src/fonts/font12x16.rs
@@ -128,7 +128,7 @@ impl<'a> Transform for Font12x16<'a> {
     /// ```
     fn translate(&self, by: Coord) -> Self {
         Self {
-            pos: Coord::new(self.pos.0 + by.0, self.pos.1 + by.1),
+            pos: self.pos + by,
             ..*self
         }
     }
@@ -146,7 +146,7 @@ impl<'a> Transform for Font12x16<'a> {
     /// assert_eq!(text.pos, Coord::new(25, 30));
     /// ```
     fn translate_mut(&mut self, by: Coord) -> &mut Self {
-        self.pos = Coord::new(self.pos.0 + by.0, self.pos.1 + by.1);
+        self.pos += by;
 
         self
     }

--- a/embedded-graphics/src/fonts/font6x12.rs
+++ b/embedded-graphics/src/fonts/font6x12.rs
@@ -3,6 +3,7 @@
 use super::super::drawable::*;
 use super::super::transform::*;
 use super::Font;
+use coord::Coord;
 
 const FONT_IMAGE: &[u8] = include_bytes!("../../data/font6x12_1bpp.raw");
 const CHAR_HEIGHT: u32 = 12;
@@ -118,7 +119,7 @@ impl<'a> Transform for Font6x12<'a> {
     /// ```
     /// # use embedded_graphics::fonts::{ Font, Font6x8 };
     /// # use embedded_graphics::transform::Transform;
-    /// # use embedded_graphics::drawable::Coord;
+    /// # use embedded_graphics::coord::Coord;
     ///
     /// let text = Font6x8::render_str("Hello world");
     /// let moved = text.translate(Coord::new(25, 30));
@@ -138,7 +139,7 @@ impl<'a> Transform for Font6x12<'a> {
     /// ```
     /// # use embedded_graphics::fonts::{ Font, Font6x12 };
     /// # use embedded_graphics::transform::Transform;
-    /// # use embedded_graphics::drawable::Coord;
+    /// # use embedded_graphics::coord::Coord;
     ///
     /// // 8px x 1px test image
     /// let mut text = Font6x12::render_str("Hello world");

--- a/embedded-graphics/src/fonts/font6x12.rs
+++ b/embedded-graphics/src/fonts/font6x12.rs
@@ -128,7 +128,7 @@ impl<'a> Transform for Font6x12<'a> {
     /// ```
     fn translate(&self, by: Coord) -> Self {
         Self {
-            pos: Coord::new(self.pos.0 + by.0, self.pos.1 + by.1),
+            pos: self.pos + by,
             ..*self
         }
     }
@@ -147,7 +147,7 @@ impl<'a> Transform for Font6x12<'a> {
     /// assert_eq!(text.pos, Coord::new(25, 30));
     /// ```
     fn translate_mut(&mut self, by: Coord) -> &mut Self {
-        self.pos = Coord::new(self.pos.0 + by.0, self.pos.1 + by.1);
+        self.pos += by;
 
         self
     }

--- a/embedded-graphics/src/fonts/font6x12.rs
+++ b/embedded-graphics/src/fonts/font6x12.rs
@@ -99,8 +99,8 @@ impl<'a> Iterator for Font6x12Iterator<'a> {
                 }
             }
 
-            let x = self.pos.0 + (CHAR_WIDTH * self.idx as u32) + self.char_walk_x;
-            let y = self.pos.1 + self.char_walk_y;
+            let x = self.pos[0] + (CHAR_WIDTH * self.idx as u32) + self.char_walk_x;
+            let y = self.pos[1] + self.char_walk_y;
 
             Some((Coord::new(x, y), bit_value))
         } else {

--- a/embedded-graphics/src/fonts/font6x12.rs
+++ b/embedded-graphics/src/fonts/font6x12.rs
@@ -23,7 +23,10 @@ pub struct Font6x12<'a> {
 
 impl<'a> Font<'a> for Font6x12<'a> {
     fn render_str(text: &'a str) -> Font6x12<'a> {
-        Self { pos: (0, 0), text }
+        Self {
+            pos: Coord::new(0, 0),
+            text,
+        }
     }
 }
 
@@ -99,7 +102,7 @@ impl<'a> Iterator for Font6x12Iterator<'a> {
             let x = self.pos.0 + (CHAR_WIDTH * self.idx as u32) + self.char_walk_x;
             let y = self.pos.1 + self.char_walk_y;
 
-            Some(((x, y), bit_value))
+            Some((Coord::new(x, y), bit_value))
         } else {
             None
         }
@@ -115,16 +118,17 @@ impl<'a> Transform for Font6x12<'a> {
     /// ```
     /// # use embedded_graphics::fonts::{ Font, Font6x8 };
     /// # use embedded_graphics::transform::Transform;
+    /// # use embedded_graphics::drawable::Coord;
     ///
     /// let text = Font6x8::render_str("Hello world");
-    /// let moved = text.translate((25, 30));
+    /// let moved = text.translate(Coord::new(25, 30));
     ///
-    /// assert_eq!(text.pos, (0, 0));
-    /// assert_eq!(moved.pos, (25, 30));
+    /// assert_eq!(text.pos, Coord::new(0, 0));
+    /// assert_eq!(moved.pos, Coord::new(25, 30));
     /// ```
     fn translate(&self, by: Coord) -> Self {
         Self {
-            pos: (self.pos.0 + by.0, self.pos.1 + by.1),
+            pos: Coord::new(self.pos.0 + by.0, self.pos.1 + by.1),
             ..*self
         }
     }
@@ -134,15 +138,16 @@ impl<'a> Transform for Font6x12<'a> {
     /// ```
     /// # use embedded_graphics::fonts::{ Font, Font6x12 };
     /// # use embedded_graphics::transform::Transform;
+    /// # use embedded_graphics::drawable::Coord;
     ///
     /// // 8px x 1px test image
     /// let mut text = Font6x12::render_str("Hello world");
-    /// text.translate_mut((25, 30));
+    /// text.translate_mut(Coord::new(25, 30));
     ///
-    /// assert_eq!(text.pos, (25, 30));
+    /// assert_eq!(text.pos, Coord::new(25, 30));
     /// ```
     fn translate_mut(&mut self, by: Coord) -> &mut Self {
-        self.pos = (self.pos.0 + by.0, self.pos.1 + by.1);
+        self.pos = Coord::new(self.pos.0 + by.0, self.pos.1 + by.1);
 
         self
     }

--- a/embedded-graphics/src/fonts/font6x8.rs
+++ b/embedded-graphics/src/fonts/font6x8.rs
@@ -23,7 +23,10 @@ pub struct Font6x8<'a> {
 
 impl<'a> Font<'a> for Font6x8<'a> {
     fn render_str(text: &'a str) -> Font6x8<'a> {
-        Self { pos: (0, 0), text }
+        Self {
+            pos: Coord::new(0, 0),
+            text,
+        }
     }
 }
 
@@ -99,7 +102,7 @@ impl<'a> Iterator for Font6x8Iterator<'a> {
             let x = self.pos.0 + (CHAR_WIDTH * self.idx as u32) + self.char_walk_x;
             let y = self.pos.1 + self.char_walk_y;
 
-            Some(((x, y), bit_value))
+            Some((Coord::new(x, y), bit_value))
         } else {
             None
         }
@@ -115,17 +118,18 @@ impl<'a> Transform for Font6x8<'a> {
     /// ```
     /// # use embedded_graphics::fonts::{ Font, Font6x8 };
     /// # use embedded_graphics::transform::Transform;
+    /// # use embedded_graphics::drawable::Coord;
     ///
     /// // 8px x 1px test image
     /// let text = Font6x8::render_str("Hello world");
-    /// let moved = text.translate((25, 30));
+    /// let moved = text.translate(Coord::new(25, 30));
     ///
-    /// assert_eq!(text.pos, (0, 0));
-    /// assert_eq!(moved.pos, (25, 30));
+    /// assert_eq!(text.pos, Coord::new(0, 0));
+    /// assert_eq!(moved.pos, Coord::new(25, 30));
     /// ```
     fn translate(&self, by: Coord) -> Self {
         Self {
-            pos: (self.pos.0 + by.0, self.pos.1 + by.1),
+            pos: Coord::new(self.pos.0 + by.0, self.pos.1 + by.1),
             ..*self
         }
     }
@@ -135,14 +139,15 @@ impl<'a> Transform for Font6x8<'a> {
     /// ```
     /// # use embedded_graphics::fonts::{ Font, Font6x8 };
     /// # use embedded_graphics::transform::Transform;
+    /// # use embedded_graphics::drawable::Coord;
     ///
     /// let mut text = Font6x8::render_str("Hello world");
-    /// text.translate_mut((25, 30));
+    /// text.translate_mut(Coord::new(25, 30));
     ///
-    /// assert_eq!(text.pos, (25, 30));
+    /// assert_eq!(text.pos, Coord::new(25, 30));
     /// ```
     fn translate_mut(&mut self, by: Coord) -> &mut Self {
-        self.pos = (self.pos.0 + by.0, self.pos.1 + by.1);
+        self.pos = Coord::new(self.pos.0 + by.0, self.pos.1 + by.1);
 
         self
     }

--- a/embedded-graphics/src/fonts/font6x8.rs
+++ b/embedded-graphics/src/fonts/font6x8.rs
@@ -129,7 +129,7 @@ impl<'a> Transform for Font6x8<'a> {
     /// ```
     fn translate(&self, by: Coord) -> Self {
         Self {
-            pos: Coord::new(self.pos.0 + by.0, self.pos.1 + by.1),
+            pos: self.pos + by,
             ..*self
         }
     }
@@ -147,7 +147,7 @@ impl<'a> Transform for Font6x8<'a> {
     /// assert_eq!(text.pos, Coord::new(25, 30));
     /// ```
     fn translate_mut(&mut self, by: Coord) -> &mut Self {
-        self.pos = Coord::new(self.pos.0 + by.0, self.pos.1 + by.1);
+        self.pos += by;
 
         self
     }

--- a/embedded-graphics/src/fonts/font6x8.rs
+++ b/embedded-graphics/src/fonts/font6x8.rs
@@ -3,6 +3,7 @@
 use super::super::drawable::*;
 use super::super::transform::*;
 use super::Font;
+use coord::Coord;
 
 const FONT_IMAGE: &[u8] = include_bytes!("../../data/font6x8_1bpp.raw");
 const CHAR_HEIGHT: u32 = 8;
@@ -118,7 +119,7 @@ impl<'a> Transform for Font6x8<'a> {
     /// ```
     /// # use embedded_graphics::fonts::{ Font, Font6x8 };
     /// # use embedded_graphics::transform::Transform;
-    /// # use embedded_graphics::drawable::Coord;
+    /// # use embedded_graphics::coord::Coord;
     ///
     /// // 8px x 1px test image
     /// let text = Font6x8::render_str("Hello world");
@@ -139,7 +140,7 @@ impl<'a> Transform for Font6x8<'a> {
     /// ```
     /// # use embedded_graphics::fonts::{ Font, Font6x8 };
     /// # use embedded_graphics::transform::Transform;
-    /// # use embedded_graphics::drawable::Coord;
+    /// # use embedded_graphics::coord::Coord;
     ///
     /// let mut text = Font6x8::render_str("Hello world");
     /// text.translate_mut(Coord::new(25, 30));

--- a/embedded-graphics/src/fonts/font6x8.rs
+++ b/embedded-graphics/src/fonts/font6x8.rs
@@ -99,8 +99,8 @@ impl<'a> Iterator for Font6x8Iterator<'a> {
                 }
             }
 
-            let x = self.pos.0 + (CHAR_WIDTH * self.idx as u32) + self.char_walk_x;
-            let y = self.pos.1 + self.char_walk_y;
+            let x = self.pos[0] + (CHAR_WIDTH * self.idx as u32) + self.char_walk_x;
+            let y = self.pos[1] + self.char_walk_y;
 
             Some((Coord::new(x, y), bit_value))
         } else {

--- a/embedded-graphics/src/fonts/font8x16.rs
+++ b/embedded-graphics/src/fonts/font8x16.rs
@@ -99,8 +99,8 @@ impl<'a> Iterator for Font8x16Iterator<'a> {
                 }
             }
 
-            let x = self.pos.0 + (CHAR_WIDTH * self.idx as u32) + self.char_walk_x;
-            let y = self.pos.1 + self.char_walk_y;
+            let x = self.pos[0] + (CHAR_WIDTH * self.idx as u32) + self.char_walk_x;
+            let y = self.pos[1] + self.char_walk_y;
 
             Some((Coord::new(x, y), bit_value))
         } else {

--- a/embedded-graphics/src/fonts/font8x16.rs
+++ b/embedded-graphics/src/fonts/font8x16.rs
@@ -23,7 +23,10 @@ pub struct Font8x16<'a> {
 
 impl<'a> Font<'a> for Font8x16<'a> {
     fn render_str(text: &'a str) -> Font8x16<'a> {
-        Self { pos: (0, 0), text }
+        Self {
+            pos: Coord::new(0, 0),
+            text,
+        }
     }
 }
 
@@ -99,7 +102,7 @@ impl<'a> Iterator for Font8x16Iterator<'a> {
             let x = self.pos.0 + (CHAR_WIDTH * self.idx as u32) + self.char_walk_x;
             let y = self.pos.1 + self.char_walk_y;
 
-            Some(((x, y), bit_value))
+            Some((Coord::new(x, y), bit_value))
         } else {
             None
         }
@@ -115,17 +118,18 @@ impl<'a> Transform for Font8x16<'a> {
     /// ```
     /// # use embedded_graphics::fonts::{ Font, Font8x16 };
     /// # use embedded_graphics::transform::Transform;
+    /// # use embedded_graphics::drawable::Coord;
     ///
     /// // 8px x 1px test image
     /// let text = Font8x16::render_str("Hello world");
-    /// let moved = text.translate((25, 30));
+    /// let moved = text.translate(Coord::new(25, 30));
     ///
-    /// assert_eq!(text.pos, (0, 0));
-    /// assert_eq!(moved.pos, (25, 30));
+    /// assert_eq!(text.pos, Coord::new(0, 0));
+    /// assert_eq!(moved.pos, Coord::new(25, 30));
     /// ```
     fn translate(&self, by: Coord) -> Self {
         Self {
-            pos: (self.pos.0 + by.0, self.pos.1 + by.1),
+            pos: Coord::new(self.pos.0 + by.0, self.pos.1 + by.1),
             ..*self
         }
     }
@@ -135,14 +139,15 @@ impl<'a> Transform for Font8x16<'a> {
     /// ```
     /// # use embedded_graphics::fonts::{ Font, Font6x8 };
     /// # use embedded_graphics::transform::Transform;
+    /// # use embedded_graphics::drawable::Coord;
     ///
     /// let mut text = Font6x8::render_str("Hello world");
-    /// text.translate_mut((25, 30));
+    /// text.translate_mut(Coord::new(25, 30));
     ///
-    /// assert_eq!(text.pos, (25, 30));
+    /// assert_eq!(text.pos, Coord::new(25, 30));
     /// ```
     fn translate_mut(&mut self, by: Coord) -> &mut Self {
-        self.pos = (self.pos.0 + by.0, self.pos.1 + by.1);
+        self.pos = Coord::new(self.pos.0 + by.0, self.pos.1 + by.1);
 
         self
     }

--- a/embedded-graphics/src/fonts/font8x16.rs
+++ b/embedded-graphics/src/fonts/font8x16.rs
@@ -129,7 +129,7 @@ impl<'a> Transform for Font8x16<'a> {
     /// ```
     fn translate(&self, by: Coord) -> Self {
         Self {
-            pos: Coord::new(self.pos.0 + by.0, self.pos.1 + by.1),
+            pos: self.pos + by,
             ..*self
         }
     }
@@ -147,7 +147,7 @@ impl<'a> Transform for Font8x16<'a> {
     /// assert_eq!(text.pos, Coord::new(25, 30));
     /// ```
     fn translate_mut(&mut self, by: Coord) -> &mut Self {
-        self.pos = Coord::new(self.pos.0 + by.0, self.pos.1 + by.1);
+        self.pos += by;
 
         self
     }

--- a/embedded-graphics/src/fonts/font8x16.rs
+++ b/embedded-graphics/src/fonts/font8x16.rs
@@ -3,6 +3,7 @@
 use super::super::drawable::*;
 use super::super::transform::*;
 use super::Font;
+use coord::Coord;
 
 const FONT_IMAGE: &[u8] = include_bytes!("../../data/font8x16_1bpp.raw");
 const CHAR_HEIGHT: u32 = 16;
@@ -118,7 +119,7 @@ impl<'a> Transform for Font8x16<'a> {
     /// ```
     /// # use embedded_graphics::fonts::{ Font, Font8x16 };
     /// # use embedded_graphics::transform::Transform;
-    /// # use embedded_graphics::drawable::Coord;
+    /// # use embedded_graphics::coord::Coord;
     ///
     /// // 8px x 1px test image
     /// let text = Font8x16::render_str("Hello world");
@@ -139,7 +140,7 @@ impl<'a> Transform for Font8x16<'a> {
     /// ```
     /// # use embedded_graphics::fonts::{ Font, Font6x8 };
     /// # use embedded_graphics::transform::Transform;
-    /// # use embedded_graphics::drawable::Coord;
+    /// # use embedded_graphics::coord::Coord;
     ///
     /// let mut text = Font6x8::render_str("Hello world");
     /// text.translate_mut(Coord::new(25, 30));

--- a/embedded-graphics/src/image/image1bpp.rs
+++ b/embedded-graphics/src/image/image1bpp.rs
@@ -11,6 +11,7 @@
 use super::super::drawable::*;
 use super::super::transform::*;
 use super::Image;
+use coord::Coord;
 
 /// 1 bit per pixel image
 #[derive(Debug)]
@@ -109,7 +110,7 @@ impl<'a> Transform for Image1BPP<'a> {
     /// ```
     /// # use embedded_graphics::image::{ Image, Image1BPP };
     /// # use embedded_graphics::transform::Transform;
-    /// # use embedded_graphics::drawable::Coord;
+    /// # use embedded_graphics::coord::Coord;
     ///
     /// // 8px x 1px test image
     /// let image = Image1BPP::new(&[ 0xff ], 8, 1);
@@ -130,7 +131,7 @@ impl<'a> Transform for Image1BPP<'a> {
     /// ```
     /// # use embedded_graphics::image::{ Image, Image1BPP };
     /// # use embedded_graphics::transform::Transform;
-    /// # use embedded_graphics::drawable::Coord;
+    /// # use embedded_graphics::coord::Coord;
     ///
     /// let mut image = Image1BPP::new(&[ 0xff ], 8, 1);
     /// image.translate_mut(Coord::new(25, 30));

--- a/embedded-graphics/src/image/image1bpp.rs
+++ b/embedded-graphics/src/image/image1bpp.rs
@@ -123,7 +123,7 @@ impl<'a> Transform for Image1BPP<'a> {
     /// ```
     fn translate(&self, by: Coord) -> Self {
         Self {
-            offset: Coord::new(self.offset.0 + by.0, self.offset.1 + by.1),
+            offset: self.offset + by,
             ..*self
         }
     }
@@ -141,7 +141,7 @@ impl<'a> Transform for Image1BPP<'a> {
     /// assert_eq!(image.offset, Coord::new(25, 30));
     /// ```
     fn translate_mut(&mut self, by: Coord) -> &mut Self {
-        self.offset = Coord::new(self.offset.0 + by.0, self.offset.1 + by.1);
+        self.offset += by;
 
         self
     }

--- a/embedded-graphics/src/image/image1bpp.rs
+++ b/embedded-graphics/src/image/image1bpp.rs
@@ -34,7 +34,7 @@ impl<'a> Image<'a> for Image1BPP<'a> {
             width,
             height,
             imagedata,
-            offset: (0, 0),
+            offset: Coord::new(0, 0),
         }
     }
 }
@@ -85,7 +85,10 @@ impl<'a> Iterator for Image1BPPIterator<'a> {
         let bit_offset = 7 - (x - (row_byte_index * 8));
         let bit_value = (self.im.imagedata[byte_index as usize] >> bit_offset) & 1;
 
-        let current_pixel: Self::Item = ((x + self.im.offset.0, y + self.im.offset.1), bit_value);
+        let current_pixel: Self::Item = (
+            Coord::new(x + self.im.offset.0, y + self.im.offset.1),
+            bit_value,
+        );
 
         // Increment stuff
         self.x += 1;
@@ -109,17 +112,18 @@ impl<'a> Transform for Image1BPP<'a> {
     /// ```
     /// # use embedded_graphics::image::{ Image, Image1BPP };
     /// # use embedded_graphics::transform::Transform;
+    /// # use embedded_graphics::drawable::Coord;
     ///
     /// // 8px x 1px test image
     /// let image = Image1BPP::new(&[ 0xff ], 8, 1);
-    /// let moved = image.translate((25, 30));
+    /// let moved = image.translate(Coord::new(25, 30));
     ///
-    /// assert_eq!(image.offset, (0, 0));
-    /// assert_eq!(moved.offset, (25, 30));
+    /// assert_eq!(image.offset, Coord::new(0, 0));
+    /// assert_eq!(moved.offset, Coord::new(25, 30));
     /// ```
     fn translate(&self, by: Coord) -> Self {
         Self {
-            offset: (self.offset.0 + by.0, self.offset.1 + by.1),
+            offset: Coord::new(self.offset.0 + by.0, self.offset.1 + by.1),
             ..*self
         }
     }
@@ -129,14 +133,15 @@ impl<'a> Transform for Image1BPP<'a> {
     /// ```
     /// # use embedded_graphics::image::{ Image, Image1BPP };
     /// # use embedded_graphics::transform::Transform;
+    /// # use embedded_graphics::drawable::Coord;
     ///
     /// let mut image = Image1BPP::new(&[ 0xff ], 8, 1);
-    /// image.translate_mut((25, 30));
+    /// image.translate_mut(Coord::new(25, 30));
     ///
-    /// assert_eq!(image.offset, (25, 30));
+    /// assert_eq!(image.offset, Coord::new(25, 30));
     /// ```
     fn translate_mut(&mut self, by: Coord) -> &mut Self {
-        self.offset = (self.offset.0 + by.0, self.offset.1 + by.1);
+        self.offset = Coord::new(self.offset.0 + by.0, self.offset.1 + by.1);
 
         self
     }

--- a/embedded-graphics/src/image/image1bpp.rs
+++ b/embedded-graphics/src/image/image1bpp.rs
@@ -85,10 +85,7 @@ impl<'a> Iterator for Image1BPPIterator<'a> {
         let bit_offset = 7 - (x - (row_byte_index * 8));
         let bit_value = (self.im.imagedata[byte_index as usize] >> bit_offset) & 1;
 
-        let current_pixel: Self::Item = (
-            Coord::new(x + self.im.offset.0, y + self.im.offset.1),
-            bit_value,
-        );
+        let current_pixel: Self::Item = (self.im.offset + Coord::new(x, y), bit_value);
 
         // Increment stuff
         self.x += 1;

--- a/embedded-graphics/src/image/image8bpp.rs
+++ b/embedded-graphics/src/image/image8bpp.rs
@@ -12,6 +12,7 @@
 use super::super::drawable::*;
 use super::super::transform::*;
 use super::Image;
+use coord::Coord;
 
 /// 8 bit per pixel image
 #[derive(Debug)]
@@ -104,7 +105,7 @@ impl<'a> Transform for Image8BPP<'a> {
     /// ```
     /// # use embedded_graphics::image::{ Image, Image8BPP };
     /// # use embedded_graphics::transform::Transform;
-    /// # use embedded_graphics::drawable::Coord;
+    /// # use embedded_graphics::coord::Coord;
     ///
     /// // 1px x 1px test image
     /// let image = Image8BPP::new(&[ 0xff ], 1, 1);
@@ -125,7 +126,7 @@ impl<'a> Transform for Image8BPP<'a> {
     /// ```
     /// # use embedded_graphics::image::{ Image, Image8BPP };
     /// # use embedded_graphics::transform::Transform;
-    /// # use embedded_graphics::drawable::Coord;
+    /// # use embedded_graphics::coord::Coord;
     ///
     /// // 1px x 1px test image
     /// let mut image = Image8BPP::new(&[ 0xff ], 1, 1);

--- a/embedded-graphics/src/image/image8bpp.rs
+++ b/embedded-graphics/src/image/image8bpp.rs
@@ -80,10 +80,7 @@ impl<'a> Iterator for Image8BPPIterator<'a> {
         let offset = (y * w) + x;
         let bit_value = self.im.imagedata[offset as usize];
 
-        let current_pixel: Self::Item = (
-            Coord::new(self.im.offset.0 + x, self.im.offset.1 + y),
-            bit_value,
-        );
+        let current_pixel: Self::Item = (self.im.offset + Coord::new(x, y), bit_value);
 
         // Increment stuff
         self.x += 1;

--- a/embedded-graphics/src/image/image8bpp.rs
+++ b/embedded-graphics/src/image/image8bpp.rs
@@ -37,7 +37,7 @@ impl<'a> Image<'a> for Image8BPP<'a> {
             width,
             height,
             imagedata,
-            offset: (0, 0),
+            offset: Coord::new(0, 0),
         }
     }
 }
@@ -80,7 +80,10 @@ impl<'a> Iterator for Image8BPPIterator<'a> {
         let offset = (y * w) + x;
         let bit_value = self.im.imagedata[offset as usize];
 
-        let current_pixel: Self::Item = ((self.im.offset.0 + x, self.im.offset.1 + y), bit_value);
+        let current_pixel: Self::Item = (
+            Coord::new(self.im.offset.0 + x, self.im.offset.1 + y),
+            bit_value,
+        );
 
         // Increment stuff
         self.x += 1;
@@ -104,17 +107,18 @@ impl<'a> Transform for Image8BPP<'a> {
     /// ```
     /// # use embedded_graphics::image::{ Image, Image8BPP };
     /// # use embedded_graphics::transform::Transform;
+    /// # use embedded_graphics::drawable::Coord;
     ///
     /// // 1px x 1px test image
     /// let image = Image8BPP::new(&[ 0xff ], 1, 1);
-    /// let moved = image.translate((25, 30));
+    /// let moved = image.translate(Coord::new(25, 30));
     ///
-    /// assert_eq!(image.offset, (0, 0));
-    /// assert_eq!(moved.offset, (25, 30));
+    /// assert_eq!(image.offset, Coord::new(0, 0));
+    /// assert_eq!(moved.offset, Coord::new(25, 30));
     /// ```
     fn translate(&self, by: Coord) -> Self {
         Self {
-            offset: (self.offset.0 + by.0, self.offset.1 + by.1),
+            offset: Coord::new(self.offset.0 + by.0, self.offset.1 + by.1),
             ..*self
         }
     }
@@ -124,15 +128,16 @@ impl<'a> Transform for Image8BPP<'a> {
     /// ```
     /// # use embedded_graphics::image::{ Image, Image8BPP };
     /// # use embedded_graphics::transform::Transform;
+    /// # use embedded_graphics::drawable::Coord;
     ///
     /// // 1px x 1px test image
     /// let mut image = Image8BPP::new(&[ 0xff ], 1, 1);
-    /// image.translate_mut((25, 30));
+    /// image.translate_mut(Coord::new(25, 30));
     ///
-    /// assert_eq!(image.offset, (25, 30));
+    /// assert_eq!(image.offset, Coord::new(25, 30));
     /// ```
     fn translate_mut(&mut self, by: Coord) -> &mut Self {
-        self.offset = (self.offset.0 + by.0, self.offset.1 + by.1);
+        self.offset = Coord::new(self.offset.0 + by.0, self.offset.1 + by.1);
 
         self
     }

--- a/embedded-graphics/src/image/image8bpp.rs
+++ b/embedded-graphics/src/image/image8bpp.rs
@@ -118,7 +118,7 @@ impl<'a> Transform for Image8BPP<'a> {
     /// ```
     fn translate(&self, by: Coord) -> Self {
         Self {
-            offset: Coord::new(self.offset.0 + by.0, self.offset.1 + by.1),
+            offset: self.offset + by,
             ..*self
         }
     }
@@ -137,7 +137,7 @@ impl<'a> Transform for Image8BPP<'a> {
     /// assert_eq!(image.offset, Coord::new(25, 30));
     /// ```
     fn translate_mut(&mut self, by: Coord) -> &mut Self {
-        self.offset = Coord::new(self.offset.0 + by.0, self.offset.1 + by.1);
+        self.offset += by;
 
         self
     }

--- a/embedded-graphics/src/lib.rs
+++ b/embedded-graphics/src/lib.rs
@@ -22,6 +22,12 @@
 //!
 //! You can also add your own objects by implementing `IntoIterator<Item = Pixel>` to create an
 //! iterator that `Drawable#draw()` can consume.
+//!
+//! ## Crate features
+//!
+//! * `nalgebra_support` - use the [Nalgebra](https://crates.io/crates/nalgebra) crate with `no_std`
+//! support to use as the `Coord` type. This should allow you to use most Nalgebra methods on
+//! objects rendered by embedded_graphics.
 
 #![no_std]
 #![deny(missing_docs)]

--- a/embedded-graphics/src/lib.rs
+++ b/embedded-graphics/src/lib.rs
@@ -34,6 +34,9 @@
 #![deny(unused_import_braces)]
 #![deny(unused_qualifications)]
 
+#[cfg(feature = "nalgebra_support")]
+extern crate nalgebra;
+
 pub mod drawable;
 pub mod fonts;
 pub mod image;

--- a/embedded-graphics/src/lib.rs
+++ b/embedded-graphics/src/lib.rs
@@ -37,6 +37,7 @@
 #[cfg(feature = "nalgebra_support")]
 extern crate nalgebra;
 
+pub mod coord;
 pub mod drawable;
 pub mod fonts;
 pub mod image;

--- a/embedded-graphics/src/prelude.rs
+++ b/embedded-graphics/src/prelude.rs
@@ -1,5 +1,6 @@
 //! Prelude
 
+pub use super::coord::Coord;
 pub use super::fonts::Font;
 pub use super::image::Image;
 pub use super::transform::Transform;

--- a/embedded-graphics/src/primitives/circle.rs
+++ b/embedded-graphics/src/primitives/circle.rs
@@ -70,7 +70,8 @@ impl Iterator for CircleIterator {
             return None;
         }
 
-        let Coord(mx, my) = self.center;
+        let mx = self.center[0];
+        let my = self.center[1];
 
         if self.octant > 7 {
             self.octant = 0;

--- a/embedded-graphics/src/primitives/circle.rs
+++ b/embedded-graphics/src/primitives/circle.rs
@@ -2,6 +2,7 @@
 
 use super::super::drawable::*;
 use super::super::transform::*;
+use coord::Coord;
 
 // TODO: Impl Default so people can leave the color bit out
 /// Circle primitive
@@ -117,7 +118,7 @@ impl Transform for Circle {
     /// ```
     /// # use embedded_graphics::primitives::Circle;
     /// # use embedded_graphics::transform::Transform;
-    /// # use embedded_graphics::drawable::Coord;
+    /// # use embedded_graphics::coord::Coord;
     ///
     /// let circle = Circle::new(Coord::new(5, 10), 10, 1);
     /// let moved = circle.translate(Coord::new(10, 10));
@@ -136,7 +137,7 @@ impl Transform for Circle {
     /// ```
     /// # use embedded_graphics::primitives::Circle;
     /// # use embedded_graphics::transform::Transform;
-    /// # use embedded_graphics::drawable::Coord;
+    /// # use embedded_graphics::coord::Coord;
     ///
     /// let mut circle = Circle::new(Coord::new(5, 10), 10, 1);
     /// circle.translate_mut(Coord::new(10, 10));

--- a/embedded-graphics/src/primitives/circle.rs
+++ b/embedded-graphics/src/primitives/circle.rs
@@ -125,7 +125,7 @@ impl Transform for Circle {
     /// ```
     fn translate(&self, by: Coord) -> Self {
         Self {
-            center: Coord::new(self.center.0 + by.0, self.center.1 + by.1),
+            center: self.center + by,
             ..*self
         }
     }
@@ -143,7 +143,7 @@ impl Transform for Circle {
     /// assert_eq!(circle.center, Coord::new(15, 20));
     /// ```
     fn translate_mut(&mut self, by: Coord) -> &mut Self {
-        self.center = Coord::new(self.center.0 + by.0, self.center.1 + by.1);
+        self.center += by;
 
         self
     }

--- a/embedded-graphics/src/primitives/circle.rs
+++ b/embedded-graphics/src/primitives/circle.rs
@@ -70,7 +70,7 @@ impl Iterator for CircleIterator {
             return None;
         }
 
-        let (mx, my) = self.center;
+        let Coord(mx, my) = self.center;
 
         if self.octant > 7 {
             self.octant = 0;
@@ -86,14 +86,14 @@ impl Iterator for CircleIterator {
         }
 
         let item = match self.octant {
-            0 => Some((mx + self.x, my + self.y)),
-            1 => Some((mx + self.x, my - self.y)),
-            2 => Some((mx - self.x, my + self.y)),
-            3 => Some((mx - self.x, my - self.y)),
-            4 => Some((mx + self.y, my + self.x)),
-            5 => Some((mx + self.y, my - self.x)),
-            6 => Some((mx - self.y, my + self.x)),
-            7 => Some((mx - self.y, my - self.x)),
+            0 => Some(Coord::new(mx + self.x, my + self.y)),
+            1 => Some(Coord::new(mx + self.x, my - self.y)),
+            2 => Some(Coord::new(mx - self.x, my + self.y)),
+            3 => Some(Coord::new(mx - self.x, my - self.y)),
+            4 => Some(Coord::new(mx + self.y, my + self.x)),
+            5 => Some(Coord::new(mx + self.y, my - self.x)),
+            6 => Some(Coord::new(mx - self.y, my + self.x)),
+            7 => Some(Coord::new(mx - self.y, my - self.x)),
             _ => None,
         };
 
@@ -116,15 +116,16 @@ impl Transform for Circle {
     /// ```
     /// # use embedded_graphics::primitives::Circle;
     /// # use embedded_graphics::transform::Transform;
+    /// # use embedded_graphics::drawable::Coord;
     ///
-    /// let circle = Circle::new((5, 10), 10, 1);
-    /// let moved = circle.translate((10, 10));
+    /// let circle = Circle::new(Coord::new(5, 10), 10, 1);
+    /// let moved = circle.translate(Coord::new(10, 10));
     ///
-    /// assert_eq!(moved.center, (15, 20));
+    /// assert_eq!(moved.center, Coord::new(15, 20));
     /// ```
     fn translate(&self, by: Coord) -> Self {
         Self {
-            center: (self.center.0 + by.0, self.center.1 + by.1),
+            center: Coord::new(self.center.0 + by.0, self.center.1 + by.1),
             ..*self
         }
     }
@@ -134,14 +135,15 @@ impl Transform for Circle {
     /// ```
     /// # use embedded_graphics::primitives::Circle;
     /// # use embedded_graphics::transform::Transform;
+    /// # use embedded_graphics::drawable::Coord;
     ///
-    /// let mut circle = Circle::new((5, 10), 10, 1);
-    /// circle.translate_mut((10, 10));
+    /// let mut circle = Circle::new(Coord::new(5, 10), 10, 1);
+    /// circle.translate_mut(Coord::new(10, 10));
     ///
-    /// assert_eq!(circle.center, (15, 20));
+    /// assert_eq!(circle.center, Coord::new(15, 20));
     /// ```
     fn translate_mut(&mut self, by: Coord) -> &mut Self {
-        self.center = (self.center.0 + by.0, self.center.1 + by.1);
+        self.center = Coord::new(self.center.0 + by.0, self.center.1 + by.1);
 
         self
     }

--- a/embedded-graphics/src/primitives/line.rs
+++ b/embedded-graphics/src/primitives/line.rs
@@ -2,6 +2,7 @@
 
 use super::super::drawable::*;
 use super::super::transform::*;
+use coord::Coord;
 
 // TODO: Impl Default so people can leave the color bit out
 /// Line primitive
@@ -147,7 +148,7 @@ impl Transform for Line {
     /// ```
     /// # use embedded_graphics::primitives::Line;
     /// # use embedded_graphics::transform::Transform;
-    /// # use embedded_graphics::drawable::Coord;
+    /// # use embedded_graphics::coord::Coord;
     ///
     /// let line = Line::new(Coord::new(5, 10), Coord::new(15, 20), 1);
     /// let moved = line.translate(Coord::new(10, 10));
@@ -168,7 +169,7 @@ impl Transform for Line {
     /// ```
     /// # use embedded_graphics::primitives::Line;
     /// # use embedded_graphics::transform::Transform;
-    /// # use embedded_graphics::drawable::Coord;
+    /// # use embedded_graphics::coord::Coord;
     ///
     /// let mut line = Line::new(Coord::new(5, 10), Coord::new(15, 20), 1);
     /// line.translate_mut(Coord::new(10, 10));

--- a/embedded-graphics/src/primitives/line.rs
+++ b/embedded-graphics/src/primitives/line.rs
@@ -158,8 +158,8 @@ impl Transform for Line {
     /// ```
     fn translate(&self, by: Coord) -> Self {
         Self {
-            start: Coord::new(self.start.0 + by.0, self.start.1 + by.1),
-            end: Coord::new(self.end.0 + by.0, self.end.1 + by.1),
+            start: self.start + by,
+            end: self.end + by,
             ..*self
         }
     }
@@ -178,8 +178,8 @@ impl Transform for Line {
     /// assert_eq!(line.end, Coord::new(25, 30));
     /// ```
     fn translate_mut(&mut self, by: Coord) -> &mut Self {
-        self.start = Coord::new(self.start.0 + by.0, self.start.1 + by.1);
-        self.end = Coord::new(self.end.0 + by.0, self.end.1 + by.1);
+        self.start += by;
+        self.end += by;
 
         self
     }

--- a/embedded-graphics/src/primitives/line.rs
+++ b/embedded-graphics/src/primitives/line.rs
@@ -30,8 +30,8 @@ impl<'a> IntoIterator for &'a Line {
 
     fn into_iter(self) -> Self::IntoIter {
         let &Line {
-            start: (x0, y0),
-            end: (x1, y1),
+            start: Coord(x0, y0),
+            end: Coord(x1, y1),
             ..
         } = self;
 
@@ -119,9 +119,9 @@ impl<'a> Iterator for LineIterator<'a> {
         // Get the next point
         let &Line { color, .. } = self.line;
         let coord = if self.is_steep {
-            (self.slow, self.quick)
+            Coord::new(self.slow, self.quick)
         } else {
-            (self.quick, self.slow)
+            Coord::new(self.quick, self.slow)
         };
 
         // Update error and increment slow direction
@@ -148,17 +148,18 @@ impl Transform for Line {
     /// ```
     /// # use embedded_graphics::primitives::Line;
     /// # use embedded_graphics::transform::Transform;
+    /// # use embedded_graphics::drawable::Coord;
     ///
-    /// let line = Line::new((5, 10), (15, 20), 1);
-    /// let moved = line.translate((10, 10));
+    /// let line = Line::new(Coord::new(5, 10), Coord::new(15, 20), 1);
+    /// let moved = line.translate(Coord::new(10, 10));
     ///
-    /// assert_eq!(moved.start, (15, 20));
-    /// assert_eq!(moved.end, (25, 30));
+    /// assert_eq!(moved.start, Coord::new(15, 20));
+    /// assert_eq!(moved.end, Coord::new(25, 30));
     /// ```
     fn translate(&self, by: Coord) -> Self {
         Self {
-            start: (self.start.0 + by.0, self.start.1 + by.1),
-            end: (self.end.0 + by.0, self.end.1 + by.1),
+            start: Coord::new(self.start.0 + by.0, self.start.1 + by.1),
+            end: Coord::new(self.end.0 + by.0, self.end.1 + by.1),
             ..*self
         }
     }
@@ -168,16 +169,17 @@ impl Transform for Line {
     /// ```
     /// # use embedded_graphics::primitives::Line;
     /// # use embedded_graphics::transform::Transform;
+    /// # use embedded_graphics::drawable::Coord;
     ///
-    /// let mut line = Line::new((5, 10), (15, 20), 1);
-    /// line.translate_mut((10, 10));
+    /// let mut line = Line::new(Coord::new(5, 10), Coord::new(15, 20), 1);
+    /// line.translate_mut(Coord::new(10, 10));
     ///
-    /// assert_eq!(line.start, (15, 20));
-    /// assert_eq!(line.end, (25, 30));
+    /// assert_eq!(line.start, Coord::new(15, 20));
+    /// assert_eq!(line.end, Coord::new(25, 30));
     /// ```
     fn translate_mut(&mut self, by: Coord) -> &mut Self {
-        self.start = (self.start.0 + by.0, self.start.1 + by.1);
-        self.end = (self.end.0 + by.0, self.end.1 + by.1);
+        self.start = Coord::new(self.start.0 + by.0, self.start.1 + by.1);
+        self.end = Coord::new(self.end.0 + by.0, self.end.1 + by.1);
 
         self
     }
@@ -201,65 +203,121 @@ mod tests {
 
     #[test]
     fn draws_octant_1_correctly() {
-        let start = (10, 10);
-        let end = (15, 13);
-        let expected = [(10, 10), (11, 11), (12, 11), (13, 12), (14, 12), (15, 13)];
+        let start = Coord::new(10, 10);
+        let end = Coord::new(15, 13);
+        let expected = [
+            Coord::new(10, 10),
+            Coord::new(11, 11),
+            Coord::new(12, 11),
+            Coord::new(13, 12),
+            Coord::new(14, 12),
+            Coord::new(15, 13),
+        ];
         test_expected_line(start, end, &expected, "Octant 1 failed to draw correctly");
     }
 
     #[test]
     fn draws_octant_2_correctly() {
-        let start = (10, 10);
-        let end = (13, 15);
-        let expected = [(10, 10), (11, 11), (11, 12), (12, 13), (12, 14), (13, 15)];
+        let start = Coord::new(10, 10);
+        let end = Coord::new(13, 15);
+        let expected = [
+            Coord::new(10, 10),
+            Coord::new(11, 11),
+            Coord::new(11, 12),
+            Coord::new(12, 13),
+            Coord::new(12, 14),
+            Coord::new(13, 15),
+        ];
         test_expected_line(start, end, &expected, "Octant 2 failed to draw correctly");
     }
 
     #[test]
     fn draws_octant_3_correctly() {
-        let start = (10, 10);
-        let end = (7, 15);
-        let expected = [(10, 10), (9, 11), (9, 12), (8, 13), (8, 14), (7, 15)];
+        let start = Coord::new(10, 10);
+        let end = Coord::new(7, 15);
+        let expected = [
+            Coord::new(10, 10),
+            Coord::new(9, 11),
+            Coord::new(9, 12),
+            Coord::new(8, 13),
+            Coord::new(8, 14),
+            Coord::new(7, 15),
+        ];
         test_expected_line(start, end, &expected, "Octant 3 failed to draw correctly");
     }
 
     #[test]
     fn draws_octant_4_correctly() {
-        let start = (10, 10);
-        let end = (5, 13);
-        let expected = [(5, 13), (6, 12), (7, 12), (8, 11), (9, 11), (10, 10)];
+        let start = Coord::new(10, 10);
+        let end = Coord::new(5, 13);
+        let expected = [
+            Coord::new(5, 13),
+            Coord::new(6, 12),
+            Coord::new(7, 12),
+            Coord::new(8, 11),
+            Coord::new(9, 11),
+            Coord::new(10, 10),
+        ];
         test_expected_line(start, end, &expected, "Octant 4 failed to draw correctly");
     }
 
     #[test]
     fn draws_octant_5_correctly() {
-        let start = (10, 10);
-        let end = (5, 7);
-        let expected = [(5, 7), (6, 8), (7, 8), (8, 9), (9, 9), (10, 10)];
+        let start = Coord::new(10, 10);
+        let end = Coord::new(5, 7);
+        let expected = [
+            Coord::new(5, 7),
+            Coord::new(6, 8),
+            Coord::new(7, 8),
+            Coord::new(8, 9),
+            Coord::new(9, 9),
+            Coord::new(10, 10),
+        ];
         test_expected_line(start, end, &expected, "Octant 5 failed to draw correctly");
     }
 
     #[test]
     fn draws_octant_6_correctly() {
-        let start = (10, 10);
-        let end = (7, 5);
-        let expected = [(7, 5), (8, 6), (8, 7), (9, 8), (9, 9), (10, 10)];
+        let start = Coord::new(10, 10);
+        let end = Coord::new(7, 5);
+        let expected = [
+            Coord::new(7, 5),
+            Coord::new(8, 6),
+            Coord::new(8, 7),
+            Coord::new(9, 8),
+            Coord::new(9, 9),
+            Coord::new(10, 10),
+        ];
         test_expected_line(start, end, &expected, "Octant 6 failed to draw correctly");
     }
 
     #[test]
     fn draws_octant_7_correctly() {
-        let start = (10, 10);
-        let end = (13, 5);
-        let expected = [(13, 5), (12, 6), (12, 7), (11, 8), (11, 9), (10, 10)];
+        let start = Coord::new(10, 10);
+        let end = Coord::new(13, 5);
+        let expected = [
+            Coord::new(13, 5),
+            Coord::new(12, 6),
+            Coord::new(12, 7),
+            Coord::new(11, 8),
+            Coord::new(11, 9),
+            Coord::new(10, 10),
+        ];
         test_expected_line(start, end, &expected, "Octant 7 failed to draw correctly");
     }
 
     #[test]
     fn draws_octant_8_correctly() {
-        let start = (10, 10);
-        let end = (15, 7);
-        let expected = [(10, 10), (11, 9), (12, 9), (13, 8), (14, 8), (15, 7)];
+        let start = Coord::new(10, 10);
+        let end = Coord::new(15, 7);
+        let expected = [
+            Coord::new(10, 10),
+            Coord::new(11, 9),
+            Coord::new(12, 9),
+            Coord::new(13, 8),
+            Coord::new(14, 8),
+            Coord::new(15, 7),
+        ];
         test_expected_line(start, end, &expected, "Octant 8 failed to draw correctly");
     }
 }

--- a/embedded-graphics/src/primitives/line.rs
+++ b/embedded-graphics/src/primitives/line.rs
@@ -29,11 +29,10 @@ impl<'a> IntoIterator for &'a Line {
     type IntoIter = LineIterator<'a>;
 
     fn into_iter(self) -> Self::IntoIter {
-        let &Line {
-            start: Coord(x0, y0),
-            end: Coord(x1, y1),
-            ..
-        } = self;
+        let x0 = self.start[0];
+        let y0 = self.start[1];
+        let x1 = self.end[0];
+        let y1 = self.end[1];
 
         // Find out if our line is steep or shallow
         let is_steep = (y1 as i32 - y0 as i32).abs() > (x1 as i32 - x0 as i32).abs();

--- a/embedded-graphics/src/primitives/rect.rs
+++ b/embedded-graphics/src/primitives/rect.rs
@@ -38,8 +38,8 @@ impl<'a> IntoIterator for &'a Rect {
             top_left: self.top_left,
             bottom_right: self.bottom_right,
             color: self.color,
-            x: self.top_left.0,
-            y: self.top_left.1,
+            x: self.top_left[0],
+            y: self.top_left[1],
         }
     }
 }
@@ -58,24 +58,24 @@ impl Iterator for RectIterator {
     type Item = Pixel;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.y > self.bottom_right.1 {
+        if self.y > self.bottom_right[1] {
             return None;
         }
 
         let coord = Coord::new(self.x, self.y);
 
         // Step across 1 if rendering top/bottom lines
-        if self.y == self.top_left.1 || self.y == self.bottom_right.1 {
+        if self.y == self.top_left[1] || self.y == self.bottom_right[1] {
             self.x += 1;
         }
         // Skip across rect empty space if rendering left/right lines
         else {
-            self.x += self.bottom_right.0 - self.top_left.0;
+            self.x += self.bottom_right[0] - self.top_left[0];
         }
 
         // Reached end of row? Jump down one line
-        if self.x > self.bottom_right.0 {
-            self.x = self.top_left.0;
+        if self.x > self.bottom_right[0] {
+            self.x = self.top_left[0];
             self.y += 1;
         }
 

--- a/embedded-graphics/src/primitives/rect.rs
+++ b/embedded-graphics/src/primitives/rect.rs
@@ -102,8 +102,8 @@ impl Transform for Rect {
     /// ```
     fn translate(&self, by: Coord) -> Self {
         Self {
-            top_left: Coord::new(self.top_left.0 + by.0, self.top_left.1 + by.1),
-            bottom_right: Coord::new(self.bottom_right.0 + by.0, self.bottom_right.1 + by.1),
+            top_left: self.top_left + by,
+            bottom_right: self.bottom_right + by,
             ..*self
         }
     }
@@ -122,9 +122,23 @@ impl Transform for Rect {
     /// assert_eq!(rect.bottom_right, Coord::new(25, 30));
     /// ```
     fn translate_mut(&mut self, by: Coord) -> &mut Self {
-        self.top_left = Coord::new(self.top_left.0 + by.0, self.top_left.1 + by.1);
-        self.bottom_right = Coord::new(self.bottom_right.0 + by.0, self.bottom_right.1 + by.1);
+        self.top_left += by;
+        self.bottom_right += by;
 
         self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_can_be_translated() {
+        let rect = Rect::new(Coord::new(5, 10), Coord::new(15, 20), 1);
+        let moved = rect.translate(Coord::new(10, 10));
+
+        assert_eq!(moved.top_left, Coord::new(15, 20));
+        assert_eq!(moved.bottom_right, Coord::new(25, 30));
     }
 }

--- a/embedded-graphics/src/primitives/rect.rs
+++ b/embedded-graphics/src/primitives/rect.rs
@@ -5,7 +5,7 @@ use super::super::transform::*;
 
 // TODO: Impl Default so people can leave the color bit out
 /// Rectangle primitive
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct Rect {
     /// Top left point of the rect
     pub top_left: Coord,
@@ -45,7 +45,7 @@ impl<'a> IntoIterator for &'a Rect {
 }
 
 /// Pixel iterator for each pixel in the rect border
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct RectIterator {
     top_left: Coord,
     bottom_right: Coord,
@@ -62,7 +62,7 @@ impl Iterator for RectIterator {
             return None;
         }
 
-        let coord = (self.x, self.y);
+        let coord = Coord::new(self.x, self.y);
 
         // Step across 1 if rendering top/bottom lines
         if self.y == self.top_left.1 || self.y == self.bottom_right.1 {
@@ -92,17 +92,18 @@ impl Transform for Rect {
     /// ```
     /// # use embedded_graphics::primitives::Rect;
     /// # use embedded_graphics::transform::Transform;
+    /// # use embedded_graphics::drawable::Coord;
     ///
-    /// let rect = Rect::new((5, 10), (15, 20), 1);
-    /// let moved = rect.translate((10, 10));
+    /// let rect = Rect::new(Coord::new(5, 10), Coord::new(15, 20), 1);
+    /// let moved = rect.translate(Coord::new(10, 10));
     ///
-    /// assert_eq!(moved.top_left, (15, 20));
-    /// assert_eq!(moved.bottom_right, (25, 30));
+    /// assert_eq!(moved.top_left, Coord::new(15, 20));
+    /// assert_eq!(moved.bottom_right, Coord::new(25, 30));
     /// ```
     fn translate(&self, by: Coord) -> Self {
         Self {
-            top_left: (self.top_left.0 + by.0, self.top_left.1 + by.1),
-            bottom_right: (self.bottom_right.0 + by.0, self.bottom_right.1 + by.1),
+            top_left: Coord::new(self.top_left.0 + by.0, self.top_left.1 + by.1),
+            bottom_right: Coord::new(self.bottom_right.0 + by.0, self.bottom_right.1 + by.1),
             ..*self
         }
     }
@@ -112,16 +113,17 @@ impl Transform for Rect {
     /// ```
     /// # use embedded_graphics::primitives::Rect;
     /// # use embedded_graphics::transform::Transform;
+    /// # use embedded_graphics::drawable::Coord;
     ///
-    /// let mut rect = Rect::new((5, 10), (15, 20), 1);
-    /// rect.translate_mut((10, 10));
+    /// let mut rect = Rect::new(Coord::new(5, 10), Coord::new(15, 20), 1);
+    /// rect.translate_mut(Coord::new(10, 10));
     ///
-    /// assert_eq!(rect.top_left, (15, 20));
-    /// assert_eq!(rect.bottom_right, (25, 30));
+    /// assert_eq!(rect.top_left, Coord::new(15, 20));
+    /// assert_eq!(rect.bottom_right, Coord::new(25, 30));
     /// ```
     fn translate_mut(&mut self, by: Coord) -> &mut Self {
-        self.top_left = (self.top_left.0 + by.0, self.top_left.1 + by.1);
-        self.bottom_right = (self.bottom_right.0 + by.0, self.bottom_right.1 + by.1);
+        self.top_left = Coord::new(self.top_left.0 + by.0, self.top_left.1 + by.1);
+        self.bottom_right = Coord::new(self.bottom_right.0 + by.0, self.bottom_right.1 + by.1);
 
         self
     }

--- a/embedded-graphics/src/primitives/rect.rs
+++ b/embedded-graphics/src/primitives/rect.rs
@@ -2,6 +2,7 @@
 
 use super::super::drawable::*;
 use super::super::transform::*;
+use coord::Coord;
 
 // TODO: Impl Default so people can leave the color bit out
 /// Rectangle primitive
@@ -92,7 +93,7 @@ impl Transform for Rect {
     /// ```
     /// # use embedded_graphics::primitives::Rect;
     /// # use embedded_graphics::transform::Transform;
-    /// # use embedded_graphics::drawable::Coord;
+    /// # use embedded_graphics::coord::Coord;
     ///
     /// let rect = Rect::new(Coord::new(5, 10), Coord::new(15, 20), 1);
     /// let moved = rect.translate(Coord::new(10, 10));
@@ -113,7 +114,7 @@ impl Transform for Rect {
     /// ```
     /// # use embedded_graphics::primitives::Rect;
     /// # use embedded_graphics::transform::Transform;
-    /// # use embedded_graphics::drawable::Coord;
+    /// # use embedded_graphics::coord::Coord;
     ///
     /// let mut rect = Rect::new(Coord::new(5, 10), Coord::new(15, 20), 1);
     /// rect.translate_mut(Coord::new(10, 10));

--- a/embedded-graphics/src/transform.rs
+++ b/embedded-graphics/src/transform.rs
@@ -1,6 +1,6 @@
 //! Transformations for graphics objects
 
-use super::drawable::Coord;
+use coord::Coord;
 
 /// Transform operations
 pub trait Transform {

--- a/embedded-graphics/tests/chaining.rs
+++ b/embedded-graphics/tests/chaining.rs
@@ -1,6 +1,6 @@
 extern crate embedded_graphics;
 
-use embedded_graphics::drawable;
+use embedded_graphics::drawable::{Coord, Pixel};
 use embedded_graphics::primitives::{Circle, Rect};
 use embedded_graphics::Drawing;
 
@@ -9,7 +9,7 @@ struct FakeDisplay {}
 impl Drawing for FakeDisplay {
     fn draw<T>(&mut self, _item_pixels: T)
     where
-        T: Iterator<Item = drawable::Pixel>,
+        T: Iterator<Item = Pixel>,
     {
         // Noop
     }
@@ -19,9 +19,9 @@ impl Drawing for FakeDisplay {
 fn it_supports_chaining() {
     let mut disp = FakeDisplay {};
 
-    let chained = Rect::new((0, 0), (1, 1), 1)
+    let chained = Rect::new(Coord::new(0, 0), Coord::new(1, 1), 1)
         .into_iter()
-        .chain(Circle::new((2, 2), 1, 1).into_iter());
+        .chain(Circle::new(Coord::new(2, 2), 1, 1).into_iter());
 
     disp.draw(chained);
 }

--- a/embedded-graphics/tests/chaining.rs
+++ b/embedded-graphics/tests/chaining.rs
@@ -1,6 +1,7 @@
 extern crate embedded_graphics;
 
-use embedded_graphics::drawable::{Coord, Pixel};
+use embedded_graphics::coord::Coord;
+use embedded_graphics::drawable::Pixel;
 use embedded_graphics::primitives::{Circle, Rect};
 use embedded_graphics::Drawing;
 

--- a/simulator/src/lib.rs
+++ b/simulator/src/lib.rs
@@ -1,7 +1,8 @@
 extern crate embedded_graphics;
 extern crate sdl2;
 
-use embedded_graphics::drawable::{Coord, Pixel};
+use embedded_graphics::coord::Coord;
+use embedded_graphics::drawable::Pixel;
 use embedded_graphics::Drawing;
 
 use sdl2::event::Event;

--- a/simulator/src/lib.rs
+++ b/simulator/src/lib.rs
@@ -1,7 +1,7 @@
 extern crate embedded_graphics;
 extern crate sdl2;
 
-use embedded_graphics::drawable::Pixel;
+use embedded_graphics::drawable::{Coord, Pixel};
 use embedded_graphics::Drawing;
 
 use sdl2::event::Event;
@@ -82,7 +82,7 @@ impl Drawing for Display {
     where
         T: Iterator<Item = Pixel>,
     {
-        for ((x, y), color) in item_pixels {
+        for (Coord(x, y), color) in item_pixels {
             if x >= DISPLAY_SIZE as u32 || y >= DISPLAY_SIZE as u32 {
                 continue;
             }

--- a/simulator/src/main.rs
+++ b/simulator/src/main.rs
@@ -4,6 +4,7 @@ extern crate simulator;
 use std::thread;
 use std::time::Duration;
 
+use embedded_graphics::drawable::Coord;
 use embedded_graphics::fonts::Font6x8;
 use embedded_graphics::prelude::*;
 use embedded_graphics::primitives::{Circle, Line};
@@ -14,15 +15,15 @@ fn main() {
     let mut display = Display::new();
 
     // Outline
-    display.draw(Circle::new((64, 64), 63, 1).into_iter());
+    display.draw(Circle::new(Coord::new(64, 64), 63, 1).into_iter());
 
     // Clock hands
-    display.draw(Line::new((64, 64), (0, 64), 1).into_iter());
-    display.draw(Line::new((64, 64), (80, 80), 1).into_iter());
+    display.draw(Line::new(Coord::new(64, 64), Coord::new(0, 64), 1).into_iter());
+    display.draw(Line::new(Coord::new(64, 64), Coord::new(80, 80), 1).into_iter());
 
     display.draw(
         Font6x8::render_str("Hello World!")
-            .translate((5, 50))
+            .translate(Coord::new(5, 50))
             .into_iter(),
     );
 

--- a/simulator/src/main.rs
+++ b/simulator/src/main.rs
@@ -4,7 +4,7 @@ extern crate simulator;
 use std::thread;
 use std::time::Duration;
 
-use embedded_graphics::drawable::Coord;
+use embedded_graphics::coord::Coord;
 use embedded_graphics::fonts::Font6x8;
 use embedded_graphics::prelude::*;
 use embedded_graphics::primitives::{Circle, Line};


### PR DESCRIPTION
Enable with `features = [ "nalgebra_support" ]` in `Cargo.toml`. Uses `nalgebra::Vector2<u32>` as the crate's `Coord` type instead of the builtin struct.

Closes #34 