### PR TITLE
Add Dimensions trait

### DIFF
--- a/embedded-graphics/src/coord.rs
+++ b/embedded-graphics/src/coord.rs
@@ -24,7 +24,7 @@ mod internal_coord {
 
         /// Clamp coordinate components to positive integer range
         pub fn clamp_positive(&self) -> Self {
-            Coord(self.0.max(0), self.1.max(0))
+            Coord::new(self.0.max(0), self.1.max(0))
         }
 
         /// Remove the sign from a coordinate
@@ -38,7 +38,7 @@ mod internal_coord {
         /// assert_eq!(coord.abs(), Coord::new(5, 10));
         /// ```
         pub fn abs(&self) -> Self {
-            Coord(self.0.abs(), self.1.abs())
+            Coord::new(self.0.abs(), self.1.abs())
         }
     }
 

--- a/embedded-graphics/src/drawable.rs
+++ b/embedded-graphics/src/drawable.rs
@@ -1,5 +1,6 @@
 //! `Drawable` trait and helpers
 
+use coord::Coord;
 use pixelcolor::PixelColor;
 use unsignedcoord::UnsignedCoord;
 
@@ -9,3 +10,19 @@ pub struct Pixel<C: PixelColor>(pub UnsignedCoord, pub C);
 
 /// Marks an object as "drawable". Must be implemented for all graphics objects
 pub trait Drawable {}
+
+/// Adds the ability to get the dimensions/position of a graphics object
+///
+/// This **should** be implemented for all builtin embedded-graphics primitives and fonts. Third party
+/// implementations do not have to implement this trait as an object may not have a known size. If
+/// the object _does_ have a known size, this trait **should** be implemented.
+pub trait Dimensions {
+    /// Get the top left corner of the bounding box for an object
+    fn top_left(&self) -> Coord;
+
+    /// Get the bottom right corner of the bounding box for an object
+    fn bottom_right(&self) -> Coord;
+
+    /// Get the width and height for an object
+    fn size(&self) -> UnsignedCoord;
+}

--- a/embedded-graphics/src/fonts/font12x16.rs
+++ b/embedded-graphics/src/fonts/font12x16.rs
@@ -58,6 +58,19 @@ mod tests {
     }
 
     #[test]
+    fn text_corners() {
+        let hello: Font12x16<TestPixelColor> =
+            Font12x16::render_str("Hello World!").translate(Coord::new(5, -20));
+        let empty: Font12x16<TestPixelColor> =
+            Font12x16::render_str("").translate(Coord::new(10, 20));
+
+        assert_eq!(hello.top_left(), Coord::new(5, -20));
+        assert_eq!(hello.bottom_right(), Coord::new(144 + 5, 16 - 20));
+        assert_eq!(empty.top_left(), Coord::new(10, 20));
+        assert_eq!(empty.bottom_right(), Coord::new(10, 20));
+    }
+
+    #[test]
     fn correct_m() {
         let mut display = Display::default();
         display.draw(

--- a/embedded-graphics/src/fonts/font12x16.rs
+++ b/embedded-graphics/src/fonts/font12x16.rs
@@ -29,6 +29,7 @@ mod tests {
     use super::*;
     use coord::Coord;
     use dev::TestPixelColor;
+    use drawable::Dimensions;
     use fonts::Font;
     use mock_display::Display;
     use style::Style;
@@ -52,8 +53,8 @@ mod tests {
         let hello: Font12x16<TestPixelColor> = Font12x16::render_str("Hello World!");
         let empty: Font12x16<TestPixelColor> = Font12x16::render_str("");
 
-        assert_eq!(hello.dimensions(), UnsignedCoord::new(144, 16));
-        assert_eq!(empty.dimensions(), UnsignedCoord::new(0, 0));
+        assert_eq!(hello.size(), UnsignedCoord::new(144, 16));
+        assert_eq!(empty.size(), UnsignedCoord::new(0, 0));
     }
 
     #[test]

--- a/embedded-graphics/src/fonts/font6x12.rs
+++ b/embedded-graphics/src/fonts/font6x12.rs
@@ -29,6 +29,7 @@ mod tests {
     use super::*;
     use coord::Coord;
     use dev::TestPixelColor;
+    use drawable::Dimensions;
     use fonts::Font;
     use mock_display::Display;
     use style::Style;
@@ -52,8 +53,8 @@ mod tests {
         let hello: Font6x12<TestPixelColor> = Font6x12::render_str("Hello World!");
         let empty: Font6x12<TestPixelColor> = Font6x12::render_str("");
 
-        assert_eq!(hello.dimensions(), UnsignedCoord::new(72, 12));
-        assert_eq!(empty.dimensions(), UnsignedCoord::new(0, 0));
+        assert_eq!(hello.size(), UnsignedCoord::new(72, 12));
+        assert_eq!(empty.size(), UnsignedCoord::new(0, 0));
     }
 
     #[test]

--- a/embedded-graphics/src/fonts/font6x12.rs
+++ b/embedded-graphics/src/fonts/font6x12.rs
@@ -58,6 +58,19 @@ mod tests {
     }
 
     #[test]
+    fn text_corners() {
+        let hello: Font6x12<TestPixelColor> =
+            Font6x12::render_str("Hello World!").translate(Coord::new(5, -20));
+        let empty: Font6x12<TestPixelColor> =
+            Font6x12::render_str("").translate(Coord::new(10, 20));
+
+        assert_eq!(hello.top_left(), Coord::new(5, -20));
+        assert_eq!(hello.bottom_right(), Coord::new(72 + 5, 12 - 20));
+        assert_eq!(empty.top_left(), Coord::new(10, 20));
+        assert_eq!(empty.bottom_right(), Coord::new(10, 20));
+    }
+
+    #[test]
     fn correct_m() {
         let mut display = Display::default();
         display.draw(

--- a/embedded-graphics/src/fonts/font6x8.rs
+++ b/embedded-graphics/src/fonts/font6x8.rs
@@ -71,6 +71,18 @@ mod tests {
     }
 
     #[test]
+    fn text_corners() {
+        let hello: Font6x8<TestPixelColor> =
+            Font6x8::render_str("Hello World!").translate(Coord::new(5, -20));
+        let empty: Font6x8<TestPixelColor> = Font6x8::render_str("").translate(Coord::new(10, 20));
+
+        assert_eq!(hello.top_left(), Coord::new(5, -20));
+        assert_eq!(hello.bottom_right(), Coord::new(72 + 5, 8 - 20));
+        assert_eq!(empty.top_left(), Coord::new(10, 20));
+        assert_eq!(empty.bottom_right(), Coord::new(10, 20));
+    }
+
+    #[test]
     fn default_style() {
         let mut display_default = Display::default();
         display_default.draw(Font6x8::render_str("Mm").into_iter());

--- a/embedded-graphics/src/fonts/font6x8.rs
+++ b/embedded-graphics/src/fonts/font6x8.rs
@@ -32,6 +32,7 @@ mod tests {
     use super::*;
     use coord::Coord;
     use dev::TestPixelColor;
+    use drawable::Dimensions;
     use fonts::Font;
     use mock_display::Display;
     use style::Style;
@@ -65,8 +66,8 @@ mod tests {
         let hello: Font6x8<TestPixelColor> = Font6x8::render_str("Hello World!");
         let empty: Font6x8<TestPixelColor> = Font6x8::render_str("");
 
-        assert_eq!(hello.dimensions(), UnsignedCoord::new(72, 8));
-        assert_eq!(empty.dimensions(), UnsignedCoord::new(0, 0));
+        assert_eq!(hello.size(), UnsignedCoord::new(72, 8));
+        assert_eq!(empty.size(), UnsignedCoord::new(0, 0));
     }
 
     #[test]

--- a/embedded-graphics/src/fonts/font8x16.rs
+++ b/embedded-graphics/src/fonts/font8x16.rs
@@ -32,6 +32,7 @@ mod tests {
     use super::*;
     use coord::Coord;
     use dev::TestPixelColor;
+    use drawable::Dimensions;
     use fonts::Font;
     use mock_display::Display;
     use style::Style;
@@ -55,8 +56,8 @@ mod tests {
         let hello: Font8x16<TestPixelColor> = Font8x16::render_str("Hello World!");
         let empty: Font8x16<TestPixelColor> = Font8x16::render_str("");
 
-        assert_eq!(hello.dimensions(), UnsignedCoord::new(96, 16));
-        assert_eq!(empty.dimensions(), UnsignedCoord::new(0, 0));
+        assert_eq!(hello.size(), UnsignedCoord::new(96, 16));
+        assert_eq!(empty.size(), UnsignedCoord::new(0, 0));
     }
 
     #[test]

--- a/embedded-graphics/src/fonts/font8x16.rs
+++ b/embedded-graphics/src/fonts/font8x16.rs
@@ -61,6 +61,19 @@ mod tests {
     }
 
     #[test]
+    fn text_corners() {
+        let hello: Font8x16<TestPixelColor> =
+            Font8x16::render_str("Hello World!").translate(Coord::new(5, -20));
+        let empty: Font8x16<TestPixelColor> =
+            Font8x16::render_str("").translate(Coord::new(10, 20));
+
+        assert_eq!(hello.top_left(), Coord::new(5, -20));
+        assert_eq!(hello.bottom_right(), Coord::new(96 + 5, 16 - 20));
+        assert_eq!(empty.top_left(), Coord::new(10, 20));
+        assert_eq!(empty.bottom_right(), Coord::new(10, 20));
+    }
+
+    #[test]
     fn correct_m() {
         let mut display = Display::default();
         display.draw(

--- a/embedded-graphics/src/fonts/font_builder.rs
+++ b/embedded-graphics/src/fonts/font_builder.rs
@@ -77,7 +77,7 @@ where
         let width = Conf::CHAR_WIDTH * self.text.len() as u32;
         let height = if width > 0 { Conf::CHAR_HEIGHT } else { 0 };
 
-        UnsignedCoord(width, height)
+        UnsignedCoord::new(width, height)
     }
 }
 

--- a/embedded-graphics/src/fonts/font_builder.rs
+++ b/embedded-graphics/src/fonts/font_builder.rs
@@ -3,6 +3,7 @@
 use coord::Coord;
 use coord::ToUnsigned;
 use core::marker::PhantomData;
+use drawable::Dimensions;
 use drawable::Drawable;
 use drawable::Pixel;
 use fonts::Font;
@@ -10,7 +11,7 @@ use pixelcolor::PixelColor;
 use style::Style;
 use style::WithStyle;
 use transform::Transform;
-use unsignedcoord::UnsignedCoord;
+use unsignedcoord::{ToSigned, UnsignedCoord};
 
 /// The configuration of the font
 pub trait FontBuilderConf {
@@ -41,6 +42,7 @@ pub struct FontBuilder<'a, C: PixelColor, Conf> {
 
     _conf: PhantomData<Conf>,
 }
+
 impl<'a, C: PixelColor + Copy, Conf> Copy for FontBuilder<'a, C, Conf> {}
 impl<'a, C: PixelColor + Clone, Conf> Clone for FontBuilder<'a, C, Conf> {
     fn clone(&self) -> Self {
@@ -50,6 +52,28 @@ impl<'a, C: PixelColor + Clone, Conf> Clone for FontBuilder<'a, C, Conf> {
             style: self.style.clone(),
             _conf: Default::default(),
         }
+    }
+}
+
+impl<'a, C, Conf> Dimensions for FontBuilder<'a, C, Conf>
+where
+    C: PixelColor,
+    Conf: FontBuilderConf,
+{
+    fn top_left(&self) -> Coord {
+        self.pos
+    }
+
+    fn bottom_right(&self) -> Coord {
+        self.top_left() + self.size().to_signed()
+    }
+
+    fn size(&self) -> UnsignedCoord {
+        // TODO: Handle height of text with newlines in it
+        let height = Conf::CHAR_HEIGHT;
+        let width = Conf::CHAR_WIDTH * self.text.len() as u32;
+
+        UnsignedCoord(width, height)
     }
 }
 

--- a/embedded-graphics/src/fonts/font_builder.rs
+++ b/embedded-graphics/src/fonts/font_builder.rs
@@ -68,10 +68,14 @@ where
         self.top_left() + self.size().to_signed()
     }
 
+    /// Get the bounding box of a piece of text
+    ///
+    /// Currently does not handle newlines (but neither does the rasteriser). It will give `(0, 0)`
+    /// if the string to render is empty.
     fn size(&self) -> UnsignedCoord {
         // TODO: Handle height of text with newlines in it
-        let height = Conf::CHAR_HEIGHT;
         let width = Conf::CHAR_WIDTH * self.text.len() as u32;
+        let height = if width > 0 { Conf::CHAR_HEIGHT } else { 0 };
 
         UnsignedCoord(width, height)
     }

--- a/embedded-graphics/src/fonts/mod.rs
+++ b/embedded-graphics/src/fonts/mod.rs
@@ -10,12 +10,13 @@ pub use self::font12x16::Font12x16;
 pub use self::font6x12::Font6x12;
 pub use self::font6x8::Font6x8;
 pub use self::font8x16::Font8x16;
+use drawable::Dimensions;
 use pixelcolor::PixelColor;
 use style::WithStyle;
 use unsignedcoord::UnsignedCoord;
 
 /// Common methods for all fonts
-pub trait Font<'a, C>: WithStyle<C>
+pub trait Font<'a, C>: WithStyle<C> + Dimensions
 where
     C: PixelColor,
 {

--- a/embedded-graphics/src/fonts/mod.rs
+++ b/embedded-graphics/src/fonts/mod.rs
@@ -51,5 +51,6 @@ where
     fn render_str(chars: &'a str) -> Self;
 
     /// Get the dimensions of a piece of text rendered in a particular font
+    #[deprecated(since = "0.4.5", note = "use `.size()` instead")]
     fn dimensions(&self) -> UnsignedCoord;
 }

--- a/embedded-graphics/src/image/image16bpp.rs
+++ b/embedded-graphics/src/image/image16bpp.rs
@@ -23,6 +23,7 @@ use super::Image;
 use coord::{Coord, ToUnsigned};
 use core::marker::PhantomData;
 use pixelcolor::PixelColor;
+use unsignedcoord::{ToSigned, UnsignedCoord};
 
 /// 8 bit per pixel image
 #[derive(Debug)]
@@ -40,6 +41,26 @@ pub struct Image16BPP<'a, C: PixelColor> {
     pub offset: Coord,
 
     pixel_type: PhantomData<C>,
+}
+
+impl<'a, C> Dimensions for Image16BPP<'a, C>
+where
+    C: PixelColor,
+{
+    fn top_left(&self) -> Coord {
+        self.offset
+    }
+
+    fn bottom_right(&self) -> Coord {
+        self.top_left() + self.size().to_signed()
+    }
+
+    fn size(&self) -> UnsignedCoord {
+        let height = self.height;
+        let width = self.width;
+
+        UnsignedCoord(width, height)
+    }
 }
 
 impl<'a, C> Image<'a> for Image16BPP<'a, C>

--- a/embedded-graphics/src/image/image16bpp.rs
+++ b/embedded-graphics/src/image/image16bpp.rs
@@ -59,7 +59,7 @@ where
         let height = self.height;
         let width = self.width;
 
-        UnsignedCoord(width, height)
+        UnsignedCoord::new(width, height)
     }
 }
 
@@ -217,9 +217,9 @@ mod tests {
         )
         .translate(Coord::new(-1, -1));
 
-        assert_eq!(image.top_left(), Coord(-1, -1));
-        assert_eq!(image.bottom_right(), Coord(2, 2));
-        assert_eq!(image.size(), UnsignedCoord(3, 3));
+        assert_eq!(image.top_left(), Coord::new(-1, -1));
+        assert_eq!(image.bottom_right(), Coord::new(2, 2));
+        assert_eq!(image.size(), UnsignedCoord::new(3, 3));
     }
 
     #[test]
@@ -234,9 +234,9 @@ mod tests {
         )
         .translate(Coord::new(100, 200));
 
-        assert_eq!(image.top_left(), Coord(100, 200));
-        assert_eq!(image.bottom_right(), Coord(103, 203));
-        assert_eq!(image.size(), UnsignedCoord(3, 3));
+        assert_eq!(image.top_left(), Coord::new(100, 200));
+        assert_eq!(image.bottom_right(), Coord::new(103, 203));
+        assert_eq!(image.size(), UnsignedCoord::new(3, 3));
     }
 
     #[test]

--- a/embedded-graphics/src/image/image16bpp.rs
+++ b/embedded-graphics/src/image/image16bpp.rs
@@ -206,6 +206,40 @@ mod tests {
     use unsignedcoord::UnsignedCoord;
 
     #[test]
+    fn negative_top_left() {
+        let image: Image16BPP<PixelColorU16> = Image16BPP::new(
+            &[
+                0xff, 0x00, 0x00, 0x00, 0xbb, 0x00, 0x00, 0x00, 0xcc, 0x00, 0x00, 0x00, 0xee, 0x00,
+                0x00, 0x00, 0xaa, 0x00,
+            ],
+            3,
+            3,
+        )
+        .translate(Coord::new(-1, -1));
+
+        assert_eq!(image.top_left(), Coord(-1, -1));
+        assert_eq!(image.bottom_right(), Coord(2, 2));
+        assert_eq!(image.size(), UnsignedCoord(3, 3));
+    }
+
+    #[test]
+    fn dimensions() {
+        let image: Image16BPP<PixelColorU16> = Image16BPP::new(
+            &[
+                0xff, 0x00, 0x00, 0x00, 0xbb, 0x00, 0x00, 0x00, 0xcc, 0x00, 0x00, 0x00, 0xee, 0x00,
+                0x00, 0x00, 0xaa, 0x00,
+            ],
+            3,
+            3,
+        )
+        .translate(Coord::new(100, 200));
+
+        assert_eq!(image.top_left(), Coord(100, 200));
+        assert_eq!(image.bottom_right(), Coord(103, 203));
+        assert_eq!(image.size(), UnsignedCoord(3, 3));
+    }
+
+    #[test]
     fn it_can_have_negative_offsets() {
         let image: Image16BPP<PixelColorU16> = Image16BPP::new(
             &[

--- a/embedded-graphics/src/image/image1bpp.rs
+++ b/embedded-graphics/src/image/image1bpp.rs
@@ -50,7 +50,7 @@ where
         let height = self.height;
         let width = self.width;
 
-        UnsignedCoord(width, height)
+        UnsignedCoord::new(width, height)
     }
 }
 
@@ -206,9 +206,9 @@ mod tests {
         let image: Image1BPP<PixelColorU16> =
             Image1BPP::new(&[0xff, 0x00], 4, 4).translate(Coord::new(-1, -1));
 
-        assert_eq!(image.top_left(), Coord(-1, -1));
-        assert_eq!(image.bottom_right(), Coord(3, 3));
-        assert_eq!(image.size(), UnsignedCoord(4, 4));
+        assert_eq!(image.top_left(), Coord::new(-1, -1));
+        assert_eq!(image.bottom_right(), Coord::new(3, 3));
+        assert_eq!(image.size(), UnsignedCoord::new(4, 4));
     }
 
     #[test]
@@ -216,8 +216,8 @@ mod tests {
         let image: Image1BPP<PixelColorU16> =
             Image1BPP::new(&[0xff, 0x00], 4, 4).translate(Coord::new(100, 200));
 
-        assert_eq!(image.top_left(), Coord(100, 200));
-        assert_eq!(image.bottom_right(), Coord(104, 204));
-        assert_eq!(image.size(), UnsignedCoord(4, 4));
+        assert_eq!(image.top_left(), Coord::new(100, 200));
+        assert_eq!(image.bottom_right(), Coord::new(104, 204));
+        assert_eq!(image.size(), UnsignedCoord::new(4, 4));
     }
 }

--- a/embedded-graphics/src/image/image1bpp.rs
+++ b/embedded-graphics/src/image/image1bpp.rs
@@ -14,6 +14,7 @@ use super::Image;
 use coord::{Coord, ToUnsigned};
 use core::marker::PhantomData;
 use pixelcolor::PixelColor;
+use unsignedcoord::{ToSigned, UnsignedCoord};
 
 /// 1 bit per pixel image
 #[derive(Debug)]
@@ -31,6 +32,26 @@ pub struct Image1BPP<'a, C> {
     pub offset: Coord,
 
     pixel_type: PhantomData<C>,
+}
+
+impl<'a, C> Dimensions for Image1BPP<'a, C>
+where
+    C: PixelColor,
+{
+    fn top_left(&self) -> Coord {
+        self.offset
+    }
+
+    fn bottom_right(&self) -> Coord {
+        self.top_left() + self.size().to_signed()
+    }
+
+    fn size(&self) -> UnsignedCoord {
+        let height = self.height;
+        let width = self.width;
+
+        UnsignedCoord(width, height)
+    }
 }
 
 impl<'a, C> Image<'a> for Image1BPP<'a, C>

--- a/embedded-graphics/src/image/image1bpp.rs
+++ b/embedded-graphics/src/image/image1bpp.rs
@@ -194,3 +194,30 @@ impl<'a, C> Transform for Image1BPP<'a, C> {
         self
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pixelcolor::PixelColorU16;
+    use unsignedcoord::UnsignedCoord;
+
+    #[test]
+    fn negative_top_left() {
+        let image: Image1BPP<PixelColorU16> =
+            Image1BPP::new(&[0xff, 0x00], 4, 4).translate(Coord::new(-1, -1));
+
+        assert_eq!(image.top_left(), Coord(-1, -1));
+        assert_eq!(image.bottom_right(), Coord(3, 3));
+        assert_eq!(image.size(), UnsignedCoord(4, 4));
+    }
+
+    #[test]
+    fn dimensions() {
+        let image: Image1BPP<PixelColorU16> =
+            Image1BPP::new(&[0xff, 0x00], 4, 4).translate(Coord::new(100, 200));
+
+        assert_eq!(image.top_left(), Coord(100, 200));
+        assert_eq!(image.bottom_right(), Coord(104, 204));
+        assert_eq!(image.size(), UnsignedCoord(4, 4));
+    }
+}

--- a/embedded-graphics/src/image/image8bpp.rs
+++ b/embedded-graphics/src/image/image8bpp.rs
@@ -197,6 +197,34 @@ mod tests {
     use unsignedcoord::UnsignedCoord;
 
     #[test]
+    fn negative_top_left() {
+        let image: Image8BPP<PixelColorU8> = Image8BPP::new(
+            &[0xff, 0x00, 0xbb, 0x00, 0xcc, 0x00, 0xee, 0x00, 0xaa],
+            3,
+            3,
+        )
+        .translate(Coord::new(-1, -1));
+
+        assert_eq!(image.top_left(), Coord(-1, -1));
+        assert_eq!(image.bottom_right(), Coord(2, 2));
+        assert_eq!(image.size(), UnsignedCoord(3, 3));
+    }
+
+    #[test]
+    fn dimensions() {
+        let image: Image8BPP<PixelColorU8> = Image8BPP::new(
+            &[0xff, 0x00, 0xbb, 0x00, 0xcc, 0x00, 0xee, 0x00, 0xaa],
+            3,
+            3,
+        )
+        .translate(Coord::new(100, 200));
+
+        assert_eq!(image.top_left(), Coord(100, 200));
+        assert_eq!(image.bottom_right(), Coord(103, 203));
+        assert_eq!(image.size(), UnsignedCoord(3, 3));
+    }
+
+    #[test]
     fn it_can_have_negative_offsets() {
         let image: Image8BPP<PixelColorU8> = Image8BPP::new(
             &[0xff, 0x00, 0xbb, 0x00, 0xcc, 0x00, 0xee, 0x00, 0xaa],

--- a/embedded-graphics/src/image/image8bpp.rs
+++ b/embedded-graphics/src/image/image8bpp.rs
@@ -51,7 +51,7 @@ where
         let height = self.height;
         let width = self.width;
 
-        UnsignedCoord(width, height)
+        UnsignedCoord::new(width, height)
     }
 }
 
@@ -205,9 +205,9 @@ mod tests {
         )
         .translate(Coord::new(-1, -1));
 
-        assert_eq!(image.top_left(), Coord(-1, -1));
-        assert_eq!(image.bottom_right(), Coord(2, 2));
-        assert_eq!(image.size(), UnsignedCoord(3, 3));
+        assert_eq!(image.top_left(), Coord::new(-1, -1));
+        assert_eq!(image.bottom_right(), Coord::new(2, 2));
+        assert_eq!(image.size(), UnsignedCoord::new(3, 3));
     }
 
     #[test]
@@ -219,9 +219,9 @@ mod tests {
         )
         .translate(Coord::new(100, 200));
 
-        assert_eq!(image.top_left(), Coord(100, 200));
-        assert_eq!(image.bottom_right(), Coord(103, 203));
-        assert_eq!(image.size(), UnsignedCoord(3, 3));
+        assert_eq!(image.top_left(), Coord::new(100, 200));
+        assert_eq!(image.bottom_right(), Coord::new(103, 203));
+        assert_eq!(image.size(), UnsignedCoord::new(3, 3));
     }
 
     #[test]

--- a/embedded-graphics/src/image/image8bpp.rs
+++ b/embedded-graphics/src/image/image8bpp.rs
@@ -15,6 +15,7 @@ use super::Image;
 use coord::{Coord, ToUnsigned};
 use core::marker::PhantomData;
 use pixelcolor::PixelColor;
+use unsignedcoord::{ToSigned, UnsignedCoord};
 
 /// 8 bit per pixel image
 #[derive(Debug)]
@@ -32,6 +33,26 @@ pub struct Image8BPP<'a, C: PixelColor> {
     pub offset: Coord,
 
     pixel_type: PhantomData<C>,
+}
+
+impl<'a, C> Dimensions for Image8BPP<'a, C>
+where
+    C: PixelColor,
+{
+    fn top_left(&self) -> Coord {
+        self.offset
+    }
+
+    fn bottom_right(&self) -> Coord {
+        self.top_left() + self.size().to_signed()
+    }
+
+    fn size(&self) -> UnsignedCoord {
+        let height = self.height;
+        let width = self.width;
+
+        UnsignedCoord(width, height)
+    }
 }
 
 impl<'a, C> Image<'a> for Image8BPP<'a, C>

--- a/embedded-graphics/src/image/mod.rs
+++ b/embedded-graphics/src/image/mod.rs
@@ -1,11 +1,13 @@
 //! Image object
 
+use drawable::Dimensions;
+
 mod image16bpp;
 mod image1bpp;
 mod image8bpp;
 
 /// Image trait
-pub trait Image<'a> {
+pub trait Image<'a>: Dimensions {
     /// Create a new image with given pixel data, width and height
     fn new(imagedata: &'a [u8], width: u32, height: u32) -> Self;
 }

--- a/embedded-graphics/src/prelude.rs
+++ b/embedded-graphics/src/prelude.rs
@@ -7,5 +7,5 @@ pub use super::image::Image;
 pub use super::pixelcolor::PixelColor;
 pub use super::style::{Style, WithStyle};
 pub use super::transform::Transform;
-pub use super::unsignedcoord::UnsignedCoord;
+pub use super::unsignedcoord::{ToSigned, UnsignedCoord};
 pub use super::Drawing;

--- a/embedded-graphics/src/prelude.rs
+++ b/embedded-graphics/src/prelude.rs
@@ -1,7 +1,7 @@
 //! Prelude
 
 pub use super::coord::{Coord, ToUnsigned};
-pub use super::drawable::Pixel;
+pub use super::drawable::{Dimensions, Pixel};
 pub use super::fonts::Font;
 pub use super::image::Image;
 pub use super::pixelcolor::PixelColor;

--- a/embedded-graphics/src/primitives/circle.rs
+++ b/embedded-graphics/src/primitives/circle.rs
@@ -4,8 +4,10 @@ use super::super::drawable::*;
 use super::super::transform::*;
 use coord::{Coord, ToUnsigned};
 use pixelcolor::PixelColor;
+use primitives::Primitive;
 use style::Style;
 use style::WithStyle;
+use unsignedcoord::{ToSigned, UnsignedCoord};
 
 // TODO: Impl Default so people can leave the color bit out
 /// Circle primitive
@@ -32,6 +34,27 @@ where
             radius,
             style: Style::default(),
         }
+    }
+}
+
+impl<C> Primitive for Circle<C> where C: PixelColor {}
+
+impl<C> Dimensions for Circle<C>
+where
+    C: PixelColor,
+{
+    fn top_left(&self) -> Coord {
+        let radius_coord = Coord(self.radius as i32, self.radius as i32);
+
+        self.center - radius_coord
+    }
+
+    fn bottom_right(&self) -> Coord {
+        self.top_left() + self.size().to_signed()
+    }
+
+    fn size(&self) -> UnsignedCoord {
+        UnsignedCoord(self.radius * 2, self.radius * 2)
     }
 }
 

--- a/embedded-graphics/src/primitives/circle.rs
+++ b/embedded-graphics/src/primitives/circle.rs
@@ -44,7 +44,7 @@ where
     C: PixelColor,
 {
     fn top_left(&self) -> Coord {
-        let radius_coord = Coord(self.radius as i32, self.radius as i32);
+        let radius_coord = Coord::new(self.radius as i32, self.radius as i32);
 
         self.center - radius_coord
     }
@@ -54,7 +54,7 @@ where
     }
 
     fn size(&self) -> UnsignedCoord {
-        UnsignedCoord(self.radius * 2, self.radius * 2)
+        UnsignedCoord::new(self.radius * 2, self.radius * 2)
     }
 }
 
@@ -247,27 +247,27 @@ mod tests {
     fn negative_dimensions() {
         let circ: Circle<TestPixelColor> = Circle::new(Coord::new(-10, -10), 5);
 
-        assert_eq!(circ.top_left(), Coord(-15, -15));
-        assert_eq!(circ.bottom_right(), Coord(-5, -5));
-        assert_eq!(circ.size(), UnsignedCoord(10, 10));
+        assert_eq!(circ.top_left(), Coord::new(-15, -15));
+        assert_eq!(circ.bottom_right(), Coord::new(-5, -5));
+        assert_eq!(circ.size(), UnsignedCoord::new(10, 10));
     }
 
     #[test]
     fn dimensions() {
         let circ: Circle<TestPixelColor> = Circle::new(Coord::new(10, 20), 5);
 
-        assert_eq!(circ.top_left(), Coord(5, 15));
-        assert_eq!(circ.bottom_right(), Coord(15, 25));
-        assert_eq!(circ.size(), UnsignedCoord(10, 10));
+        assert_eq!(circ.top_left(), Coord::new(5, 15));
+        assert_eq!(circ.bottom_right(), Coord::new(15, 25));
+        assert_eq!(circ.size(), UnsignedCoord::new(10, 10));
     }
 
     #[test]
     fn large_radius() {
         let circ: Circle<TestPixelColor> = Circle::new(Coord::new(5, 5), 10);
 
-        assert_eq!(circ.top_left(), Coord(-5, -5));
-        assert_eq!(circ.bottom_right(), Coord(15, 15));
-        assert_eq!(circ.size(), UnsignedCoord(20, 20));
+        assert_eq!(circ.top_left(), Coord::new(-5, -5));
+        assert_eq!(circ.bottom_right(), Coord::new(15, 15));
+        assert_eq!(circ.size(), UnsignedCoord::new(20, 20));
     }
 
     #[test]

--- a/embedded-graphics/src/primitives/circle.rs
+++ b/embedded-graphics/src/primitives/circle.rs
@@ -241,6 +241,34 @@ where
 mod tests {
     use super::*;
     use dev::TestPixelColor;
+    use drawable::Dimensions;
+
+    #[test]
+    fn negative_dimensions() {
+        let circ: Circle<TestPixelColor> = Circle::new(Coord::new(-10, -10), 5);
+
+        assert_eq!(circ.top_left(), Coord(-15, -15));
+        assert_eq!(circ.bottom_right(), Coord(-5, -5));
+        assert_eq!(circ.size(), UnsignedCoord(10, 10));
+    }
+
+    #[test]
+    fn dimensions() {
+        let circ: Circle<TestPixelColor> = Circle::new(Coord::new(10, 20), 5);
+
+        assert_eq!(circ.top_left(), Coord(5, 15));
+        assert_eq!(circ.bottom_right(), Coord(15, 25));
+        assert_eq!(circ.size(), UnsignedCoord(10, 10));
+    }
+
+    #[test]
+    fn large_radius() {
+        let circ: Circle<TestPixelColor> = Circle::new(Coord::new(5, 5), 10);
+
+        assert_eq!(circ.top_left(), Coord(-5, -5));
+        assert_eq!(circ.bottom_right(), Coord(15, 15));
+        assert_eq!(circ.size(), UnsignedCoord(20, 20));
+    }
 
     #[test]
     fn it_handles_offscreen_coords() {

--- a/embedded-graphics/src/primitives/line.rs
+++ b/embedded-graphics/src/primitives/line.rs
@@ -30,7 +30,7 @@ where
     C: PixelColor,
 {
     fn top_left(&self) -> Coord {
-        Coord(self.start.0.min(self.end.0), self.start.1.max(self.end.1))
+        Coord(self.start.0.min(self.end.0), self.start.1.min(self.end.1))
     }
 
     fn bottom_right(&self) -> Coord {
@@ -263,6 +263,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use dev::TestPixelColor;
     use drawable::Pixel;
     use pixelcolor::PixelColorU8;
     use style::Style;
@@ -273,6 +274,23 @@ mod tests {
         for (idx, Pixel(coord, _)) in line.into_iter().enumerate() {
             assert_eq!(coord, UnsignedCoord::new(expected[idx].0, expected[idx].1));
         }
+    }
+
+    #[test]
+    fn bounding_box() {
+        let start = Coord(10, 10);
+        let end = Coord(20, 20);
+
+        let line: Line<TestPixelColor> = Line::new(start, end);
+        let backwards_line: Line<TestPixelColor> = Line::new(end, start);
+
+        assert_eq!(line.top_left(), start);
+        assert_eq!(line.bottom_right(), end);
+        assert_eq!(line.size(), UnsignedCoord(10, 10));
+
+        assert_eq!(backwards_line.top_left(), start);
+        assert_eq!(backwards_line.bottom_right(), end);
+        assert_eq!(backwards_line.size(), UnsignedCoord(10, 10));
     }
 
     #[test]

--- a/embedded-graphics/src/primitives/line.rs
+++ b/embedded-graphics/src/primitives/line.rs
@@ -30,7 +30,10 @@ where
     C: PixelColor,
 {
     fn top_left(&self) -> Coord {
-        Coord(self.start.0.min(self.end.0), self.start.1.min(self.end.1))
+        Coord::new(
+            self.start[1].min(self.end[0]),
+            self.start[1].min(self.end[1]),
+        )
     }
 
     fn bottom_right(&self) -> Coord {
@@ -278,19 +281,19 @@ mod tests {
 
     #[test]
     fn bounding_box() {
-        let start = Coord(10, 10);
-        let end = Coord(20, 20);
+        let start = Coord::new(10, 10);
+        let end = Coord::new(20, 20);
 
         let line: Line<TestPixelColor> = Line::new(start, end);
         let backwards_line: Line<TestPixelColor> = Line::new(end, start);
 
         assert_eq!(line.top_left(), start);
         assert_eq!(line.bottom_right(), end);
-        assert_eq!(line.size(), UnsignedCoord(10, 10));
+        assert_eq!(line.size(), UnsignedCoord::new(10, 10));
 
         assert_eq!(backwards_line.top_left(), start);
         assert_eq!(backwards_line.bottom_right(), end);
-        assert_eq!(backwards_line.size(), UnsignedCoord(10, 10));
+        assert_eq!(backwards_line.size(), UnsignedCoord::new(10, 10));
     }
 
     #[test]

--- a/embedded-graphics/src/primitives/line.rs
+++ b/embedded-graphics/src/primitives/line.rs
@@ -4,8 +4,10 @@ use super::super::drawable::*;
 use super::super::transform::*;
 use coord::{Coord, ToUnsigned};
 use pixelcolor::PixelColor;
+use primitives::Primitive;
 use style::Style;
 use style::WithStyle;
+use unsignedcoord::{ToSigned, UnsignedCoord};
 
 // TODO: Impl Default so people can leave the color bit out
 /// Line primitive
@@ -19,6 +21,25 @@ pub struct Line<C: PixelColor> {
 
     /// Line style
     pub style: Style<C>,
+}
+
+impl<C> Primitive for Line<C> where C: PixelColor {}
+
+impl<C> Dimensions for Line<C>
+where
+    C: PixelColor,
+{
+    fn top_left(&self) -> Coord {
+        Coord(self.start.0.min(self.end.0), self.start.1.max(self.end.1))
+    }
+
+    fn bottom_right(&self) -> Coord {
+        self.top_left() + self.size().to_signed()
+    }
+
+    fn size(&self) -> UnsignedCoord {
+        (self.end - self.start).abs().to_unsigned()
+    }
 }
 
 impl<C> Line<C>

--- a/embedded-graphics/src/primitives/mod.rs
+++ b/embedded-graphics/src/primitives/mod.rs
@@ -1,8 +1,13 @@
 //! Graphics primitives
 
+use drawable::Dimensions;
+
 pub mod circle;
 pub mod line;
 pub mod rect;
+
+/// Primitive trait
+pub trait Primitive: Dimensions {}
 
 pub use self::circle::Circle;
 pub use self::line::Line;

--- a/embedded-graphics/src/primitives/rect.rs
+++ b/embedded-graphics/src/primitives/rect.rs
@@ -4,8 +4,10 @@ use super::super::drawable::*;
 use super::super::transform::*;
 use coord::{Coord, ToUnsigned};
 use pixelcolor::PixelColor;
+use primitives::Primitive;
 use style::Style;
 use style::WithStyle;
+use unsignedcoord::UnsignedCoord;
 
 // TODO: Impl Default so people can leave the color bit out
 /// Rectangle primitive
@@ -19,6 +21,25 @@ pub struct Rect<C: PixelColor> {
 
     /// Object style
     pub style: Style<C>,
+}
+
+impl<C> Primitive for Rect<C> where C: PixelColor {}
+
+impl<C> Dimensions for Rect<C>
+where
+    C: PixelColor,
+{
+    fn top_left(&self) -> Coord {
+        self.top_left
+    }
+
+    fn bottom_right(&self) -> Coord {
+        self.bottom_right
+    }
+
+    fn size(&self) -> UnsignedCoord {
+        (self.bottom_right - self.top_left).abs().to_unsigned()
+    }
 }
 
 impl<C> Rect<C>

--- a/embedded-graphics/src/primitives/rect.rs
+++ b/embedded-graphics/src/primitives/rect.rs
@@ -252,13 +252,13 @@ mod tests {
         let rect: Rect<TestPixelColor> = Rect::new(Coord::new(5, 10), Coord::new(15, 20));
         let moved = rect.translate(Coord::new(-10, -10));
 
-        assert_eq!(rect.top_left(), Coord(5, 10));
-        assert_eq!(rect.bottom_right(), Coord(15, 20));
-        assert_eq!(rect.size(), UnsignedCoord(10, 10));
+        assert_eq!(rect.top_left(), Coord::new(5, 10));
+        assert_eq!(rect.bottom_right(), Coord::new(15, 20));
+        assert_eq!(rect.size(), UnsignedCoord::new(10, 10));
 
-        assert_eq!(moved.top_left(), Coord(-5, 0));
-        assert_eq!(moved.bottom_right(), Coord(5, 10));
-        assert_eq!(moved.size(), UnsignedCoord(10, 10));
+        assert_eq!(moved.top_left(), Coord::new(-5, 0));
+        assert_eq!(moved.bottom_right(), Coord::new(5, 10));
+        assert_eq!(moved.size(), UnsignedCoord::new(10, 10));
     }
 
     #[test]

--- a/embedded-graphics/src/primitives/rect.rs
+++ b/embedded-graphics/src/primitives/rect.rs
@@ -248,6 +248,20 @@ mod tests {
     use unsignedcoord::UnsignedCoord;
 
     #[test]
+    fn dimensions() {
+        let rect: Rect<TestPixelColor> = Rect::new(Coord::new(5, 10), Coord::new(15, 20));
+        let moved = rect.translate(Coord::new(-10, -10));
+
+        assert_eq!(rect.top_left(), Coord(5, 10));
+        assert_eq!(rect.bottom_right(), Coord(15, 20));
+        assert_eq!(rect.size(), UnsignedCoord(10, 10));
+
+        assert_eq!(moved.top_left(), Coord(-5, 0));
+        assert_eq!(moved.bottom_right(), Coord(5, 10));
+        assert_eq!(moved.size(), UnsignedCoord(10, 10));
+    }
+
+    #[test]
     fn it_can_be_translated() {
         let rect: Rect<TestPixelColor> = Rect::new(Coord::new(5, 10), Coord::new(15, 20));
         let moved = rect.translate(Coord::new(10, 10));

--- a/embedded-graphics/src/unsignedcoord.rs
+++ b/embedded-graphics/src/unsignedcoord.rs
@@ -4,6 +4,8 @@
 //! use with [`Drawable`](../drawable/trait.Drawable.html) iterators to output valid _display pixel_
 //! coordinates, i.e. coordinates that are always positive.
 
+use coord::Coord;
+
 type UnsignedCoordPart = u32;
 
 #[cfg(not(feature = "nalgebra_support"))]
@@ -74,6 +76,21 @@ use nalgebra;
 #[cfg(feature = "nalgebra_support")]
 /// 2D coordinate type with Nalgebra support
 pub type UnsignedCoord = nalgebra::Vector2<UnsignedCoordPart>;
+
+/// Convert an unsigned coordinate to a signed representation
+///
+/// The coordinate is guaranteed to be positive. This trait is provided as a convenience method for
+/// converting between signed/unsigned coords.
+pub trait ToSigned {
+    /// Convert self into a signed `Coord`
+    fn to_signed(self) -> Coord;
+}
+
+impl ToSigned for UnsignedCoord {
+    fn to_signed(self) -> Coord {
+        Coord(self[0] as i32, self[1] as i32)
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/embedded-graphics/src/unsignedcoord.rs
+++ b/embedded-graphics/src/unsignedcoord.rs
@@ -88,7 +88,7 @@ pub trait ToSigned {
 
 impl ToSigned for UnsignedCoord {
     fn to_signed(self) -> Coord {
-        Coord(self[0] as i32, self[1] as i32)
+        Coord::new(self[0] as i32, self[1] as i32)
     }
 }
 

--- a/simulator/examples/fonts.rs
+++ b/simulator/examples/fonts.rs
@@ -7,7 +7,6 @@ use std::time::Duration;
 use embedded_graphics::coord::Coord;
 use embedded_graphics::fonts::{Font12x16, Font6x12, Font6x8, Font8x16};
 use embedded_graphics::prelude::*;
-use embedded_graphics::primitives::{Circle, Line};
 
 use simulator::Display;
 


### PR DESCRIPTION
The `Dimensions` trait adds the methods `top_left()`, `bottom_right()` and `size()` to all embedded graphics objects. This might be useful to mark the update area of a display that supports partial refreshes, for example.