### PR TITLE
Support negative coordinates

### DIFF
--- a/embedded-graphics/src/coord.rs
+++ b/embedded-graphics/src/coord.rs
@@ -1,17 +1,39 @@
 //! 2D coordinate in screen space
 
+type CoordPart = i32;
+
 #[cfg(not(feature = "nalgebra_support"))]
 mod internal_coord {
+    use super::CoordPart;
     use core::ops::{Add, AddAssign, Index, Sub, SubAssign};
 
     /// 2D coordinate type
     #[derive(Debug, Copy, Clone, Eq, PartialEq)]
-    pub struct Coord(pub u32, pub u32);
+    pub struct Coord(pub CoordPart, pub CoordPart);
 
     impl Coord {
         /// Create a new coordinate with X and Y values
-        pub fn new(x: u32, y: u32) -> Self {
+        pub fn new(x: CoordPart, y: CoordPart) -> Self {
             Coord(x, y)
+        }
+
+        /// Clamp coordinate components to positive integer range
+        pub fn clamp_positive(&self) -> Self {
+            Coord(self.0.max(0), self.1.max(0))
+        }
+
+        /// Remove the sign from a coordinate
+        ///
+        ///
+        /// ```
+        /// # use embedded_graphics::coord::Coord;
+        /// #
+        /// let coord = Coord::new(-5, -10);
+        ///
+        /// assert_eq!(coord.abs(), Coord::new(5, 10));
+        /// ```
+        pub fn abs(&self) -> Self {
+            Coord(self.0.abs(), self.1.abs())
         }
     }
 
@@ -46,9 +68,9 @@ mod internal_coord {
     }
 
     impl Index<usize> for Coord {
-        type Output = u32;
+        type Output = CoordPart;
 
-        fn index(&self, idx: usize) -> &u32 {
+        fn index(&self, idx: usize) -> &CoordPart {
             match idx {
                 0 => &self.0,
                 1 => &self.1,
@@ -86,6 +108,14 @@ mod tests {
         let right = Coord::new(10, 20);
 
         assert_eq!(left - right, Coord::new(20, 20));
+    }
+
+    #[test]
+    fn coords_can_be_negative_subtracted() {
+        let left = Coord::new(10, 20);
+        let right = Coord::new(30, 40);
+
+        assert_eq!(left - right, Coord::new(-20, -20));
     }
 
     #[test]

--- a/embedded-graphics/src/coord.rs
+++ b/embedded-graphics/src/coord.rs
@@ -88,7 +88,7 @@ use nalgebra;
 
 #[cfg(feature = "nalgebra_support")]
 /// 2D coordinate type with Nalgebra support
-pub type Coord = nalgebra::Vector2<u32>;
+pub type Coord = nalgebra::Vector2<CoordPart>;
 
 #[cfg(test)]
 mod tests {

--- a/embedded-graphics/src/coord.rs
+++ b/embedded-graphics/src/coord.rs
@@ -1,10 +1,12 @@
 //! 2D coordinate in screen space
 
+use super::unsignedcoord::UnsignedCoord;
+
 type CoordPart = i32;
 
 #[cfg(not(feature = "nalgebra_support"))]
 mod internal_coord {
-    use super::CoordPart;
+    use super::*;
     use core::ops::{Add, AddAssign, Index, Sub, SubAssign};
 
     /// 2D coordinate type
@@ -86,9 +88,29 @@ pub use self::internal_coord::Coord;
 #[cfg(feature = "nalgebra_support")]
 use nalgebra;
 
-#[cfg(feature = "nalgebra_support")]
 /// 2D coordinate type with Nalgebra support
+#[cfg(feature = "nalgebra_support")]
 pub type Coord = nalgebra::Vector2<CoordPart>;
+
+/// Convert a value to an unsigned coordinate
+pub trait ToUnsigned {
+    /// Convert the signed coordinate to an unsigned coordinate
+    fn to_unsigned(self) -> UnsignedCoord;
+}
+
+impl ToUnsigned for Coord {
+    /// Convert to a positive-only coordinate, clamping negative values to zero
+    ///
+    /// # use embedded_graphics::coord::Coord;
+    /// # use embedded_graphics::unsignedcoord::UnsignedCoord;
+    /// #
+    /// let coord = Coord::new(-5, 10);
+    ///
+    /// assert_eq!(coord.to_unsigned(), UnsignedCoord::new(0, 10));
+    fn to_unsigned(self) -> UnsignedCoord {
+        UnsignedCoord::new(self[0].max(0) as u32, self[1].max(0) as u32)
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/embedded-graphics/src/drawable.rs
+++ b/embedded-graphics/src/drawable.rs
@@ -1,13 +1,13 @@
 //! `Drawable` trait and helpers
 
-use super::coord::Coord;
+use super::unsignedcoord::UnsignedCoord;
 
 // TODO: Refactor to use both with monochrome and multicolour displays
 /// Monochrome colour type
 pub type Color = u8;
 
 /// A single pixel
-pub type Pixel = (Coord, Color);
+pub type Pixel = (UnsignedCoord, Color);
 
 /// Marks an object as "drawable". Must be implemented for all graphics objects
 pub trait Drawable {}

--- a/embedded-graphics/src/fonts/font12x16.rs
+++ b/embedded-graphics/src/fonts/font12x16.rs
@@ -3,7 +3,7 @@
 use super::super::drawable::*;
 use super::super::transform::*;
 use super::Font;
-use coord::Coord;
+use coord::{Coord, ToUnsigned};
 
 const FONT_IMAGE: &[u8] = include_bytes!("../../data/font12x16_1bpp.raw");
 const CHAR_HEIGHT: u32 = 16;
@@ -116,7 +116,7 @@ impl<'a> Iterator for Font12x16Iterator<'a> {
                 let y = self.pos[1] + self.char_walk_y as i32;
 
                 if x >= 0 && y >= 0 {
-                    break Some((Coord::new(x, y), color));
+                    break Some((Coord::new(x, y).to_unsigned(), color));
                 }
             };
 

--- a/embedded-graphics/src/fonts/font12x16.rs
+++ b/embedded-graphics/src/fonts/font12x16.rs
@@ -30,7 +30,7 @@ impl<'a> Font<'a> for Font12x16<'a> {
         Self {
             pos: Coord::new(0, 0),
             text,
-            color
+            color,
         }
     }
 }
@@ -68,52 +68,59 @@ impl<'a> Iterator for Font12x16Iterator<'a> {
 
     fn next(&mut self) -> Option<Self::Item> {
         if let Some(current_char) = self.current_char {
-            // Char _code_ offset from first char, most often a space
-            // E.g. first char = ' ' (32), target char = '!' (33), offset = 33 - 32 = 1
-            let char_offset = current_char as u32 - FIRST_CHARCODE;
-            let row = char_offset / CHARS_PER_ROW;
+            let pixel = loop {
+                // Char _code_ offset from first char, most often a space
+                // E.g. first char = ' ' (32), target char = '!' (33), offset = 33 - 32 = 1
+                let char_offset = current_char as u32 - FIRST_CHARCODE;
+                let row = char_offset / CHARS_PER_ROW;
 
-            // Top left corner of character, in pixels
-            let char_x = (char_offset - (row * CHARS_PER_ROW)) * CHAR_WIDTH;
-            let char_y = row * CHAR_HEIGHT;
+                // Top left corner of character, in pixels
+                let char_x = (char_offset - (row * CHARS_PER_ROW)) * CHAR_WIDTH;
+                let char_y = row * CHAR_HEIGHT;
 
-            // Bit index
-            // = X pixel offset for char
-            // + Character row offset (row 0 = 0, row 1 = (192 * 8) = 1536)
-            // + X offset for the pixel block that comprises this char
-            // + Y offset for pixel block
-            let bitmap_bit_index = char_x
-                + (FONT_IMAGE_WIDTH * char_y)
-                + self.char_walk_x
-                + (self.char_walk_y * FONT_IMAGE_WIDTH);
+                // Bit index
+                // = X pixel offset for char
+                // + Character row offset (row 0 = 0, row 1 = (192 * 8) = 1536)
+                // + X offset for the pixel block that comprises this char
+                // + Y offset for pixel block
+                let bitmap_bit_index = char_x
+                    + (FONT_IMAGE_WIDTH * char_y)
+                    + self.char_walk_x
+                    + (self.char_walk_y * FONT_IMAGE_WIDTH);
 
-            let bitmap_byte = bitmap_bit_index / 8;
-            let bitmap_bit = 7 - (bitmap_bit_index % 8);
+                let bitmap_byte = bitmap_bit_index / 8;
+                let bitmap_bit = 7 - (bitmap_bit_index % 8);
 
-            let color = if (FONT_IMAGE[bitmap_byte as usize] >> bitmap_bit) & 1 == 1 {
-                self.color
-            } else {
-                0 // black
+                let color = if (FONT_IMAGE[bitmap_byte as usize] >> bitmap_bit) & 1 == 1 {
+                    self.color
+                } else {
+                    0 // black
+                };
+
+                self.char_walk_x += 1;
+
+                if self.char_walk_x >= CHAR_WIDTH {
+                    self.char_walk_x = 0;
+                    self.char_walk_y += 1;
+
+                    // Done with this char, move on to the next one
+                    if self.char_walk_y >= CHAR_HEIGHT {
+                        self.char_walk_y = 0;
+                        self.idx += 1;
+                        self.current_char = self.text.chars().skip(self.idx).next();
+                    }
+                }
+
+                let x =
+                    self.pos[0] + (CHAR_WIDTH * self.idx as u32) as i32 + self.char_walk_x as i32;
+                let y = self.pos[1] + self.char_walk_y as i32;
+
+                if x >= 0 && y >= 0 {
+                    break Some((Coord::new(x, y), color));
+                }
             };
 
-            self.char_walk_x += 1;
-
-            if self.char_walk_x >= CHAR_WIDTH {
-                self.char_walk_x = 0;
-                self.char_walk_y += 1;
-
-                // Done with this char, move on to the next one
-                if self.char_walk_y >= CHAR_HEIGHT {
-                    self.char_walk_y = 0;
-                    self.idx += 1;
-                    self.current_char = self.text.chars().skip(self.idx).next();
-                }
-            }
-
-            let x = self.pos[0] + (CHAR_WIDTH * self.idx as u32) + self.char_walk_x;
-            let y = self.pos[1] + self.char_walk_y;
-
-            Some((Coord::new(x, y), color))
+            pixel
         } else {
             None
         }

--- a/embedded-graphics/src/fonts/font12x16.rs
+++ b/embedded-graphics/src/fonts/font12x16.rs
@@ -67,6 +67,12 @@ impl<'a> Iterator for Font12x16Iterator<'a> {
     type Item = Pixel;
 
     fn next(&mut self) -> Option<Self::Item> {
+        if self.pos[0] + ((self.text.len() as i32 * CHAR_WIDTH as i32)) < 0
+            || self.pos[1] + (CHAR_HEIGHT as i32) < 0
+        {
+            return None;
+        }
+
         if let Some(current_char) = self.current_char {
             let pixel = loop {
                 // Char _code_ offset from first char, most often a space
@@ -167,5 +173,18 @@ impl<'a> Transform for Font12x16<'a> {
         self.pos += by;
 
         self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn off_screen_text_does_not_infinite_loop() {
+        let text = Font12x16::render_str("Hello World!", 1).translate(Coord::new(5, -20));
+        let mut it = text.into_iter();
+
+        assert_eq!(it.next(), None);
     }
 }

--- a/embedded-graphics/src/fonts/font6x12.rs
+++ b/embedded-graphics/src/fonts/font6x12.rs
@@ -67,6 +67,12 @@ impl<'a> Iterator for Font6x12Iterator<'a> {
     type Item = Pixel;
 
     fn next(&mut self) -> Option<Self::Item> {
+        if self.pos[0] + ((self.text.len() as i32 * CHAR_WIDTH as i32)) < 0
+            || self.pos[1] + (CHAR_HEIGHT as i32) < 0
+        {
+            return None;
+        }
+
         if let Some(current_char) = self.current_char {
             let pixel = loop {
                 // Char _code_ offset from first char, most often a space
@@ -168,5 +174,18 @@ impl<'a> Transform for Font6x12<'a> {
         self.pos += by;
 
         self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn off_screen_text_does_not_infinite_loop() {
+        let text = Font6x12::render_str("Hello World!", 1).translate(Coord::new(5, -20));
+        let mut it = text.into_iter();
+
+        assert_eq!(it.next(), None);
     }
 }

--- a/embedded-graphics/src/fonts/font6x12.rs
+++ b/embedded-graphics/src/fonts/font6x12.rs
@@ -3,7 +3,7 @@
 use super::super::drawable::*;
 use super::super::transform::*;
 use super::Font;
-use coord::Coord;
+use coord::{Coord, ToUnsigned};
 
 const FONT_IMAGE: &[u8] = include_bytes!("../../data/font6x12_1bpp.raw");
 const CHAR_HEIGHT: u32 = 12;
@@ -116,7 +116,7 @@ impl<'a> Iterator for Font6x12Iterator<'a> {
                 let y = self.pos[1] + self.char_walk_y as i32;
 
                 if x >= 0 && y >= 0 {
-                    break Some((Coord::new(x, y), color));
+                    break Some((Coord::new(x, y).to_unsigned(), color));
                 }
             };
 

--- a/embedded-graphics/src/fonts/font6x12.rs
+++ b/embedded-graphics/src/fonts/font6x12.rs
@@ -22,7 +22,7 @@ pub struct Font6x12<'a> {
     text: &'a str,
 
     /// Fill Color of font
-    color: u8
+    color: u8,
 }
 
 impl<'a> Font<'a> for Font6x12<'a> {
@@ -30,7 +30,7 @@ impl<'a> Font<'a> for Font6x12<'a> {
         Self {
             pos: Coord::new(0, 0),
             text,
-            color
+            color,
         }
     }
 }
@@ -68,52 +68,59 @@ impl<'a> Iterator for Font6x12Iterator<'a> {
 
     fn next(&mut self) -> Option<Self::Item> {
         if let Some(current_char) = self.current_char {
-            // Char _code_ offset from first char, most often a space
-            // E.g. first char = ' ' (32), target char = '!' (33), offset = 33 - 32 = 1
-            let char_offset = current_char as u32 - FIRST_CHARCODE;
-            let row = char_offset / CHARS_PER_ROW;
+            let pixel = loop {
+                // Char _code_ offset from first char, most often a space
+                // E.g. first char = ' ' (32), target char = '!' (33), offset = 33 - 32 = 1
+                let char_offset = current_char as u32 - FIRST_CHARCODE;
+                let row = char_offset / CHARS_PER_ROW;
 
-            // Top left corner of character, in pixels
-            let char_x = (char_offset - (row * CHARS_PER_ROW)) * CHAR_WIDTH;
-            let char_y = row * CHAR_HEIGHT;
+                // Top left corner of character, in pixels
+                let char_x = (char_offset - (row * CHARS_PER_ROW)) * CHAR_WIDTH;
+                let char_y = row * CHAR_HEIGHT;
 
-            // Bit index
-            // = X pixel offset for char
-            // + Character row offset (row 0 = 0, row 1 = (192 * 8) = 1536)
-            // + X offset for the pixel block that comprises this char
-            // + Y offset for pixel block
-            let bitmap_bit_index = char_x
-                + (FONT_IMAGE_WIDTH * char_y)
-                + self.char_walk_x
-                + (self.char_walk_y * FONT_IMAGE_WIDTH);
+                // Bit index
+                // = X pixel offset for char
+                // + Character row offset (row 0 = 0, row 1 = (192 * 8) = 1536)
+                // + X offset for the pixel block that comprises this char
+                // + Y offset for pixel block
+                let bitmap_bit_index = char_x
+                    + (FONT_IMAGE_WIDTH * char_y)
+                    + self.char_walk_x
+                    + (self.char_walk_y * FONT_IMAGE_WIDTH);
 
-            let bitmap_byte = bitmap_bit_index / 8;
-            let bitmap_bit = 7 - (bitmap_bit_index % 8);
+                let bitmap_byte = bitmap_bit_index / 8;
+                let bitmap_bit = 7 - (bitmap_bit_index % 8);
 
-            let color = if (FONT_IMAGE[bitmap_byte as usize] >> bitmap_bit) & 1 == 1 {
-                self.color
-            } else {
-                0 // black
+                let color = if (FONT_IMAGE[bitmap_byte as usize] >> bitmap_bit) & 1 == 1 {
+                    self.color
+                } else {
+                    0 // black
+                };
+
+                self.char_walk_x += 1;
+
+                if self.char_walk_x >= CHAR_WIDTH {
+                    self.char_walk_x = 0;
+                    self.char_walk_y += 1;
+
+                    // Done with this char, move on to the next one
+                    if self.char_walk_y >= CHAR_HEIGHT {
+                        self.char_walk_y = 0;
+                        self.idx += 1;
+                        self.current_char = self.text.chars().skip(self.idx).next();
+                    }
+                }
+
+                let x =
+                    self.pos[0] + (CHAR_WIDTH * self.idx as u32) as i32 + self.char_walk_x as i32;
+                let y = self.pos[1] + self.char_walk_y as i32;
+
+                if x >= 0 && y >= 0 {
+                    break Some((Coord::new(x, y), color));
+                }
             };
 
-            self.char_walk_x += 1;
-
-            if self.char_walk_x >= CHAR_WIDTH {
-                self.char_walk_x = 0;
-                self.char_walk_y += 1;
-
-                // Done with this char, move on to the next one
-                if self.char_walk_y >= CHAR_HEIGHT {
-                    self.char_walk_y = 0;
-                    self.idx += 1;
-                    self.current_char = self.text.chars().skip(self.idx).next();
-                }
-            }
-
-            let x = self.pos[0] + (CHAR_WIDTH * self.idx as u32) + self.char_walk_x;
-            let y = self.pos[1] + self.char_walk_y;
-
-            Some((Coord::new(x, y), color))
+            pixel
         } else {
             None
         }

--- a/embedded-graphics/src/fonts/font6x8.rs
+++ b/embedded-graphics/src/fonts/font6x8.rs
@@ -67,6 +67,12 @@ impl<'a> Iterator for Font6x8Iterator<'a> {
     type Item = Pixel;
 
     fn next(&mut self) -> Option<Self::Item> {
+        if self.pos[0] + ((self.text.len() as i32 * CHAR_WIDTH as i32)) < 0
+            || self.pos[1] + (CHAR_HEIGHT as i32) < 0
+        {
+            return None;
+        }
+
         if let Some(current_char) = self.current_char {
             let pixel = loop {
                 // Char _code_ offset from first char, most often a space
@@ -168,5 +174,18 @@ impl<'a> Transform for Font6x8<'a> {
         self.pos += by;
 
         self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn off_screen_text_does_not_infinite_loop() {
+        let text = Font6x8::render_str("Hello World!", 1).translate(Coord::new(5, -10));
+        let mut it = text.into_iter();
+
+        assert_eq!(it.next(), None);
     }
 }

--- a/embedded-graphics/src/fonts/font6x8.rs
+++ b/embedded-graphics/src/fonts/font6x8.rs
@@ -30,7 +30,7 @@ impl<'a> Font<'a> for Font6x8<'a> {
         Self {
             pos: Coord::new(0, 0),
             text,
-            color
+            color,
         }
     }
 }
@@ -43,7 +43,7 @@ pub struct Font6x8Iterator<'a> {
     idx: usize,
     pos: Coord,
     text: &'a str,
-    color: u8
+    color: u8,
 }
 
 impl<'a> IntoIterator for &'a Font6x8<'a> {
@@ -58,7 +58,7 @@ impl<'a> IntoIterator for &'a Font6x8<'a> {
             char_walk_x: 0,
             char_walk_y: 0,
             pos: self.pos,
-            color: self.color
+            color: self.color,
         }
     }
 }
@@ -68,52 +68,59 @@ impl<'a> Iterator for Font6x8Iterator<'a> {
 
     fn next(&mut self) -> Option<Self::Item> {
         if let Some(current_char) = self.current_char {
-            // Char _code_ offset from first char, most often a space
-            // E.g. first char = ' ' (32), target char = '!' (33), offset = 33 - 32 = 1
-            let char_offset = current_char as u32 - FIRST_CHARCODE;
-            let row = char_offset / CHARS_PER_ROW;
+            let pixel = loop {
+                // Char _code_ offset from first char, most often a space
+                // E.g. first char = ' ' (32), target char = '!' (33), offset = 33 - 32 = 1
+                let char_offset = current_char as u32 - FIRST_CHARCODE;
+                let row = char_offset / CHARS_PER_ROW;
 
-            // Top left corner of character, in pixels
-            let char_x = (char_offset - (row * CHARS_PER_ROW)) * CHAR_WIDTH;
-            let char_y = row * CHAR_HEIGHT;
+                // Top left corner of character, in pixels
+                let char_x = (char_offset - (row * CHARS_PER_ROW)) * CHAR_WIDTH;
+                let char_y = row * CHAR_HEIGHT;
 
-            // Bit index
-            // = X pixel offset for char
-            // + Character row offset (row 0 = 0, row 1 = (192 * 8) = 1536)
-            // + X offset for the pixel block that comprises this char
-            // + Y offset for pixel block
-            let bitmap_bit_index = char_x
-                + (FONT_IMAGE_WIDTH * char_y)
-                + self.char_walk_x
-                + (self.char_walk_y * FONT_IMAGE_WIDTH);
+                // Bit index
+                // = X pixel offset for char
+                // + Character row offset (row 0 = 0, row 1 = (192 * 8) = 1536)
+                // + X offset for the pixel block that comprises this char
+                // + Y offset for pixel block
+                let bitmap_bit_index = char_x
+                    + (FONT_IMAGE_WIDTH * char_y)
+                    + self.char_walk_x
+                    + (self.char_walk_y * FONT_IMAGE_WIDTH);
 
-            let bitmap_byte = bitmap_bit_index / 8;
-            let bitmap_bit = 7 - (bitmap_bit_index % 8);
+                let bitmap_byte = bitmap_bit_index / 8;
+                let bitmap_bit = 7 - (bitmap_bit_index % 8);
 
-            let color = if (FONT_IMAGE[bitmap_byte as usize] >> bitmap_bit) & 1 == 1 {
-                self.color
-            } else {
-                0 // black
+                let color = if (FONT_IMAGE[bitmap_byte as usize] >> bitmap_bit) & 1 == 1 {
+                    self.color
+                } else {
+                    0 // black
+                };
+
+                self.char_walk_x += 1;
+
+                if self.char_walk_x >= CHAR_WIDTH {
+                    self.char_walk_x = 0;
+                    self.char_walk_y += 1;
+
+                    // Done with this char, move on to the next one
+                    if self.char_walk_y >= CHAR_HEIGHT {
+                        self.char_walk_y = 0;
+                        self.idx += 1;
+                        self.current_char = self.text.chars().skip(self.idx).next();
+                    }
+                }
+
+                let x =
+                    self.pos[0] + (CHAR_WIDTH * self.idx as u32) as i32 + self.char_walk_x as i32;
+                let y = self.pos[1] + self.char_walk_y as i32;
+
+                if x >= 0 && y >= 0 {
+                    break Some((Coord::new(x, y), color));
+                }
             };
 
-            self.char_walk_x += 1;
-
-            if self.char_walk_x >= CHAR_WIDTH {
-                self.char_walk_x = 0;
-                self.char_walk_y += 1;
-
-                // Done with this char, move on to the next one
-                if self.char_walk_y >= CHAR_HEIGHT {
-                    self.char_walk_y = 0;
-                    self.idx += 1;
-                    self.current_char = self.text.chars().skip(self.idx).next();
-                }
-            }
-
-            let x = self.pos[0] + (CHAR_WIDTH * self.idx as u32) + self.char_walk_x;
-            let y = self.pos[1] + self.char_walk_y;
-
-            Some((Coord::new(x, y), color))
+            pixel
         } else {
             None
         }

--- a/embedded-graphics/src/fonts/font6x8.rs
+++ b/embedded-graphics/src/fonts/font6x8.rs
@@ -3,7 +3,7 @@
 use super::super::drawable::*;
 use super::super::transform::*;
 use super::Font;
-use coord::Coord;
+use coord::{Coord, ToUnsigned};
 
 const FONT_IMAGE: &[u8] = include_bytes!("../../data/font6x8_1bpp.raw");
 const CHAR_HEIGHT: u32 = 8;
@@ -116,7 +116,7 @@ impl<'a> Iterator for Font6x8Iterator<'a> {
                 let y = self.pos[1] + self.char_walk_y as i32;
 
                 if x >= 0 && y >= 0 {
-                    break Some((Coord::new(x, y), color));
+                    break Some((Coord::new(x, y).to_unsigned(), color));
                 }
             };
 

--- a/embedded-graphics/src/fonts/font8x16.rs
+++ b/embedded-graphics/src/fonts/font8x16.rs
@@ -30,7 +30,7 @@ impl<'a> Font<'a> for Font8x16<'a> {
         Self {
             pos: Coord::new(0, 0),
             text,
-            color
+            color,
         }
     }
 }
@@ -68,52 +68,59 @@ impl<'a> Iterator for Font8x16Iterator<'a> {
 
     fn next(&mut self) -> Option<Self::Item> {
         if let Some(current_char) = self.current_char {
-            // Char _code_ offset from first char, most often a space
-            // E.g. first char = ' ' (32), target char = '!' (33), offset = 33 - 32 = 1
-            let char_offset = current_char as u32 - FIRST_CHARCODE;
-            let row = char_offset / CHARS_PER_ROW;
+            let pixel = loop {
+                // Char _code_ offset from first char, most often a space
+                // E.g. first char = ' ' (32), target char = '!' (33), offset = 33 - 32 = 1
+                let char_offset = current_char as u32 - FIRST_CHARCODE;
+                let row = char_offset / CHARS_PER_ROW;
 
-            // Top left corner of character, in pixels
-            let char_x = (char_offset - (row * CHARS_PER_ROW)) * CHAR_WIDTH;
-            let char_y = row * CHAR_HEIGHT;
+                // Top left corner of character, in pixels
+                let char_x = (char_offset - (row * CHARS_PER_ROW)) * CHAR_WIDTH;
+                let char_y = row * CHAR_HEIGHT;
 
-            // Bit index
-            // = X pixel offset for char
-            // + Character row offset (row 0 = 0, row 1 = (192 * 8) = 1536)
-            // + X offset for the pixel block that comprises this char
-            // + Y offset for pixel block
-            let bitmap_bit_index = char_x
-                + (FONT_IMAGE_WIDTH * char_y)
-                + self.char_walk_x
-                + (self.char_walk_y * FONT_IMAGE_WIDTH);
+                // Bit index
+                // = X pixel offset for char
+                // + Character row offset (row 0 = 0, row 1 = (192 * 8) = 1536)
+                // + X offset for the pixel block that comprises this char
+                // + Y offset for pixel block
+                let bitmap_bit_index = char_x
+                    + (FONT_IMAGE_WIDTH * char_y)
+                    + self.char_walk_x
+                    + (self.char_walk_y * FONT_IMAGE_WIDTH);
 
-            let bitmap_byte = bitmap_bit_index / 8;
-            let bitmap_bit = 7 - (bitmap_bit_index % 8);
+                let bitmap_byte = bitmap_bit_index / 8;
+                let bitmap_bit = 7 - (bitmap_bit_index % 8);
 
-            let color = if (FONT_IMAGE[bitmap_byte as usize] >> bitmap_bit) & 1 == 1 {
-                self.color
-            } else {
-                0 // black
+                let color = if (FONT_IMAGE[bitmap_byte as usize] >> bitmap_bit) & 1 == 1 {
+                    self.color
+                } else {
+                    0 // black
+                };
+
+                self.char_walk_x += 1;
+
+                if self.char_walk_x >= CHAR_WIDTH {
+                    self.char_walk_x = 0;
+                    self.char_walk_y += 1;
+
+                    // Done with this char, move on to the next one
+                    if self.char_walk_y >= CHAR_HEIGHT {
+                        self.char_walk_y = 0;
+                        self.idx += 1;
+                        self.current_char = self.text.chars().skip(self.idx).next();
+                    }
+                }
+
+                let x =
+                    self.pos[0] + (CHAR_WIDTH * self.idx as u32) as i32 + self.char_walk_x as i32;
+                let y = self.pos[1] + self.char_walk_y as i32;
+
+                if x >= 0 && y >= 0 {
+                    break Some((Coord::new(x, y), color));
+                }
             };
 
-            self.char_walk_x += 1;
-
-            if self.char_walk_x >= CHAR_WIDTH {
-                self.char_walk_x = 0;
-                self.char_walk_y += 1;
-
-                // Done with this char, move on to the next one
-                if self.char_walk_y >= CHAR_HEIGHT {
-                    self.char_walk_y = 0;
-                    self.idx += 1;
-                    self.current_char = self.text.chars().skip(self.idx).next();
-                }
-            }
-
-            let x = self.pos[0] + (CHAR_WIDTH * self.idx as u32) + self.char_walk_x;
-            let y = self.pos[1] + self.char_walk_y;
-
-            Some((Coord::new(x, y), color))
+            pixel
         } else {
             None
         }

--- a/embedded-graphics/src/fonts/font8x16.rs
+++ b/embedded-graphics/src/fonts/font8x16.rs
@@ -67,6 +67,12 @@ impl<'a> Iterator for Font8x16Iterator<'a> {
     type Item = Pixel;
 
     fn next(&mut self) -> Option<Self::Item> {
+        if self.pos[0] + ((self.text.len() as i32 * CHAR_WIDTH as i32)) < 0
+            || self.pos[1] + (CHAR_HEIGHT as i32) < 0
+        {
+            return None;
+        }
+
         if let Some(current_char) = self.current_char {
             let pixel = loop {
                 // Char _code_ offset from first char, most often a space
@@ -168,5 +174,18 @@ impl<'a> Transform for Font8x16<'a> {
         self.pos += by;
 
         self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn off_screen_text_does_not_infinite_loop() {
+        let text = Font8x16::render_str("Hello World!", 1).translate(Coord::new(5, -20));
+        let mut it = text.into_iter();
+
+        assert_eq!(it.next(), None);
     }
 }

--- a/embedded-graphics/src/fonts/font8x16.rs
+++ b/embedded-graphics/src/fonts/font8x16.rs
@@ -3,7 +3,7 @@
 use super::super::drawable::*;
 use super::super::transform::*;
 use super::Font;
-use coord::Coord;
+use coord::{Coord, ToUnsigned};
 
 const FONT_IMAGE: &[u8] = include_bytes!("../../data/font8x16_1bpp.raw");
 const CHAR_HEIGHT: u32 = 16;
@@ -116,7 +116,7 @@ impl<'a> Iterator for Font8x16Iterator<'a> {
                 let y = self.pos[1] + self.char_walk_y as i32;
 
                 if x >= 0 && y >= 0 {
-                    break Some((Coord::new(x, y), color));
+                    break Some((Coord::new(x, y).to_unsigned(), color));
                 }
             };
 

--- a/embedded-graphics/src/image/image1bpp.rs
+++ b/embedded-graphics/src/image/image1bpp.rs
@@ -11,7 +11,7 @@
 use super::super::drawable::*;
 use super::super::transform::*;
 use super::Image;
-use coord::Coord;
+use coord::{Coord, ToUnsigned};
 
 /// 1 bit per pixel image
 #[derive(Debug)]
@@ -106,7 +106,7 @@ impl<'a> Iterator for Image1BPPIterator<'a> {
             }
 
             if current_pixel[0] >= 0 && current_pixel[1] >= 0 {
-                break (current_pixel, bit_value);
+                break (current_pixel.to_unsigned(), bit_value);
             }
         };
 

--- a/embedded-graphics/src/image/image8bpp.rs
+++ b/embedded-graphics/src/image/image8bpp.rs
@@ -12,7 +12,7 @@
 use super::super::drawable::*;
 use super::super::transform::*;
 use super::Image;
-use coord::Coord;
+use coord::{Coord, ToUnsigned};
 
 /// 8 bit per pixel image
 #[derive(Debug)]
@@ -94,7 +94,7 @@ impl<'a> Iterator for Image8BPPIterator<'a> {
             }
 
             if current_pixel[0] >= 0 && current_pixel[1] >= 0 {
-                break (current_pixel, bit_value);
+                break (current_pixel.to_unsigned(), bit_value);
             }
         };
 
@@ -150,6 +150,7 @@ impl<'a> Transform for Image8BPP<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use unsignedcoord::UnsignedCoord;
 
     #[test]
     fn it_can_have_negative_offsets() {
@@ -160,10 +161,10 @@ mod tests {
         ).translate(Coord::new(-1, -1));
         let mut it = image.into_iter();
 
-        assert_eq!(it.next(), Some((Coord::new(0, 0), 0xcc)));
-        assert_eq!(it.next(), Some((Coord::new(1, 0), 0x00)));
-        assert_eq!(it.next(), Some((Coord::new(0, 1), 0x00)));
-        assert_eq!(it.next(), Some((Coord::new(1, 1), 0xaa)));
+        assert_eq!(it.next(), Some((UnsignedCoord::new(0, 0), 0xcc)));
+        assert_eq!(it.next(), Some((UnsignedCoord::new(1, 0), 0x00)));
+        assert_eq!(it.next(), Some((UnsignedCoord::new(0, 1), 0x00)));
+        assert_eq!(it.next(), Some((UnsignedCoord::new(1, 1), 0xaa)));
 
         assert_eq!(it.next(), None);
     }

--- a/embedded-graphics/src/lib.rs
+++ b/embedded-graphics/src/lib.rs
@@ -50,6 +50,7 @@ pub mod image;
 pub mod prelude;
 pub mod primitives;
 pub mod transform;
+pub mod unsignedcoord;
 
 /// The main trait of this crate. All graphics objects must implement it.
 pub trait Drawing {

--- a/embedded-graphics/src/prelude.rs
+++ b/embedded-graphics/src/prelude.rs
@@ -1,6 +1,6 @@
 //! Prelude
 
-pub use super::coord::Coord;
+pub use super::coord::{Coord, ToUnsigned};
 pub use super::fonts::Font;
 pub use super::image::Image;
 pub use super::transform::Transform;

--- a/embedded-graphics/src/prelude.rs
+++ b/embedded-graphics/src/prelude.rs
@@ -4,4 +4,5 @@ pub use super::coord::Coord;
 pub use super::fonts::Font;
 pub use super::image::Image;
 pub use super::transform::Transform;
+pub use super::unsignedcoord::UnsignedCoord;
 pub use super::Drawing;

--- a/embedded-graphics/src/primitives/circle.rs
+++ b/embedded-graphics/src/primitives/circle.rs
@@ -2,7 +2,7 @@
 
 use super::super::drawable::*;
 use super::super::transform::*;
-use coord::Coord;
+use coord::{Coord, ToUnsigned};
 
 // TODO: Impl Default so people can leave the color bit out
 /// Circle primitive
@@ -109,13 +109,7 @@ impl Iterator for CircleIterator {
             }
         };
 
-        // if item.is_none() {
-        //     None
-        // } else {
-        //     Some((item.unwrap(), self.color))
-        // }
-
-        item.map(|(x, y)| (Coord::new(x, y), self.color))
+        item.map(|(x, y)| (Coord::new(x, y).to_unsigned(), self.color))
     }
 }
 

--- a/embedded-graphics/src/primitives/line.rs
+++ b/embedded-graphics/src/primitives/line.rs
@@ -2,7 +2,7 @@
 
 use super::super::drawable::*;
 use super::super::transform::*;
-use coord::Coord;
+use coord::{Coord, ToUnsigned};
 
 // TODO: Impl Default so people can leave the color bit out
 /// Line primitive
@@ -135,7 +135,7 @@ impl<'a> Iterator for LineIterator<'a> {
         self.quick += 1;
 
         // Return
-        Some((coord, color))
+        Some((coord.to_unsigned(), color))
     }
 }
 
@@ -188,11 +188,12 @@ impl Transform for Line {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use unsignedcoord::UnsignedCoord;
 
-    fn test_expected_line(start: Coord, end: Coord, expected: &[Coord]) {
+    fn test_expected_line(start: Coord, end: Coord, expected: &[(u32, u32)]) {
         let line = Line::new(start, end, 1);
         for (idx, (coord, _)) in line.into_iter().enumerate() {
-            assert_eq!(coord, expected[idx]);
+            assert_eq!(coord, UnsignedCoord::new(expected[idx].0, expected[idx].1));
         }
     }
 
@@ -200,14 +201,7 @@ mod tests {
     fn draws_octant_1_correctly() {
         let start = Coord::new(10, 10);
         let end = Coord::new(15, 13);
-        let expected = [
-            Coord::new(10, 10),
-            Coord::new(11, 11),
-            Coord::new(12, 11),
-            Coord::new(13, 12),
-            Coord::new(14, 12),
-            Coord::new(15, 13),
-        ];
+        let expected = [(10, 10), (11, 11), (12, 11), (13, 12), (14, 12), (15, 13)];
         test_expected_line(start, end, &expected);
     }
 
@@ -215,14 +209,7 @@ mod tests {
     fn draws_octant_2_correctly() {
         let start = Coord::new(10, 10);
         let end = Coord::new(13, 15);
-        let expected = [
-            Coord::new(10, 10),
-            Coord::new(11, 11),
-            Coord::new(11, 12),
-            Coord::new(12, 13),
-            Coord::new(12, 14),
-            Coord::new(13, 15),
-        ];
+        let expected = [(10, 10), (11, 11), (11, 12), (12, 13), (12, 14), (13, 15)];
         test_expected_line(start, end, &expected);
     }
 
@@ -230,14 +217,7 @@ mod tests {
     fn draws_octant_3_correctly() {
         let start = Coord::new(10, 10);
         let end = Coord::new(7, 15);
-        let expected = [
-            Coord::new(10, 10),
-            Coord::new(9, 11),
-            Coord::new(9, 12),
-            Coord::new(8, 13),
-            Coord::new(8, 14),
-            Coord::new(7, 15),
-        ];
+        let expected = [(10, 10), (9, 11), (9, 12), (8, 13), (8, 14), (7, 15)];
         test_expected_line(start, end, &expected);
     }
 
@@ -245,14 +225,7 @@ mod tests {
     fn draws_octant_4_correctly() {
         let start = Coord::new(10, 10);
         let end = Coord::new(5, 13);
-        let expected = [
-            Coord::new(5, 13),
-            Coord::new(6, 12),
-            Coord::new(7, 12),
-            Coord::new(8, 11),
-            Coord::new(9, 11),
-            Coord::new(10, 10),
-        ];
+        let expected = [(5, 13), (6, 12), (7, 12), (8, 11), (9, 11), (10, 10)];
         test_expected_line(start, end, &expected);
     }
 
@@ -260,14 +233,7 @@ mod tests {
     fn draws_octant_5_correctly() {
         let start = Coord::new(10, 10);
         let end = Coord::new(5, 7);
-        let expected = [
-            Coord::new(5, 7),
-            Coord::new(6, 8),
-            Coord::new(7, 8),
-            Coord::new(8, 9),
-            Coord::new(9, 9),
-            Coord::new(10, 10),
-        ];
+        let expected = [(5, 7), (6, 8), (7, 8), (8, 9), (9, 9), (10, 10)];
         test_expected_line(start, end, &expected);
     }
 
@@ -275,14 +241,7 @@ mod tests {
     fn draws_octant_6_correctly() {
         let start = Coord::new(10, 10);
         let end = Coord::new(7, 5);
-        let expected = [
-            Coord::new(7, 5),
-            Coord::new(8, 6),
-            Coord::new(8, 7),
-            Coord::new(9, 8),
-            Coord::new(9, 9),
-            Coord::new(10, 10),
-        ];
+        let expected = [(7, 5), (8, 6), (8, 7), (9, 8), (9, 9), (10, 10)];
         test_expected_line(start, end, &expected);
     }
 
@@ -290,14 +249,7 @@ mod tests {
     fn draws_octant_7_correctly() {
         let start = Coord::new(10, 10);
         let end = Coord::new(13, 5);
-        let expected = [
-            Coord::new(13, 5),
-            Coord::new(12, 6),
-            Coord::new(12, 7),
-            Coord::new(11, 8),
-            Coord::new(11, 9),
-            Coord::new(10, 10),
-        ];
+        let expected = [(13, 5), (12, 6), (12, 7), (11, 8), (11, 9), (10, 10)];
         test_expected_line(start, end, &expected);
     }
 
@@ -306,12 +258,12 @@ mod tests {
         let start = Coord::new(10, 10);
         let end = Coord::new(15, 7);
         let expected = [
-            Coord::new(10, 10),
-            Coord::new(11, 9),
-            Coord::new(12, 9),
-            Coord::new(13, 8),
-            Coord::new(14, 8),
-            Coord::new(15, 7),
+            (10, 10).into(),
+            (11, 9).into(),
+            (12, 9).into(),
+            (13, 8).into(),
+            (14, 8).into(),
+            (15, 7).into(),
         ];
         test_expected_line(start, end, &expected);
     }
@@ -320,7 +272,7 @@ mod tests {
     fn it_truncates_lines_out_of_bounds() {
         let start = Coord::new(-2, -2);
         let end = Coord::new(2, 2);
-        let expected = [Coord::new(0, 0), Coord::new(1, 1), Coord::new(2, 2)];
+        let expected = [(0, 0).into(), (1, 1).into(), (2, 2).into()];
         test_expected_line(start, end, &expected);
     }
 }

--- a/embedded-graphics/src/primitives/rect.rs
+++ b/embedded-graphics/src/primitives/rect.rs
@@ -2,7 +2,7 @@
 
 use super::super::drawable::*;
 use super::super::transform::*;
-use coord::Coord;
+use coord::{Coord, ToUnsigned};
 
 // TODO: Impl Default so people can leave the color bit out
 /// Rectangle primitive
@@ -96,7 +96,7 @@ impl Iterator for RectIterator {
             }
         };
 
-        Some((coord, self.color))
+        Some((coord.to_unsigned(), self.color))
     }
 }
 
@@ -149,6 +149,7 @@ impl Transform for Rect {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use unsignedcoord::UnsignedCoord;
 
     #[test]
     fn it_can_be_translated() {
@@ -163,16 +164,16 @@ mod tests {
     fn it_draws_unfilled_rect() {
         let mut rect = Rect::new(Coord::new(2, 2), Coord::new(4, 4), 1).into_iter();
 
-        assert_eq!(rect.next(), Some((Coord::new(2, 2), 1)));
-        assert_eq!(rect.next(), Some((Coord::new(3, 2), 1)));
-        assert_eq!(rect.next(), Some((Coord::new(4, 2), 1)));
+        assert_eq!(rect.next(), Some((UnsignedCoord::new(2, 2), 1)));
+        assert_eq!(rect.next(), Some((UnsignedCoord::new(3, 2), 1)));
+        assert_eq!(rect.next(), Some((UnsignedCoord::new(4, 2), 1)));
 
-        assert_eq!(rect.next(), Some((Coord::new(2, 3), 1)));
-        assert_eq!(rect.next(), Some((Coord::new(4, 3), 1)));
+        assert_eq!(rect.next(), Some((UnsignedCoord::new(2, 3), 1)));
+        assert_eq!(rect.next(), Some((UnsignedCoord::new(4, 3), 1)));
 
-        assert_eq!(rect.next(), Some((Coord::new(2, 4), 1)));
-        assert_eq!(rect.next(), Some((Coord::new(3, 4), 1)));
-        assert_eq!(rect.next(), Some((Coord::new(4, 4), 1)));
+        assert_eq!(rect.next(), Some((UnsignedCoord::new(2, 4), 1)));
+        assert_eq!(rect.next(), Some((UnsignedCoord::new(3, 4), 1)));
+        assert_eq!(rect.next(), Some((UnsignedCoord::new(4, 4), 1)));
     }
 
     #[test]
@@ -181,10 +182,10 @@ mod tests {
 
         // TODO: Macro
         // Only the bottom right corner of the rect should be visible
-        assert_eq!(rect.next(), Some((Coord::new(2, 0), 1)));
-        assert_eq!(rect.next(), Some((Coord::new(2, 1), 1)));
-        assert_eq!(rect.next(), Some((Coord::new(0, 2), 1)));
-        assert_eq!(rect.next(), Some((Coord::new(1, 2), 1)));
-        assert_eq!(rect.next(), Some((Coord::new(2, 2), 1)));
+        assert_eq!(rect.next(), Some((UnsignedCoord::new(2, 0), 1)));
+        assert_eq!(rect.next(), Some((UnsignedCoord::new(2, 1), 1)));
+        assert_eq!(rect.next(), Some((UnsignedCoord::new(0, 2), 1)));
+        assert_eq!(rect.next(), Some((UnsignedCoord::new(1, 2), 1)));
+        assert_eq!(rect.next(), Some((UnsignedCoord::new(2, 2), 1)));
     }
 }

--- a/embedded-graphics/src/unsignedcoord.rs
+++ b/embedded-graphics/src/unsignedcoord.rs
@@ -1,0 +1,102 @@
+//! 2D coordinate in screen space
+
+type UnsignedCoordPart = u32;
+
+#[cfg(not(feature = "nalgebra_support"))]
+mod internal_unsigned_coord {
+    use super::UnsignedCoordPart;
+    use core::ops::{Add, AddAssign, Index, Sub, SubAssign};
+
+    /// 2D coordinate type
+    #[derive(Debug, Copy, Clone, Eq, PartialEq)]
+    pub struct UnsignedCoord(pub UnsignedCoordPart, pub UnsignedCoordPart);
+
+    impl UnsignedCoord {
+        /// Create a new coordinate with X and Y values
+        pub fn new(x: UnsignedCoordPart, y: UnsignedCoordPart) -> Self {
+            UnsignedCoord(x, y)
+        }
+    }
+
+    impl Add for UnsignedCoord {
+        type Output = UnsignedCoord;
+
+        fn add(self, other: UnsignedCoord) -> UnsignedCoord {
+            UnsignedCoord::new(self.0 + other.0, self.1 + other.1)
+        }
+    }
+
+    impl AddAssign for UnsignedCoord {
+        fn add_assign(&mut self, other: UnsignedCoord) {
+            self.0 += other.0;
+            self.1 += other.1;
+        }
+    }
+
+    impl Sub for UnsignedCoord {
+        type Output = UnsignedCoord;
+
+        fn sub(self, other: UnsignedCoord) -> UnsignedCoord {
+            UnsignedCoord::new(self.0 - other.0, self.1 - other.1)
+        }
+    }
+
+    impl SubAssign for UnsignedCoord {
+        fn sub_assign(&mut self, other: UnsignedCoord) {
+            self.0 -= other.0;
+            self.1 -= other.1;
+        }
+    }
+
+    impl Index<usize> for UnsignedCoord {
+        type Output = UnsignedCoordPart;
+
+        fn index(&self, idx: usize) -> &UnsignedCoordPart {
+            match idx {
+                0 => &self.0,
+                1 => &self.1,
+                _ => panic!("Unreachable index {}", idx),
+            }
+        }
+    }
+}
+
+#[cfg(not(feature = "nalgebra_support"))]
+pub use self::internal_unsigned_coord::UnsignedCoord;
+
+#[cfg(feature = "nalgebra_support")]
+use nalgebra;
+
+#[cfg(feature = "nalgebra_support")]
+/// 2D coordinate type with Nalgebra support
+pub type UnsignedCoord = nalgebra::Vector2<UnsignedCoordPart>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn coords_can_be_added() {
+        let left = UnsignedCoord::new(10, 20);
+        let right = UnsignedCoord::new(30, 40);
+
+        assert_eq!(left + right, UnsignedCoord::new(40, 60));
+    }
+
+    #[test]
+    fn coords_can_be_subtracted() {
+        let left = UnsignedCoord::new(30, 40);
+        let right = UnsignedCoord::new(10, 20);
+
+        assert_eq!(left - right, UnsignedCoord::new(20, 20));
+    }
+
+    #[test]
+    #[cfg(feature = "nalgebra_support")]
+    fn nalgebra_support() {
+        let left = nalgebra::Vector2::new(30, 40);
+        let right = nalgebra::Vector2::new(10, 20);
+
+        assert_eq!(left - right, UnsignedCoord::new(20, 20));
+    }
+}

--- a/simulator/src/lib.rs
+++ b/simulator/src/lib.rs
@@ -1,8 +1,8 @@
 extern crate embedded_graphics;
 extern crate sdl2;
 
-use embedded_graphics::coord::Coord;
 use embedded_graphics::drawable::Pixel;
+use embedded_graphics::prelude::*;
 use embedded_graphics::Drawing;
 
 use sdl2::event::Event;
@@ -83,7 +83,7 @@ impl Drawing for Display {
     where
         T: Iterator<Item = Pixel>,
     {
-        for (Coord(x, y), color) in item_pixels {
+        for (UnsignedCoord(x, y), color) in item_pixels {
             if x >= DISPLAY_SIZE as u32 || y >= DISPLAY_SIZE as u32 {
                 continue;
             }


### PR DESCRIPTION
Closes #30 

TODO

* [x] Negative transforms for lines
* [x] Negative transforms for circles
* [x] Negative transforms for rects
* [x] Negative transforms for fonts
* [x] Negative transforms for images
* [x] Introduce an `UnsignedCoord` or similarly named struct that uses `u32`s instead of `i32`s for unsigned output from iterators.