### PR TITLE
Generic colour

### DIFF
--- a/embedded-graphics/src/color.rs
+++ b/embedded-graphics/src/color.rs
@@ -1,0 +1,25 @@
+//! Generic Color
+
+/// Colour type
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Color<C>
+    where C: Clone + Copy + PartialEq
+{
+    value: C
+}
+
+impl<C> Color<C> 
+    where C: Clone + Copy + PartialEq
+{
+    /// Creates a new color from a number
+    pub fn new(color: C) -> Self {
+        Self {
+            value: color 
+        }
+    }
+
+    /// Raw value of the color type
+    pub fn value(self) -> C {
+        self.value
+    }
+}

--- a/embedded-graphics/src/drawable.rs
+++ b/embedded-graphics/src/drawable.rs
@@ -14,8 +14,8 @@ impl<C> Color<C>
     where C: Clone + Copy
 {
     /// Creates a new color from a number
-    pub fn new(self, color: C) -> Self {
-        Color {
+    pub fn new(color: C) -> Self {
+        Self {
             value: color 
         }
     }
@@ -26,27 +26,8 @@ impl<C> Color<C>
     }
 }
 
-impl<C> From<C> for Color<C>
-    where C: Clone + Copy
-{
-    fn from(color: C) -> Self {
-        Color { value: color }
-    }
-}
-
-// impl<C> Into<C> for Color<C> 
-//     where C: Clone + Copy
-// {
-//     fn into(self) -> C {
-//         self.value
-//     }
-// }
-
 /// A single pixel
 pub type Pixel<C> = (UnsignedCoord, Color<C>);
-// #[derive(Debug, Clone, Copy)]
-// pub struct Pixel<C>(pub UnsignedCoord, pub Color<C>)
-//     where C: Clone + Copy;
 
 /// Marks an object as "drawable". Must be implemented for all graphics objects
 pub trait Drawable {}

--- a/embedded-graphics/src/drawable.rs
+++ b/embedded-graphics/src/drawable.rs
@@ -1,30 +1,7 @@
 //! `Drawable` trait and helpers
 
 use super::unsignedcoord::UnsignedCoord;
-
-/// Colour type
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub struct Color<C>
-    where C: Clone + Copy + PartialEq
-{
-    value: C
-}
-
-impl<C> Color<C> 
-    where C: Clone + Copy + PartialEq
-{
-    /// Creates a new color from a number
-    pub fn new(color: C) -> Self {
-        Self {
-            value: color 
-        }
-    }
-
-    /// Raw value of the color type
-    pub fn value(self) -> C {
-        self.value
-    }
-}
+use super::color::Color;
 
 /// A single pixel
 pub type Pixel<C> = (UnsignedCoord, Color<C>);

--- a/embedded-graphics/src/drawable.rs
+++ b/embedded-graphics/src/drawable.rs
@@ -2,12 +2,51 @@
 
 use super::unsignedcoord::UnsignedCoord;
 
-// TODO: Refactor to use both with monochrome and multicolour displays
-/// Monochrome colour type
-pub type Color = u8;
+/// Colour type
+#[derive(Debug, Clone, Copy)]
+pub struct Color<C>
+    where C: Clone + Copy
+{
+    value: C
+}
+
+impl<C> Color<C> 
+    where C: Clone + Copy
+{
+    /// Creates a new color from a number
+    pub fn new(self, color: C) -> Self {
+        Color {
+            value: color 
+        }
+    }
+
+    /// Raw value of the color type
+    pub fn value(self) -> C {
+        self.value
+    }
+}
+
+impl<C> From<C> for Color<C>
+    where C: Clone + Copy
+{
+    fn from(color: C) -> Self {
+        Color { value: color }
+    }
+}
+
+// impl<C> Into<C> for Color<C> 
+//     where C: Clone + Copy
+// {
+//     fn into(self) -> C {
+//         self.value
+//     }
+// }
 
 /// A single pixel
-pub type Pixel = (UnsignedCoord, Color);
+pub type Pixel<C> = (UnsignedCoord, Color<C>);
+// #[derive(Debug, Clone, Copy)]
+// pub struct Pixel<C>(pub UnsignedCoord, pub Color<C>)
+//     where C: Clone + Copy;
 
 /// Marks an object as "drawable". Must be implemented for all graphics objects
 pub trait Drawable {}

--- a/embedded-graphics/src/drawable.rs
+++ b/embedded-graphics/src/drawable.rs
@@ -3,15 +3,15 @@
 use super::unsignedcoord::UnsignedCoord;
 
 /// Colour type
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Color<C>
-    where C: Clone + Copy
+    where C: Clone + Copy + PartialEq
 {
     value: C
 }
 
 impl<C> Color<C> 
-    where C: Clone + Copy
+    where C: Clone + Copy + PartialEq
 {
     /// Creates a new color from a number
     pub fn new(color: C) -> Self {

--- a/embedded-graphics/src/fonts/font12x16.rs
+++ b/embedded-graphics/src/fonts/font12x16.rs
@@ -4,6 +4,7 @@ use super::super::drawable::*;
 use super::super::transform::*;
 use super::Font;
 use coord::{Coord, ToUnsigned};
+use color::Color;
 
 const FONT_IMAGE: &[u8] = include_bytes!("../../data/font12x16_1bpp.raw");
 const CHAR_HEIGHT: u32 = 16;
@@ -149,8 +150,9 @@ impl<'a, C> Transform for Font12x16<'a, C> where C: Clone + Copy + PartialEq {
     /// # use embedded_graphics::fonts::{ Font, Font12x16 };
     /// # use embedded_graphics::transform::Transform;
     /// # use embedded_graphics::coord::Coord;
+    /// # use embedded_graphics::color::Color;
     ///
-    /// let text = Font12x16::render_str("Hello world", 1);
+    /// let text = Font12x16::render_str("Hello world", Color::new(1));
     /// let moved = text.translate(Coord::new(25, 30));
     ///
     /// assert_eq!(text.pos, Coord::new(0, 0));
@@ -169,8 +171,9 @@ impl<'a, C> Transform for Font12x16<'a, C> where C: Clone + Copy + PartialEq {
     /// # use embedded_graphics::fonts::{ Font, Font12x16 };
     /// # use embedded_graphics::transform::Transform;
     /// # use embedded_graphics::coord::Coord;
+    /// # use embedded_graphics::color::Color;
     ///
-    /// let mut text = Font12x16::render_str("Hello world", 1);
+    /// let mut text = Font12x16::render_str("Hello world", Color::new(1));
     /// text.translate_mut(Coord::new(25, 30));
     ///
     /// assert_eq!(text.pos, Coord::new(25, 30));

--- a/embedded-graphics/src/fonts/font12x16.rs
+++ b/embedded-graphics/src/fonts/font12x16.rs
@@ -14,7 +14,9 @@ const CHARS_PER_ROW: u32 = FONT_IMAGE_WIDTH / CHAR_WIDTH;
 
 /// Container struct to hold a positioned piece of text
 #[derive(Debug, Clone, Copy)]
-pub struct Font12x16<'a> {
+pub struct Font12x16<'a, C: 'a> 
+    where C: Clone + Copy + PartialEq
+{
     /// Top left corner of the text
     pub pos: Coord,
 
@@ -22,11 +24,14 @@ pub struct Font12x16<'a> {
     text: &'a str,
 
     /// Fill Color of font
-    color: u8,
+    color: Color<C>,
 }
 
-impl<'a> Font<'a> for Font12x16<'a> {
-    fn render_str(text: &'a str, color: u8) -> Font12x16<'a> {
+impl<'a, C> Font<'a> for Font12x16<'a, C> 
+    where C: Clone + Copy + PartialEq
+{
+    type C = C;
+    fn render_str(text: &'a str, color: Color<C>) -> Font12x16<'a, C> {
         Self {
             pos: Coord::new(0, 0),
             text,
@@ -36,19 +41,23 @@ impl<'a> Font<'a> for Font12x16<'a> {
 }
 
 #[derive(Debug, Clone, Copy)]
-pub struct Font12x16Iterator<'a> {
+pub struct Font12x16Iterator<'a, C: 'a> 
+    where C: Clone + Copy + PartialEq
+{
     char_walk_x: u32,
     char_walk_y: u32,
     current_char: Option<char>,
     idx: usize,
     pos: Coord,
     text: &'a str,
-    color: u8,
+    color: Color<C>,
 }
 
-impl<'a> IntoIterator for &'a Font12x16<'a> {
-    type IntoIter = Font12x16Iterator<'a>;
-    type Item = Pixel;
+impl<'a, C> IntoIterator for &'a Font12x16<'a, C> 
+    where C: Clone + Copy + PartialEq
+{
+    type IntoIter = Font12x16Iterator<'a, C>;
+    type Item = Pixel<C>;
 
     fn into_iter(self) -> Self::IntoIter {
         Font12x16Iterator {
@@ -63,8 +72,9 @@ impl<'a> IntoIterator for &'a Font12x16<'a> {
     }
 }
 
-impl<'a> Iterator for Font12x16Iterator<'a> {
-    type Item = Pixel;
+impl<'a, C> Iterator for Font12x16Iterator<'a, C> 
+    where C: Clone + Copy + PartialEq {
+    type Item = Pixel<C>;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.pos[0] + ((self.text.len() as i32 * CHAR_WIDTH as i32)) < 0
@@ -97,12 +107,6 @@ impl<'a> Iterator for Font12x16Iterator<'a> {
                 let bitmap_byte = bitmap_bit_index / 8;
                 let bitmap_bit = 7 - (bitmap_bit_index % 8);
 
-                let color = if (FONT_IMAGE[bitmap_byte as usize] >> bitmap_bit) & 1 == 1 {
-                    self.color
-                } else {
-                    0 // black
-                };
-
                 self.char_walk_x += 1;
 
                 if self.char_walk_x >= CHAR_WIDTH {
@@ -122,7 +126,9 @@ impl<'a> Iterator for Font12x16Iterator<'a> {
                 let y = self.pos[1] + self.char_walk_y as i32;
 
                 if x >= 0 && y >= 0 {
-                    break Some((Coord::new(x, y).to_unsigned(), color));
+                    if (FONT_IMAGE[bitmap_byte as usize] >> bitmap_bit) & 1 == 1 {
+                        break Some((Coord::new(x, y).to_unsigned(), self.color))
+                    }
                 }
             };
 
@@ -133,9 +139,9 @@ impl<'a> Iterator for Font12x16Iterator<'a> {
     }
 }
 
-impl<'a> Drawable for Font12x16<'a> {}
+impl<'a, C> Drawable for Font12x16<'a, C> where C: Clone + Copy + PartialEq {}
 
-impl<'a> Transform for Font12x16<'a> {
+impl<'a, C> Transform for Font12x16<'a, C> where C: Clone + Copy + PartialEq {
     /// Translate the font origin from its current position to a new position by (x, y) pixels,
     /// returning a new `Font12x16`. For a mutating transform, see `translate_mut`.
     ///
@@ -182,7 +188,7 @@ mod tests {
 
     #[test]
     fn off_screen_text_does_not_infinite_loop() {
-        let text = Font12x16::render_str("Hello World!", 1).translate(Coord::new(5, -20));
+        let text = Font12x16::render_str("Hello World!", Color::new(1)).translate(Coord::new(5, -20));
         let mut it = text.into_iter();
 
         assert_eq!(it.next(), None);

--- a/embedded-graphics/src/fonts/font6x12.rs
+++ b/embedded-graphics/src/fonts/font6x12.rs
@@ -4,6 +4,7 @@ use super::super::drawable::*;
 use super::super::transform::*;
 use super::Font;
 use coord::{Coord, ToUnsigned};
+use color::Color;
 
 const FONT_IMAGE: &[u8] = include_bytes!("../../data/font6x12_1bpp.raw");
 const CHAR_HEIGHT: u32 = 12;
@@ -153,8 +154,9 @@ impl<'a, C> Transform for Font6x12<'a, C>
     /// # use embedded_graphics::fonts::{ Font, Font6x8 };
     /// # use embedded_graphics::transform::Transform;
     /// # use embedded_graphics::coord::Coord;
+    /// # use embedded_graphics::color::Color;
     ///
-    /// let text = Font6x8::render_str("Hello world", 1);
+    /// let text = Font6x8::render_str("Hello world", Color::new(1));
     /// let moved = text.translate(Coord::new(25, 30));
     ///
     /// assert_eq!(text.pos, Coord::new(0, 0));
@@ -173,9 +175,9 @@ impl<'a, C> Transform for Font6x12<'a, C>
     /// # use embedded_graphics::fonts::{ Font, Font6x12 };
     /// # use embedded_graphics::transform::Transform;
     /// # use embedded_graphics::coord::Coord;
-    ///
+    /// # use embedded_graphics::color::Color;
     /// // 8px x 1px test image
-    /// let mut text = Font6x12::render_str("Hello world", 1);
+    /// let mut text = Font6x12::render_str("Hello world", Color::new(1));
     /// text.translate_mut(Coord::new(25, 30));
     ///
     /// assert_eq!(text.pos, Coord::new(25, 30));

--- a/embedded-graphics/src/fonts/font6x12.rs
+++ b/embedded-graphics/src/fonts/font6x12.rs
@@ -14,7 +14,9 @@ const CHARS_PER_ROW: u32 = FONT_IMAGE_WIDTH / CHAR_WIDTH;
 
 /// Container struct to hold a positioned piece of text
 #[derive(Debug, Clone, Copy)]
-pub struct Font6x12<'a> {
+pub struct Font6x12<'a, C: 'a> 
+    where C: Clone + Copy + PartialEq
+{
     /// Top left corner of the text
     pub pos: Coord,
 
@@ -22,11 +24,14 @@ pub struct Font6x12<'a> {
     text: &'a str,
 
     /// Fill Color of font
-    color: u8,
+    color: Color<C>,
 }
 
-impl<'a> Font<'a> for Font6x12<'a> {
-    fn render_str(text: &'a str, color: u8) -> Font6x12<'a> {
+impl<'a, C> Font<'a> for Font6x12<'a, C> 
+    where C: Clone + Copy + PartialEq
+{
+    type C = C;
+    fn render_str(text: &'a str, color: Color<C>) -> Font6x12<'a, C> {
         Self {
             pos: Coord::new(0, 0),
             text,
@@ -36,19 +41,23 @@ impl<'a> Font<'a> for Font6x12<'a> {
 }
 
 #[derive(Debug, Clone, Copy)]
-pub struct Font6x12Iterator<'a> {
+pub struct Font6x12Iterator<'a, C: 'a> 
+    where C: Clone + Copy + PartialEq
+{
     char_walk_x: u32,
     char_walk_y: u32,
     current_char: Option<char>,
     idx: usize,
     pos: Coord,
     text: &'a str,
-    color: u8,
+    color: Color<C>,
 }
 
-impl<'a> IntoIterator for &'a Font6x12<'a> {
-    type IntoIter = Font6x12Iterator<'a>;
-    type Item = Pixel;
+impl<'a, C> IntoIterator for &'a Font6x12<'a, C> 
+    where C: Clone + Copy + PartialEq
+{
+    type IntoIter = Font6x12Iterator<'a, C>;
+    type Item = Pixel<C>;
 
     fn into_iter(self) -> Self::IntoIter {
         Font6x12Iterator {
@@ -63,8 +72,10 @@ impl<'a> IntoIterator for &'a Font6x12<'a> {
     }
 }
 
-impl<'a> Iterator for Font6x12Iterator<'a> {
-    type Item = Pixel;
+impl<'a, C> Iterator for Font6x12Iterator<'a, C> 
+    where C: Clone + Copy + PartialEq
+{
+    type Item = Pixel<C>;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.pos[0] + ((self.text.len() as i32 * CHAR_WIDTH as i32)) < 0
@@ -97,12 +108,6 @@ impl<'a> Iterator for Font6x12Iterator<'a> {
                 let bitmap_byte = bitmap_bit_index / 8;
                 let bitmap_bit = 7 - (bitmap_bit_index % 8);
 
-                let color = if (FONT_IMAGE[bitmap_byte as usize] >> bitmap_bit) & 1 == 1 {
-                    self.color
-                } else {
-                    0 // black
-                };
-
                 self.char_walk_x += 1;
 
                 if self.char_walk_x >= CHAR_WIDTH {
@@ -122,7 +127,9 @@ impl<'a> Iterator for Font6x12Iterator<'a> {
                 let y = self.pos[1] + self.char_walk_y as i32;
 
                 if x >= 0 && y >= 0 {
-                    break Some((Coord::new(x, y).to_unsigned(), color));
+                    if (FONT_IMAGE[bitmap_byte as usize] >> bitmap_bit) & 1 == 1 {
+                        break Some((Coord::new(x, y).to_unsigned(), self.color))
+                    }
                 }
             };
 
@@ -133,9 +140,12 @@ impl<'a> Iterator for Font6x12Iterator<'a> {
     }
 }
 
-impl<'a> Drawable for Font6x12<'a> {}
+impl<'a, C> Drawable for Font6x12<'a, C> 
+    where C: Clone + Copy + PartialEq {}
 
-impl<'a> Transform for Font6x12<'a> {
+impl<'a, C> Transform for Font6x12<'a, C> 
+    where C: Clone + Copy + PartialEq
+{
     /// Translate the font origin from its current position to a new position by (x, y) pixels,
     /// returning a new `Font6x8`. For a mutating transform, see `translate_mut`.
     ///
@@ -183,7 +193,7 @@ mod tests {
 
     #[test]
     fn off_screen_text_does_not_infinite_loop() {
-        let text = Font6x12::render_str("Hello World!", 1).translate(Coord::new(5, -20));
+        let text = Font6x12::render_str("Hello World!", Color::new(1)).translate(Coord::new(5, -20));
         let mut it = text.into_iter();
 
         assert_eq!(it.next(), None);

--- a/embedded-graphics/src/fonts/font6x8.rs
+++ b/embedded-graphics/src/fonts/font6x8.rs
@@ -15,7 +15,7 @@ const CHARS_PER_ROW: u32 = FONT_IMAGE_WIDTH / CHAR_WIDTH;
 /// Container struct to hold a positioned piece of text
 #[derive(Debug, Clone, Copy)]
 pub struct Font6x8<'a, C: 'a> 
-    where C: Clone + Copy
+    where C: Clone + Copy + PartialEq
 {
     /// Top left corner of the text
     pub pos: Coord,
@@ -28,7 +28,7 @@ pub struct Font6x8<'a, C: 'a>
 }
 
 impl<'a, C> Font<'a> for Font6x8<'a, C> 
-    where C: Clone + Copy
+    where C: Clone + Copy + PartialEq
 {
     type C = C;
     fn render_str(text: &'a str, color: Color<C>) -> Font6x8<'a, C> {
@@ -42,7 +42,7 @@ impl<'a, C> Font<'a> for Font6x8<'a, C>
 
 #[derive(Debug, Clone, Copy)]
 pub struct Font6x8Iterator<'a, C: 'a> 
-    where C: Clone + Copy
+    where C: Clone + Copy + PartialEq
 {
     char_walk_x: u32,
     char_walk_y: u32,
@@ -54,7 +54,7 @@ pub struct Font6x8Iterator<'a, C: 'a>
 }
 
 impl<'a, C> IntoIterator for &'a Font6x8<'a, C> 
-    where C: Clone + Copy
+    where C: Clone + Copy + PartialEq
 {
     type IntoIter = Font6x8Iterator<'a, C>;
     type Item = Pixel<C>;
@@ -73,7 +73,7 @@ impl<'a, C> IntoIterator for &'a Font6x8<'a, C>
 }
 
 impl<'a, C> Iterator for Font6x8Iterator<'a, C> 
-    where C: Clone + Copy
+    where C: Clone + Copy + PartialEq
 {
     type Item = Pixel<C>;
 
@@ -130,10 +130,6 @@ impl<'a, C> Iterator for Font6x8Iterator<'a, C>
                     if (FONT_IMAGE[bitmap_byte as usize] >> bitmap_bit) & 1 == 1 {
                         break Some((Coord::new(x, y).to_unsigned(), self.color))
                     }
-                    // TODO
-                    // else {
-                    //     break Some((Coord::new(x, y).to_unsigned(), 0))
-                    // }
                 }
             };
 
@@ -145,10 +141,10 @@ impl<'a, C> Iterator for Font6x8Iterator<'a, C>
 }
 
 impl<'a, C> Drawable for Font6x8<'a, C> 
-    where C: Clone + Copy {}
+    where C: Clone + Copy + PartialEq {}
 
 impl<'a, C> Transform for Font6x8<'a, C> 
-    where C: Clone + Copy
+    where C: Clone + Copy + PartialEq
 {
     /// Translate the image from its current position to a new position by (x, y) pixels, returning
     /// a new `Font6x8`. For a mutating transform, see `translate_mut`.
@@ -200,6 +196,6 @@ mod tests {
         let text = Font6x8::render_str("Hello World!", Color::new(1)).translate(Coord::new(5, -10));
         let mut it = text.into_iter();
         // TODO FIX
-        // assert_eq!(it.next(), None);
+        assert_eq!(it.next(), None);
     }
 }

--- a/embedded-graphics/src/fonts/font6x8.rs
+++ b/embedded-graphics/src/fonts/font6x8.rs
@@ -14,7 +14,9 @@ const CHARS_PER_ROW: u32 = FONT_IMAGE_WIDTH / CHAR_WIDTH;
 
 /// Container struct to hold a positioned piece of text
 #[derive(Debug, Clone, Copy)]
-pub struct Font6x8<'a> {
+pub struct Font6x8<'a, C: 'a> 
+    where C: Clone + Copy
+{
     /// Top left corner of the text
     pub pos: Coord,
 
@@ -22,11 +24,14 @@ pub struct Font6x8<'a> {
     text: &'a str,
 
     /// Fill Color of font
-    color: u8,
+    color: Color<C>,
 }
 
-impl<'a> Font<'a> for Font6x8<'a> {
-    fn render_str(text: &'a str, color: u8) -> Font6x8<'a> {
+impl<'a, C> Font<'a> for Font6x8<'a, C> 
+    where C: Clone + Copy
+{
+    type C = C;
+    fn render_str(text: &'a str, color: Color<C>) -> Font6x8<'a, C> {
         Self {
             pos: Coord::new(0, 0),
             text,
@@ -36,19 +41,23 @@ impl<'a> Font<'a> for Font6x8<'a> {
 }
 
 #[derive(Debug, Clone, Copy)]
-pub struct Font6x8Iterator<'a> {
+pub struct Font6x8Iterator<'a, C: 'a> 
+    where C: Clone + Copy
+{
     char_walk_x: u32,
     char_walk_y: u32,
     current_char: Option<char>,
     idx: usize,
     pos: Coord,
     text: &'a str,
-    color: u8,
+    color: Color<C>,
 }
 
-impl<'a> IntoIterator for &'a Font6x8<'a> {
-    type IntoIter = Font6x8Iterator<'a>;
-    type Item = Pixel;
+impl<'a, C> IntoIterator for &'a Font6x8<'a, C> 
+    where C: Clone + Copy
+{
+    type IntoIter = Font6x8Iterator<'a, C>;
+    type Item = Pixel<C>;
 
     fn into_iter(self) -> Self::IntoIter {
         Font6x8Iterator {
@@ -63,8 +72,10 @@ impl<'a> IntoIterator for &'a Font6x8<'a> {
     }
 }
 
-impl<'a> Iterator for Font6x8Iterator<'a> {
-    type Item = Pixel;
+impl<'a, C> Iterator for Font6x8Iterator<'a, C> 
+    where C: Clone + Copy
+{
+    type Item = Pixel<C>;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.pos[0] + ((self.text.len() as i32 * CHAR_WIDTH as i32)) < 0
@@ -97,12 +108,6 @@ impl<'a> Iterator for Font6x8Iterator<'a> {
                 let bitmap_byte = bitmap_bit_index / 8;
                 let bitmap_bit = 7 - (bitmap_bit_index % 8);
 
-                let color = if (FONT_IMAGE[bitmap_byte as usize] >> bitmap_bit) & 1 == 1 {
-                    self.color
-                } else {
-                    0 // black
-                };
-
                 self.char_walk_x += 1;
 
                 if self.char_walk_x >= CHAR_WIDTH {
@@ -122,7 +127,13 @@ impl<'a> Iterator for Font6x8Iterator<'a> {
                 let y = self.pos[1] + self.char_walk_y as i32;
 
                 if x >= 0 && y >= 0 {
-                    break Some((Coord::new(x, y).to_unsigned(), color));
+                    if (FONT_IMAGE[bitmap_byte as usize] >> bitmap_bit) & 1 == 1 {
+                        break Some((Coord::new(x, y).to_unsigned(), self.color))
+                    }
+                    // TODO
+                    // else {
+                    //     break Some((Coord::new(x, y).to_unsigned(), 0))
+                    // }
                 }
             };
 
@@ -133,9 +144,12 @@ impl<'a> Iterator for Font6x8Iterator<'a> {
     }
 }
 
-impl<'a> Drawable for Font6x8<'a> {}
+impl<'a, C> Drawable for Font6x8<'a, C> 
+    where C: Clone + Copy {}
 
-impl<'a> Transform for Font6x8<'a> {
+impl<'a, C> Transform for Font6x8<'a, C> 
+    where C: Clone + Copy
+{
     /// Translate the image from its current position to a new position by (x, y) pixels, returning
     /// a new `Font6x8`. For a mutating transform, see `translate_mut`.
     ///
@@ -183,9 +197,9 @@ mod tests {
 
     #[test]
     fn off_screen_text_does_not_infinite_loop() {
-        let text = Font6x8::render_str("Hello World!", 1).translate(Coord::new(5, -10));
+        let text = Font6x8::render_str("Hello World!", Color::new(1)).translate(Coord::new(5, -10));
         let mut it = text.into_iter();
-
-        assert_eq!(it.next(), None);
+        // TODO FIX
+        // assert_eq!(it.next(), None);
     }
 }

--- a/embedded-graphics/src/fonts/font6x8.rs
+++ b/embedded-graphics/src/fonts/font6x8.rs
@@ -4,6 +4,7 @@ use super::super::drawable::*;
 use super::super::transform::*;
 use super::Font;
 use coord::{Coord, ToUnsigned};
+use color::Color;
 
 const FONT_IMAGE: &[u8] = include_bytes!("../../data/font6x8_1bpp.raw");
 const CHAR_HEIGHT: u32 = 8;
@@ -153,9 +154,10 @@ impl<'a, C> Transform for Font6x8<'a, C>
     /// # use embedded_graphics::fonts::{ Font, Font6x8 };
     /// # use embedded_graphics::transform::Transform;
     /// # use embedded_graphics::coord::Coord;
+    /// # use embedded_graphics::color::Color;
     ///
     /// // 8px x 1px test image
-    /// let text = Font6x8::render_str("Hello world", 1);
+    /// let text = Font6x8::render_str("Hello world", Color::new(1));
     /// let moved = text.translate(Coord::new(25, 30));
     ///
     /// assert_eq!(text.pos, Coord::new(0, 0));
@@ -174,8 +176,9 @@ impl<'a, C> Transform for Font6x8<'a, C>
     /// # use embedded_graphics::fonts::{ Font, Font6x8 };
     /// # use embedded_graphics::transform::Transform;
     /// # use embedded_graphics::coord::Coord;
+    /// # use embedded_graphics::color::Color;
     ///
-    /// let mut text = Font6x8::render_str("Hello world", 1);
+    /// let mut text = Font6x8::render_str("Hello world", Color::new(1));
     /// text.translate_mut(Coord::new(25, 30));
     ///
     /// assert_eq!(text.pos, Coord::new(25, 30));

--- a/embedded-graphics/src/fonts/font6x8.rs
+++ b/embedded-graphics/src/fonts/font6x8.rs
@@ -198,7 +198,6 @@ mod tests {
     fn off_screen_text_does_not_infinite_loop() {
         let text = Font6x8::render_str("Hello World!", Color::new(1)).translate(Coord::new(5, -10));
         let mut it = text.into_iter();
-        // TODO FIX
         assert_eq!(it.next(), None);
     }
 }

--- a/embedded-graphics/src/fonts/font8x16.rs
+++ b/embedded-graphics/src/fonts/font8x16.rs
@@ -4,6 +4,7 @@ use super::super::drawable::*;
 use super::super::transform::*;
 use super::Font;
 use coord::{Coord, ToUnsigned};
+use color::Color;
 
 const FONT_IMAGE: &[u8] = include_bytes!("../../data/font8x16_1bpp.raw");
 const CHAR_HEIGHT: u32 = 16;
@@ -150,9 +151,10 @@ impl<'a, C> Transform for Font8x16<'a, C> where C: Clone + Copy + PartialEq {
     /// # use embedded_graphics::fonts::{ Font, Font8x16 };
     /// # use embedded_graphics::transform::Transform;
     /// # use embedded_graphics::coord::Coord;
+    /// # use embedded_graphics::color::Color;
     ///
     /// // 8px x 1px test image
-    /// let text = Font8x16::render_str("Hello world", 1);
+    /// let text = Font8x16::render_str("Hello world", Color::new(1));
     /// let moved = text.translate(Coord::new(25, 30));
     ///
     /// assert_eq!(text.pos, Coord::new(0, 0));
@@ -171,8 +173,9 @@ impl<'a, C> Transform for Font8x16<'a, C> where C: Clone + Copy + PartialEq {
     /// # use embedded_graphics::fonts::{ Font, Font6x8 };
     /// # use embedded_graphics::transform::Transform;
     /// # use embedded_graphics::coord::Coord;
+    /// # use embedded_graphics::color::Color;
     ///
-    /// let mut text = Font6x8::render_str("Hello world", 1);
+    /// let mut text = Font6x8::render_str("Hello world", Color::new(1));
     /// text.translate_mut(Coord::new(25, 30));
     ///
     /// assert_eq!(text.pos, Coord::new(25, 30));

--- a/embedded-graphics/src/fonts/font8x16.rs
+++ b/embedded-graphics/src/fonts/font8x16.rs
@@ -14,7 +14,9 @@ const CHARS_PER_ROW: u32 = FONT_IMAGE_WIDTH / CHAR_WIDTH;
 
 /// Container struct to hold a positioned piece of text
 #[derive(Debug, Clone, Copy)]
-pub struct Font8x16<'a> {
+pub struct Font8x16<'a, C: 'a> 
+    where C: Clone + Copy + PartialEq
+{
     /// Top left corner of the text
     pub pos: Coord,
 
@@ -22,11 +24,14 @@ pub struct Font8x16<'a> {
     text: &'a str,
 
     /// Fill Color of font
-    color: u8,
+    color: Color<C>,
 }
 
-impl<'a> Font<'a> for Font8x16<'a> {
-    fn render_str(text: &'a str, color: u8) -> Font8x16<'a> {
+impl<'a, C> Font<'a> for Font8x16<'a, C> 
+    where C: Clone + Copy + PartialEq
+{
+    type C = C;
+    fn render_str(text: &'a str, color: Color<C>) -> Font8x16<'a, C> {
         Self {
             pos: Coord::new(0, 0),
             text,
@@ -36,19 +41,23 @@ impl<'a> Font<'a> for Font8x16<'a> {
 }
 
 #[derive(Debug, Clone, Copy)]
-pub struct Font8x16Iterator<'a> {
+pub struct Font8x16Iterator<'a, C: 'a> 
+    where C: Clone + Copy + PartialEq
+{
     char_walk_x: u32,
     char_walk_y: u32,
     current_char: Option<char>,
     idx: usize,
     pos: Coord,
     text: &'a str,
-    color: u8,
+    color: Color<C>,
 }
 
-impl<'a> IntoIterator for &'a Font8x16<'a> {
-    type IntoIter = Font8x16Iterator<'a>;
-    type Item = Pixel;
+impl<'a, C> IntoIterator for &'a Font8x16<'a, C> 
+    where C: Clone + Copy + PartialEq
+{
+    type IntoIter = Font8x16Iterator<'a, C>;
+    type Item = Pixel<C>;
 
     fn into_iter(self) -> Self::IntoIter {
         Font8x16Iterator {
@@ -63,8 +72,10 @@ impl<'a> IntoIterator for &'a Font8x16<'a> {
     }
 }
 
-impl<'a> Iterator for Font8x16Iterator<'a> {
-    type Item = Pixel;
+impl<'a, C> Iterator for Font8x16Iterator<'a, C>
+    where C: Clone + Copy + PartialEq
+{
+    type Item = Pixel<C>;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.pos[0] + ((self.text.len() as i32 * CHAR_WIDTH as i32)) < 0
@@ -97,12 +108,6 @@ impl<'a> Iterator for Font8x16Iterator<'a> {
                 let bitmap_byte = bitmap_bit_index / 8;
                 let bitmap_bit = 7 - (bitmap_bit_index % 8);
 
-                let color = if (FONT_IMAGE[bitmap_byte as usize] >> bitmap_bit) & 1 == 1 {
-                    self.color
-                } else {
-                    0 // black
-                };
-
                 self.char_walk_x += 1;
 
                 if self.char_walk_x >= CHAR_WIDTH {
@@ -122,7 +127,9 @@ impl<'a> Iterator for Font8x16Iterator<'a> {
                 let y = self.pos[1] + self.char_walk_y as i32;
 
                 if x >= 0 && y >= 0 {
-                    break Some((Coord::new(x, y).to_unsigned(), color));
+                    if (FONT_IMAGE[bitmap_byte as usize] >> bitmap_bit) & 1 == 1 {
+                        break Some((Coord::new(x, y).to_unsigned(), self.color))
+                    }
                 }
             };
 
@@ -133,9 +140,9 @@ impl<'a> Iterator for Font8x16Iterator<'a> {
     }
 }
 
-impl<'a> Drawable for Font8x16<'a> {}
+impl<'a, C> Drawable for Font8x16<'a, C> where C: Clone + Copy + PartialEq {}
 
-impl<'a> Transform for Font8x16<'a> {
+impl<'a, C> Transform for Font8x16<'a, C> where C: Clone + Copy + PartialEq {
     /// Translate the image from its current position to a new position by (x, y) pixels, returning
     /// a new `Font8x16`. For a mutating transform, see `translate_mut`.
     ///
@@ -183,7 +190,7 @@ mod tests {
 
     #[test]
     fn off_screen_text_does_not_infinite_loop() {
-        let text = Font8x16::render_str("Hello World!", 1).translate(Coord::new(5, -20));
+        let text = Font8x16::render_str("Hello World!", Color::new(1)).translate(Coord::new(5, -20));
         let mut it = text.into_iter();
 
         assert_eq!(it.next(), None);

--- a/embedded-graphics/src/fonts/mod.rs
+++ b/embedded-graphics/src/fonts/mod.rs
@@ -10,7 +10,7 @@ pub use self::font6x12::Font6x12;
 pub use self::font8x16::Font8x16;
 pub use self::font6x8::Font6x8;
 
-use drawable::Color;
+use color::Color;
 
 /// Common methods for all fonts
 pub trait Font<'a> {
@@ -23,12 +23,15 @@ pub trait Font<'a> {
     /// # use embedded_graphics::fonts::{Font, Font6x8};
     /// # use embedded_graphics::transform::Transform;
     /// # use embedded_graphics::drawable::Pixel;
+    /// # use embedded_graphics::color::Color;
+    /// #
     /// #
     /// # struct Display {}
     /// # impl Display {
-    /// #     pub fn draw<T>(&self, item_pixels: T) -> Result<(), ()>
+    /// #     pub fn draw<T, C>(&self, item_pixels: T) -> Result<(), ()>
     /// #     where
-    /// #         T: Iterator<Item = Pixel>,
+    /// #         T: Iterator<Item = Pixel<C>>,
+    /// #         C: Clone + Copy + PartialEq,
     /// #     {
     /// #         Ok(())
     /// #     }
@@ -37,7 +40,7 @@ pub trait Font<'a> {
     /// fn main() {
     ///     let disp = Display {};
     ///     // Render a string with a 8bit color
-    ///     let text = Font6x8::render_str("Hello world", 1);  
+    ///     let text = Font6x8::render_str("Hello world", Color::new(1));  
     ///
     ///     disp.draw(text.into_iter());
     /// }

--- a/embedded-graphics/src/fonts/mod.rs
+++ b/embedded-graphics/src/fonts/mod.rs
@@ -1,13 +1,13 @@
 //! Pixel based fonts
 
-// mod font12x16;
-// mod font6x12;
-// mod font8x16;
+mod font12x16;
+mod font6x12;
+mod font8x16;
 mod font6x8;
 
-// pub use self::font12x16::Font12x16;
-// pub use self::font6x12::Font6x12;
-// pub use self::font8x16::Font8x16;
+pub use self::font12x16::Font12x16;
+pub use self::font6x12::Font6x12;
+pub use self::font8x16::Font8x16;
 pub use self::font6x8::Font6x8;
 
 use drawable::Color;
@@ -15,7 +15,7 @@ use drawable::Color;
 /// Common methods for all fonts
 pub trait Font<'a> {
     /// Data type to store color
-    type C : Clone + Copy;
+    type C : Clone + Copy + PartialEq;
 
     /// Render a string in the implementing font's typeface.
     ///

--- a/embedded-graphics/src/fonts/mod.rs
+++ b/embedded-graphics/src/fonts/mod.rs
@@ -1,17 +1,22 @@
 //! Pixel based fonts
 
-mod font12x16;
-mod font6x12;
+// mod font12x16;
+// mod font6x12;
+// mod font8x16;
 mod font6x8;
-mod font8x16;
 
-pub use self::font12x16::Font12x16;
-pub use self::font6x12::Font6x12;
+// pub use self::font12x16::Font12x16;
+// pub use self::font6x12::Font6x12;
+// pub use self::font8x16::Font8x16;
 pub use self::font6x8::Font6x8;
-pub use self::font8x16::Font8x16;
+
+use drawable::Color;
 
 /// Common methods for all fonts
 pub trait Font<'a> {
+    /// Data type to store color
+    type C : Clone + Copy;
+
     /// Render a string in the implementing font's typeface.
     ///
     /// ```rust
@@ -37,5 +42,5 @@ pub trait Font<'a> {
     ///     disp.draw(text.into_iter());
     /// }
     /// ```
-    fn render_str(chars: &'a str, color: u8) -> Self;
+    fn render_str(chars: &'a str, color: Color<Self::C>) -> Self;
 }

--- a/embedded-graphics/src/image/image1bpp.rs
+++ b/embedded-graphics/src/image/image1bpp.rs
@@ -41,7 +41,7 @@ impl<'a> Image<'a> for Image1BPP<'a> {
 }
 
 impl<'a> IntoIterator for &'a Image1BPP<'a> {
-    type Item = Pixel;
+    type Item = Pixel<u8>;
     type IntoIter = Image1BPPIterator<'a>;
 
     // NOTE: `self` is a reference already, no copies here!
@@ -63,7 +63,7 @@ pub struct Image1BPPIterator<'a> {
 
 /// Iterator over every pixel in the source image
 impl<'a> Iterator for Image1BPPIterator<'a> {
-    type Item = Pixel;
+    type Item = Pixel<u8>;
 
     fn next(&mut self) -> Option<Self::Item> {
         // If we're outside the upper left screen bounds, bail
@@ -106,7 +106,7 @@ impl<'a> Iterator for Image1BPPIterator<'a> {
             }
 
             if current_pixel[0] >= 0 && current_pixel[1] >= 0 {
-                break (current_pixel.to_unsigned(), bit_value);
+                break (current_pixel.to_unsigned(), Color::new(bit_value));
             }
         };
 

--- a/embedded-graphics/src/image/image1bpp.rs
+++ b/embedded-graphics/src/image/image1bpp.rs
@@ -12,6 +12,7 @@ use super::super::drawable::*;
 use super::super::transform::*;
 use super::Image;
 use coord::{Coord, ToUnsigned};
+use color::Color;
 
 /// 1 bit per pixel image
 #[derive(Debug)]

--- a/embedded-graphics/src/image/image8bpp.rs
+++ b/embedded-graphics/src/image/image8bpp.rs
@@ -44,7 +44,7 @@ impl<'a> Image<'a> for Image8BPP<'a> {
 }
 
 impl<'a> IntoIterator for &'a Image8BPP<'a> {
-    type Item = Pixel;
+    type Item = Pixel<u8>;
     type IntoIter = Image8BPPIterator<'a>;
 
     // NOTE: `self` is a reference already, no copies here!
@@ -65,7 +65,7 @@ pub struct Image8BPPIterator<'a> {
 }
 
 impl<'a> Iterator for Image8BPPIterator<'a> {
-    type Item = Pixel;
+    type Item = Pixel<u8>;
 
     fn next(&mut self) -> Option<Self::Item> {
         let current_pixel = loop {
@@ -94,7 +94,7 @@ impl<'a> Iterator for Image8BPPIterator<'a> {
             }
 
             if current_pixel[0] >= 0 && current_pixel[1] >= 0 {
-                break (current_pixel.to_unsigned(), bit_value);
+                break (current_pixel.to_unsigned(), Color::new(bit_value));
             }
         };
 
@@ -161,10 +161,10 @@ mod tests {
         ).translate(Coord::new(-1, -1));
         let mut it = image.into_iter();
 
-        assert_eq!(it.next(), Some((UnsignedCoord::new(0, 0), 0xcc)));
-        assert_eq!(it.next(), Some((UnsignedCoord::new(1, 0), 0x00)));
-        assert_eq!(it.next(), Some((UnsignedCoord::new(0, 1), 0x00)));
-        assert_eq!(it.next(), Some((UnsignedCoord::new(1, 1), 0xaa)));
+        assert_eq!(it.next(), Some((UnsignedCoord::new(0, 0), Color::new(0xcc))));
+        assert_eq!(it.next(), Some((UnsignedCoord::new(1, 0), Color::new(0x00))));
+        assert_eq!(it.next(), Some((UnsignedCoord::new(0, 1), Color::new(0x00))));
+        assert_eq!(it.next(), Some((UnsignedCoord::new(1, 1), Color::new(0xaa))));
 
         assert_eq!(it.next(), None);
     }

--- a/embedded-graphics/src/image/image8bpp.rs
+++ b/embedded-graphics/src/image/image8bpp.rs
@@ -13,6 +13,7 @@ use super::super::drawable::*;
 use super::super::transform::*;
 use super::Image;
 use coord::{Coord, ToUnsigned};
+use color::Color;
 
 /// 8 bit per pixel image
 #[derive(Debug)]

--- a/embedded-graphics/src/lib.rs
+++ b/embedded-graphics/src/lib.rs
@@ -48,7 +48,7 @@ pub mod drawable;
 pub mod fonts;
 // pub mod image;
 pub mod prelude;
-// pub mod primitives;
+pub mod primitives;
 pub mod transform;
 pub mod unsignedcoord;
 

--- a/embedded-graphics/src/lib.rs
+++ b/embedded-graphics/src/lib.rs
@@ -47,6 +47,7 @@ pub mod coord;
 pub mod drawable;
 pub mod fonts;
 pub mod image;
+pub mod color;
 pub mod prelude;
 pub mod primitives;
 pub mod transform;

--- a/embedded-graphics/src/lib.rs
+++ b/embedded-graphics/src/lib.rs
@@ -46,7 +46,7 @@ extern crate nalgebra;
 pub mod coord;
 pub mod drawable;
 pub mod fonts;
-// pub mod image;
+pub mod image;
 pub mod prelude;
 pub mod primitives;
 pub mod transform;

--- a/embedded-graphics/src/lib.rs
+++ b/embedded-graphics/src/lib.rs
@@ -55,7 +55,7 @@ pub mod unsignedcoord;
 /// The main trait of this crate. All graphics objects must implement it.
 pub trait Drawing {
     /// Data type to store color
-    type C : Clone + Copy;
+    type C : Clone + Copy + PartialEq;
     /// Draw an object from an iterator over its pixels
     fn draw<T>(&mut self, item_pixels: T)
     where

--- a/embedded-graphics/src/lib.rs
+++ b/embedded-graphics/src/lib.rs
@@ -46,16 +46,20 @@ extern crate nalgebra;
 pub mod coord;
 pub mod drawable;
 pub mod fonts;
-pub mod image;
+// pub mod image;
 pub mod prelude;
-pub mod primitives;
+// pub mod primitives;
 pub mod transform;
 pub mod unsignedcoord;
 
+use drawable::Color;
+
 /// The main trait of this crate. All graphics objects must implement it.
 pub trait Drawing {
+    /// Data type to store color
+    type C : Clone + Copy;
     /// Draw an object from an iterator over its pixels
     fn draw<T>(&mut self, item_pixels: T)
     where
-        T: Iterator<Item = drawable::Pixel>;
+        T: Iterator<Item = drawable::Pixel<Color<Self::C>>>;
 }

--- a/embedded-graphics/src/lib.rs
+++ b/embedded-graphics/src/lib.rs
@@ -52,8 +52,6 @@ pub mod prelude;
 pub mod transform;
 pub mod unsignedcoord;
 
-use drawable::Color;
-
 /// The main trait of this crate. All graphics objects must implement it.
 pub trait Drawing {
     /// Data type to store color
@@ -61,5 +59,5 @@ pub trait Drawing {
     /// Draw an object from an iterator over its pixels
     fn draw<T>(&mut self, item_pixels: T)
     where
-        T: Iterator<Item = drawable::Pixel<Color<Self::C>>>;
+        T: Iterator<Item = drawable::Pixel<Self::C>>;
 }

--- a/embedded-graphics/src/prelude.rs
+++ b/embedded-graphics/src/prelude.rs
@@ -2,7 +2,8 @@
 
 pub use super::coord::{Coord, ToUnsigned};
 pub use super::fonts::Font;
-pub use super::image::Image;
+// pub use super::image::Image;
 pub use super::transform::Transform;
 pub use super::unsignedcoord::UnsignedCoord;
 pub use super::Drawing;
+pub use super::drawable::Color;

--- a/embedded-graphics/src/prelude.rs
+++ b/embedded-graphics/src/prelude.rs
@@ -6,4 +6,4 @@ pub use super::fonts::Font;
 pub use super::transform::Transform;
 pub use super::unsignedcoord::UnsignedCoord;
 pub use super::Drawing;
-pub use super::drawable::Color;
+pub use super::color::Color;

--- a/embedded-graphics/src/primitives/circle.rs
+++ b/embedded-graphics/src/primitives/circle.rs
@@ -3,6 +3,7 @@
 use super::super::drawable::*;
 use super::super::transform::*;
 use coord::{Coord, ToUnsigned};
+use color::Color;
 
 // TODO: Impl Default so people can leave the color bit out
 /// Circle primitive
@@ -133,8 +134,9 @@ impl<C> Transform for Circle<C> where C: Clone + Copy + PartialEq {
     /// # use embedded_graphics::primitives::Circle;
     /// # use embedded_graphics::transform::Transform;
     /// # use embedded_graphics::coord::Coord;
+    /// # use embedded_graphics::color::Color;
     ///
-    /// let circle = Circle::new(Coord::new(5, 10), 10, 1);
+    /// let circle = Circle::new(Coord::new(5, 10), 10, Color::new(1));
     /// let moved = circle.translate(Coord::new(10, 10));
     ///
     /// assert_eq!(moved.center, Coord::new(15, 20));
@@ -152,8 +154,9 @@ impl<C> Transform for Circle<C> where C: Clone + Copy + PartialEq {
     /// # use embedded_graphics::primitives::Circle;
     /// # use embedded_graphics::transform::Transform;
     /// # use embedded_graphics::coord::Coord;
+    /// # use embedded_graphics::color::Color;
     ///
-    /// let mut circle = Circle::new(Coord::new(5, 10), 10, 1);
+    /// let mut circle = Circle::new(Coord::new(5, 10), 10, Color::new(1));
     /// circle.translate_mut(Coord::new(10, 10));
     ///
     /// assert_eq!(circle.center, Coord::new(15, 20));

--- a/embedded-graphics/src/primitives/circle.rs
+++ b/embedded-graphics/src/primitives/circle.rs
@@ -7,7 +7,9 @@ use coord::{Coord, ToUnsigned};
 // TODO: Impl Default so people can leave the color bit out
 /// Circle primitive
 #[derive(Debug, Copy, Clone)]
-pub struct Circle {
+pub struct Circle<C>
+    where C: Clone + Copy + PartialEq
+{
     /// Center point of circle
     pub center: Coord,
 
@@ -15,12 +17,14 @@ pub struct Circle {
     pub radius: u32,
 
     /// Line colour of circle
-    pub color: Color,
+    pub color: Color<C>,
 }
 
-impl Circle {
+impl<C> Circle<C>
+    where C: Clone + Copy + PartialEq 
+{
     /// Create a new circle with center point, radius and border color
-    pub fn new(center: Coord, radius: u32, color: u8) -> Self {
+    pub fn new(center: Coord, radius: u32, color: Color<C>) -> Self {
         Circle {
             center,
             radius,
@@ -29,9 +33,11 @@ impl Circle {
     }
 }
 
-impl<'a> IntoIterator for &'a Circle {
-    type Item = Pixel;
-    type IntoIter = CircleIterator;
+impl<'a, C> IntoIterator for &'a Circle<C> 
+    where C: Clone + Copy + PartialEq
+{
+    type Item = Pixel<C>;
+    type IntoIter = CircleIterator<C>;
 
     fn into_iter(self) -> Self::IntoIter {
         CircleIterator {
@@ -50,10 +56,12 @@ impl<'a> IntoIterator for &'a Circle {
 
 /// Pixel iterator for each pixel in the circle border
 #[derive(Debug, Copy, Clone)]
-pub struct CircleIterator {
+pub struct CircleIterator<C> 
+    where C: Clone + Copy + PartialEq
+{
     center: Coord,
     radius: u32,
-    color: Color,
+    color: Color<C>,
 
     octant: u32,
     idx: u32,
@@ -62,8 +70,10 @@ pub struct CircleIterator {
     d: i32,
 }
 
-impl Iterator for CircleIterator {
-    type Item = Pixel;
+impl<C> Iterator for CircleIterator<C> 
+    where C: Clone + Copy + PartialEq
+{
+    type Item = Pixel<C>;
 
     // http://www.sunshine2k.de/coding/java/Bresenham/RasterisingLinesCircles.pdf listing 5
     fn next(&mut self) -> Option<Self::Item> {
@@ -113,9 +123,9 @@ impl Iterator for CircleIterator {
     }
 }
 
-impl Drawable for Circle {}
+impl<C> Drawable for Circle<C> where C: Clone + Copy + PartialEq {}
 
-impl Transform for Circle {
+impl<C> Transform for Circle<C> where C: Clone + Copy + PartialEq {
     /// Translate the circle center from its current position to a new position by (x, y) pixels,
     /// returning a new `Circle`. For a mutating transform, see `translate_mut`.
     ///
@@ -161,14 +171,14 @@ mod tests {
 
     #[test]
     fn it_handles_offscreen_coords() {
-        let mut circ = Circle::new(Coord::new(-10, -10), 5, 1).into_iter();
+        let mut circ = Circle::new(Coord::new(-10, -10), 5, Color::new(1)).into_iter();
 
         assert_eq!(circ.next(), None);
     }
 
     #[test]
     fn it_handles_partially_on_screen_coords() {
-        let mut circ = Circle::new(Coord::new(-5, -5), 30, 1).into_iter();
+        let mut circ = Circle::new(Coord::new(-5, -5), 30, Color::new(1)).into_iter();
 
         assert!(circ.next().is_some());
     }

--- a/embedded-graphics/src/primitives/line.rs
+++ b/embedded-graphics/src/primitives/line.rs
@@ -7,7 +7,8 @@ use coord::{Coord, ToUnsigned};
 // TODO: Impl Default so people can leave the color bit out
 /// Line primitive
 #[derive(Debug, Copy, Clone)]
-pub struct Line {
+pub struct Line<C> 
+    where C: Clone + Copy + PartialEq {
     /// Start point
     pub start: Coord,
 
@@ -15,19 +16,23 @@ pub struct Line {
     pub end: Coord,
 
     /// Line color
-    pub color: Color,
+    pub color: Color<C>,
 }
 
-impl Line {
+impl<C> Line<C> 
+    where C: Clone + Copy + PartialEq
+{
     /// Create a new line
-    pub fn new(start: Coord, end: Coord, color: u8) -> Self {
+    pub fn new(start: Coord, end: Coord, color: Color<C>) -> Self {
         Line { start, end, color }
     }
 }
 
-impl<'a> IntoIterator for &'a Line {
-    type Item = Pixel;
-    type IntoIter = LineIterator<'a>;
+impl<'a, C> IntoIterator for &'a Line<C> 
+    where C: Clone + Copy + PartialEq
+{
+    type Item = Pixel<C>;
+    type IntoIter = LineIterator<'a, C>;
 
     fn into_iter(self) -> Self::IntoIter {
         let x0 = self.start[0].max(0);
@@ -93,8 +98,10 @@ impl<'a> IntoIterator for &'a Line {
 
 /// Pixel iterator for each pixel in the line
 #[derive(Debug)]
-pub struct LineIterator<'a> {
-    line: &'a Line,
+pub struct LineIterator<'a, C: 'a> 
+    where C: Clone + Copy + PartialEq
+{
+    line: &'a Line<C>,
 
     dquick: i32,
     dslow: i32,
@@ -108,8 +115,10 @@ pub struct LineIterator<'a> {
 }
 
 // [Bresenham's line algorithm](https://en.wikipedia.org/wiki/Bresenham%27s_line_algorithm)
-impl<'a> Iterator for LineIterator<'a> {
-    type Item = Pixel;
+impl<'a, C> Iterator for LineIterator<'a, C> 
+    where C: Clone + Copy + PartialEq
+{
+    type Item = Pixel<C>;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.quick > self.end {
@@ -139,9 +148,9 @@ impl<'a> Iterator for LineIterator<'a> {
     }
 }
 
-impl Drawable for Line {}
+impl<C> Drawable for Line<C> where C: Clone + Copy + PartialEq {}
 
-impl Transform for Line {
+impl<C> Transform for Line<C> where C: Clone + Copy + PartialEq {
     /// Translate the line from its current position to a new position by (x, y) pixels, returning
     /// a new `Line`. For a mutating transform, see `translate_mut`.
     ///
@@ -191,7 +200,7 @@ mod tests {
     use unsignedcoord::UnsignedCoord;
 
     fn test_expected_line(start: Coord, end: Coord, expected: &[(u32, u32)]) {
-        let line = Line::new(start, end, 1);
+        let line = Line::new(start, end, Color::new(1));
         for (idx, (coord, _)) in line.into_iter().enumerate() {
             assert_eq!(coord, UnsignedCoord::new(expected[idx].0, expected[idx].1));
         }

--- a/embedded-graphics/src/primitives/line.rs
+++ b/embedded-graphics/src/primitives/line.rs
@@ -3,6 +3,7 @@
 use super::super::drawable::*;
 use super::super::transform::*;
 use coord::{Coord, ToUnsigned};
+use color::Color;
 
 // TODO: Impl Default so people can leave the color bit out
 /// Line primitive
@@ -158,8 +159,9 @@ impl<C> Transform for Line<C> where C: Clone + Copy + PartialEq {
     /// # use embedded_graphics::primitives::Line;
     /// # use embedded_graphics::transform::Transform;
     /// # use embedded_graphics::coord::Coord;
+    /// # use embedded_graphics::color::Color;
     ///
-    /// let line = Line::new(Coord::new(5, 10), Coord::new(15, 20), 1);
+    /// let line = Line::new(Coord::new(5, 10), Coord::new(15, 20), Color::new(1));
     /// let moved = line.translate(Coord::new(10, 10));
     ///
     /// assert_eq!(moved.start, Coord::new(15, 20));
@@ -179,8 +181,9 @@ impl<C> Transform for Line<C> where C: Clone + Copy + PartialEq {
     /// # use embedded_graphics::primitives::Line;
     /// # use embedded_graphics::transform::Transform;
     /// # use embedded_graphics::coord::Coord;
+    /// # use embedded_graphics::color::Color;
     ///
-    /// let mut line = Line::new(Coord::new(5, 10), Coord::new(15, 20), 1);
+    /// let mut line = Line::new(Coord::new(5, 10), Coord::new(15, 20), Color::new(1));
     /// line.translate_mut(Coord::new(10, 10));
     ///
     /// assert_eq!(line.start, Coord::new(15, 20));

--- a/embedded-graphics/src/primitives/rect.rs
+++ b/embedded-graphics/src/primitives/rect.rs
@@ -3,6 +3,7 @@
 use super::super::drawable::*;
 use super::super::transform::*;
 use coord::{Coord, ToUnsigned};
+use color::Color;
 
 // TODO: Impl Default so people can leave the color bit out
 /// Rectangle primitive
@@ -120,8 +121,9 @@ impl<C> Transform for Rect<C> where C: Clone + Copy + PartialEq{
     /// # use embedded_graphics::primitives::Rect;
     /// # use embedded_graphics::transform::Transform;
     /// # use embedded_graphics::coord::Coord;
+    /// # use embedded_graphics::color::Color;
     ///
-    /// let rect = Rect::new(Coord::new(5, 10), Coord::new(15, 20), 1);
+    /// let rect = Rect::new(Coord::new(5, 10), Coord::new(15, 20), Color::new(1));
     /// let moved = rect.translate(Coord::new(10, 10));
     ///
     /// assert_eq!(moved.top_left, Coord::new(15, 20));
@@ -141,8 +143,9 @@ impl<C> Transform for Rect<C> where C: Clone + Copy + PartialEq{
     /// # use embedded_graphics::primitives::Rect;
     /// # use embedded_graphics::transform::Transform;
     /// # use embedded_graphics::coord::Coord;
+    /// # use embedded_graphics::color::Color;
     ///
-    /// let mut rect = Rect::new(Coord::new(5, 10), Coord::new(15, 20), 1);
+    /// let mut rect = Rect::new(Coord::new(5, 10), Coord::new(15, 20), Color::new(1));
     /// rect.translate_mut(Coord::new(10, 10));
     ///
     /// assert_eq!(rect.top_left, Coord::new(15, 20));

--- a/embedded-graphics/src/primitives/rect.rs
+++ b/embedded-graphics/src/primitives/rect.rs
@@ -7,7 +7,9 @@ use coord::{Coord, ToUnsigned};
 // TODO: Impl Default so people can leave the color bit out
 /// Rectangle primitive
 #[derive(Debug, Clone, Copy)]
-pub struct Rect {
+pub struct Rect<C> 
+    where C: Clone + Copy + PartialEq
+{
     /// Top left point of the rect
     pub top_left: Coord,
 
@@ -15,13 +17,15 @@ pub struct Rect {
     pub bottom_right: Coord,
 
     /// Border color
-    pub color: Color,
+    pub color: Color<C>,
 }
 
-impl Rect {
+impl<C> Rect<C> 
+    where C: Clone + Copy + PartialEq
+{
     /// Create a new rectangle from the top left point to the bottom right point with a given border
     /// color
-    pub fn new(top_left: Coord, bottom_right: Coord, color: u8) -> Self {
+    pub fn new(top_left: Coord, bottom_right: Coord, color: Color<C>) -> Self {
         Rect {
             top_left,
             bottom_right,
@@ -30,9 +34,11 @@ impl Rect {
     }
 }
 
-impl<'a> IntoIterator for &'a Rect {
-    type Item = Pixel;
-    type IntoIter = RectIterator;
+impl<'a, C> IntoIterator for &'a Rect<C> 
+    where C: Clone + Copy + PartialEq
+{
+    type Item = Pixel<C>;
+    type IntoIter = RectIterator<C>;
 
     fn into_iter(self) -> Self::IntoIter {
         RectIterator {
@@ -48,17 +54,21 @@ impl<'a> IntoIterator for &'a Rect {
 
 /// Pixel iterator for each pixel in the rect border
 #[derive(Debug, Clone, Copy)]
-pub struct RectIterator {
+pub struct RectIterator<C> 
+    where C: Clone + Copy + PartialEq
+{
     top_left: Coord,
     bottom_right: Coord,
-    color: Color,
+    color: Color<C>,
     x: i32,
     y: i32,
     screen_size: Coord,
 }
 
-impl Iterator for RectIterator {
-    type Item = Pixel;
+impl<C> Iterator for RectIterator<C> 
+    where C: Clone + Copy + PartialEq
+{
+    type Item = Pixel<C>;
 
     fn next(&mut self) -> Option<Self::Item> {
         // Entire object is off the top left of the screen, so render nothing
@@ -100,9 +110,9 @@ impl Iterator for RectIterator {
     }
 }
 
-impl Drawable for Rect {}
+impl<C> Drawable for Rect<C> where C: Clone + Copy + PartialEq{}
 
-impl Transform for Rect {
+impl<C> Transform for Rect<C> where C: Clone + Copy + PartialEq{
     /// Translate the rect from its current position to a new position by (x, y) pixels, returning
     /// a new `Rect`. For a mutating transform, see `translate_mut`.
     ///
@@ -153,7 +163,7 @@ mod tests {
 
     #[test]
     fn it_can_be_translated() {
-        let rect = Rect::new(Coord::new(5, 10), Coord::new(15, 20), 1);
+        let rect = Rect::new(Coord::new(5, 10), Coord::new(15, 20), Color::new(1));
         let moved = rect.translate(Coord::new(10, 10));
 
         assert_eq!(moved.top_left, Coord::new(15, 20));
@@ -162,30 +172,28 @@ mod tests {
 
     #[test]
     fn it_draws_unfilled_rect() {
-        let mut rect = Rect::new(Coord::new(2, 2), Coord::new(4, 4), 1).into_iter();
+        let mut rect = Rect::new(Coord::new(2, 2), Coord::new(4, 4), Color::new(1)).into_iter();
 
-        assert_eq!(rect.next(), Some((UnsignedCoord::new(2, 2), 1)));
-        assert_eq!(rect.next(), Some((UnsignedCoord::new(3, 2), 1)));
-        assert_eq!(rect.next(), Some((UnsignedCoord::new(4, 2), 1)));
-
-        assert_eq!(rect.next(), Some((UnsignedCoord::new(2, 3), 1)));
-        assert_eq!(rect.next(), Some((UnsignedCoord::new(4, 3), 1)));
-
-        assert_eq!(rect.next(), Some((UnsignedCoord::new(2, 4), 1)));
-        assert_eq!(rect.next(), Some((UnsignedCoord::new(3, 4), 1)));
-        assert_eq!(rect.next(), Some((UnsignedCoord::new(4, 4), 1)));
+        assert_eq!(rect.next(), Some((UnsignedCoord::new(2, 2), Color::new(1))));
+        assert_eq!(rect.next(), Some((UnsignedCoord::new(3, 2), Color::new(1))));
+        assert_eq!(rect.next(), Some((UnsignedCoord::new(4, 2), Color::new(1))));
+        assert_eq!(rect.next(), Some((UnsignedCoord::new(2, 3), Color::new(1))));
+        assert_eq!(rect.next(), Some((UnsignedCoord::new(4, 3), Color::new(1))));
+        assert_eq!(rect.next(), Some((UnsignedCoord::new(2, 4), Color::new(1))));
+        assert_eq!(rect.next(), Some((UnsignedCoord::new(3, 4), Color::new(1))));
+        assert_eq!(rect.next(), Some((UnsignedCoord::new(4, 4), Color::new(1))));
     }
 
     #[test]
     fn it_can_be_negative() {
-        let mut rect = Rect::new(Coord::new(-2, -2), Coord::new(2, 2), 1).into_iter();
+        let mut rect = Rect::new(Coord::new(-2, -2), Coord::new(2, 2), Color::new(1)).into_iter();
 
         // TODO: Macro
         // Only the bottom right corner of the rect should be visible
-        assert_eq!(rect.next(), Some((UnsignedCoord::new(2, 0), 1)));
-        assert_eq!(rect.next(), Some((UnsignedCoord::new(2, 1), 1)));
-        assert_eq!(rect.next(), Some((UnsignedCoord::new(0, 2), 1)));
-        assert_eq!(rect.next(), Some((UnsignedCoord::new(1, 2), 1)));
-        assert_eq!(rect.next(), Some((UnsignedCoord::new(2, 2), 1)));
+        assert_eq!(rect.next(), Some((UnsignedCoord::new(2, 0), Color::new(1))));
+        assert_eq!(rect.next(), Some((UnsignedCoord::new(2, 1), Color::new(1))));
+        assert_eq!(rect.next(), Some((UnsignedCoord::new(0, 2), Color::new(1))));
+        assert_eq!(rect.next(), Some((UnsignedCoord::new(1, 2), Color::new(1))));
+        assert_eq!(rect.next(), Some((UnsignedCoord::new(2, 2), Color::new(1))));
     }
 }

--- a/embedded-graphics/tests/chaining.rs
+++ b/embedded-graphics/tests/chaining.rs
@@ -1,16 +1,20 @@
 extern crate embedded_graphics;
 
 use embedded_graphics::coord::Coord;
-use embedded_graphics::drawable::Pixel;
+use embedded_graphics::drawable::{Pixel};
 use embedded_graphics::primitives::{Circle, Rect};
 use embedded_graphics::Drawing;
+use embedded_graphics::color::Color;
 
 struct FakeDisplay {}
+type ColorType = u8;
 
 impl Drawing for FakeDisplay {
+    type C = ColorType;
+
     fn draw<T>(&mut self, _item_pixels: T)
     where
-        T: Iterator<Item = Pixel>,
+        T: Iterator<Item = Pixel<Self::C>>
     {
         // Noop
     }
@@ -20,9 +24,9 @@ impl Drawing for FakeDisplay {
 fn it_supports_chaining() {
     let mut disp = FakeDisplay {};
 
-    let chained = Rect::new(Coord::new(0, 0), Coord::new(1, 1), 1)
+    let chained = Rect::new(Coord::new(0, 0), Coord::new(1, 1), Color::new(1))
         .into_iter()
-        .chain(Circle::new(Coord::new(2, 2), 1, 1).into_iter());
+        .chain(Circle::new(Coord::new(2, 2), 1, Color::new(1)).into_iter());
 
     disp.draw(chained);
 }


### PR DESCRIPTION
This PR hopefully adresses the issues in #33. 

An implementation of these changes would look like this:

```rust
impl<DI> Drawing for GraphicsMode<DI>
where
    DI: DisplayInterface,
{
    type C = ColorType;

    fn draw<T>(&mut self, item_pixels: T)
    where
        T: Iterator<Item = drawable::Pixel<Self::C>>
    {
        for (pos, color) in item_pixels {
            self.set_pixel(pos.0, pos.1, color.value());
        }
    }
}
```

and some example usage with the new Colour struct.

```rust
display.draw(Line::new(Coord::new(0, 0), Coord::new(74, 74), Color::new(0xBA60)).into_iter());
    display.draw(Circle::new(Coord::new(64, 64), 8, Color::new(0x25E0)).into_iter());
```

TODO
- [ ] Generic Colour depth on images, currently still 8bit