### PR TITLE
Fix some of the missing docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,11 +26,16 @@ matrix:
 
 before_install:
   - rustup component add rustfmt
+  - pip install linkchecker --user
 
 script:
   - cargo fmt --all -- --check
   - cargo test --release -p embedded-graphics
   - cargo test --release --all-features -p embedded-graphics
+
+after_success:
+  - cargo doc
+  - linkchecker target/doc/embedded_graphics
 
 cache: cargo
 before_cache:

--- a/embedded-graphics/src/coord.rs
+++ b/embedded-graphics/src/coord.rs
@@ -12,7 +12,14 @@ mod internal_coord {
     use super::*;
     use core::ops::{Add, AddAssign, Index, Sub, SubAssign};
 
-    /// 2D coordinate type
+    /// 2D signed integer coordinate type
+    ///
+    /// This coordinate should be used to define graphics object coordinates. For example, a
+    /// [`Rect`] may be defined that has its top left at `(-1,-2)`. To specify positive-only screen
+    /// coordinates and the like, see [`UnsignedCoord`]
+    ///
+    /// [`UnsignedCoord`]: ../unsignedcoord/struct.UnsignedCoord.html
+    /// [`Rect`]: ../primitives/rect/struct.Rect.html
     #[derive(Debug, Copy, Clone, Eq, PartialEq)]
     pub struct Coord(pub CoordPart, pub CoordPart);
 

--- a/embedded-graphics/src/fonts/font12x16.rs
+++ b/embedded-graphics/src/fonts/font12x16.rs
@@ -1,5 +1,3 @@
-//! 12x16 pixel font. Covers the printable ASCII characters. Image data taken from the [Uzebox Wiki page](http://uzebox.org/wiki/Font_Bitmaps)
-
 use fonts::font_builder::{FontBuilder, FontBuilderConf};
 
 #[derive(Debug, Copy, Clone)]
@@ -21,7 +19,7 @@ impl FontBuilderConf for Font12x16Conf {
     }
 }
 
-/// A 12x16 font.
+/// 12x16 pixel monospace font
 pub type Font12x16<'a, C> = FontBuilder<'a, C, Font12x16Conf>;
 
 #[cfg(test)]

--- a/embedded-graphics/src/fonts/font6x12.rs
+++ b/embedded-graphics/src/fonts/font6x12.rs
@@ -1,5 +1,3 @@
-//! 6x12 pixel font. Covers the printable ASCII characters. Image data taken from the [Uzebox Wiki page](http://uzebox.org/wiki/Font_Bitmaps)
-
 use fonts::font_builder::{FontBuilder, FontBuilderConf};
 
 #[derive(Debug, Copy, Clone)]
@@ -21,7 +19,7 @@ impl FontBuilderConf for Font6x12Conf {
     }
 }
 
-/// A 6x12 font.
+/// 6x12 pixel monospace font
 pub type Font6x12<'a, C> = FontBuilder<'a, C, Font6x12Conf>;
 
 #[cfg(test)]

--- a/embedded-graphics/src/fonts/font6x8.rs
+++ b/embedded-graphics/src/fonts/font6x8.rs
@@ -1,5 +1,3 @@
-//! 6x8 pixel font. Covers the printable latin1 characters. Image data taken from the [Uzebox Wiki page](http://uzebox.org/wiki/Font_Bitmaps)
-
 use fonts::font_builder::{FontBuilder, FontBuilderConf};
 
 #[derive(Debug, Copy, Clone)]
@@ -24,7 +22,7 @@ impl FontBuilderConf for Font6x8Conf {
     }
 }
 
-/// A 6x8 font.
+/// 6x8 pixel monospace font
 pub type Font6x8<'a, C> = FontBuilder<'a, C, Font6x8Conf>;
 
 #[cfg(test)]

--- a/embedded-graphics/src/fonts/font8x16.rs
+++ b/embedded-graphics/src/fonts/font8x16.rs
@@ -1,5 +1,3 @@
-//! 8x16 pixel font. Image data taken from the [Uzebox Wiki page](http://uzebox.org/wiki/Font_Bitmaps)
-
 use fonts::font_builder::{FontBuilder, FontBuilderConf};
 
 #[derive(Debug, Copy, Clone)]
@@ -24,7 +22,7 @@ impl FontBuilderConf for Font8x16Conf {
     }
 }
 
-/// A 8x16 font.
+/// 8x16 pixel monospace font
 pub type Font8x16<'a, C> = FontBuilder<'a, C, Font8x16Conf>;
 
 #[cfg(test)]

--- a/embedded-graphics/src/fonts/font_builder.rs
+++ b/embedded-graphics/src/fonts/font_builder.rs
@@ -1,4 +1,4 @@
-//! Boilerplate to construct fonts
+//! Common code used to define available monospace pixel fonts
 
 use coord::Coord;
 use coord::ToUnsigned;

--- a/embedded-graphics/src/image/image16bpp.rs
+++ b/embedded-graphics/src/image/image16bpp.rs
@@ -1,17 +1,3 @@
-//! 16 bits per pixel images. Every two bytes define the color for each pixel.
-//!
-//! You can convert an image to 16BPP for inclusion with `include_bytes!()` doing the following
-//!
-//! ```bash
-//! convert image.png -flip -flop -type truecolor -define bmp:subtype=RGB565 -resize '64x64!' -depth 16 -strip image.bmp
-//! ```
-//! then
-//! ```bash
-//! tail -c $bytes image.bmp > image.raw // where $bytes is w * h * 2
-//! ```
-//! This will remove the BMP header leaving the raw pixel data
-//! E.g 64x64 image will have `64 * 64 * 2` bytes of raw data.
-
 use super::super::drawable::*;
 use super::super::transform::*;
 use super::Image;
@@ -20,7 +6,21 @@ use core::marker::PhantomData;
 use pixelcolor::PixelColor;
 use unsignedcoord::{ToSigned, UnsignedCoord};
 
-/// 16 bit per pixel image
+/// # 16 bits per pixel images
+///
+/// Every two bytes define the color for each pixel.
+///
+/// You can convert an image to 16BPP for inclusion with `include_bytes!()` doing the following
+///
+/// ```bash
+/// convert image.png -flip -flop -type truecolor -define bmp:subtype=RGB565 -resize '64x64!' -depth 16 -strip image.bmp
+/// ```
+/// then
+/// ```bash
+/// tail -c $bytes image.bmp > image.raw // where $bytes is w * h * 2
+/// ```
+/// This will remove the BMP header leaving the raw pixel data
+/// E.g 64x64 image will have `64 * 64 * 2` bytes of raw data.
 #[derive(Debug)]
 pub struct Image16BPP<'a, C: PixelColor> {
     /// Image width

--- a/embedded-graphics/src/image/image1bpp.rs
+++ b/embedded-graphics/src/image/image1bpp.rs
@@ -1,13 +1,3 @@
-//! 1 bit per pixel image. Each byte of input data defines the on/off state of 8 horizontal pixels
-//! to be displayed on the screen.
-//!
-//! You can convert an image to 1BPP for inclusion with `include_bytes!()` using the following
-//! Imagemagick command:
-//!
-//! ```bash
-//! convert image.png -depth 1 gray:"image.raw"
-//! ```
-
 use super::super::drawable::*;
 use super::super::transform::*;
 use super::Image;
@@ -16,7 +6,17 @@ use core::marker::PhantomData;
 use pixelcolor::PixelColor;
 use unsignedcoord::{ToSigned, UnsignedCoord};
 
-/// 1 bit per pixel image
+/// # 1 bit per pixel image
+///
+/// Each byte of input data defines the on/off state of 8 horizontal pixels to be displayed on the
+/// screen.
+///
+/// You can convert an image to 1BPP for inclusion with `include_bytes!()` using the following
+/// Imagemagick command:
+///
+/// ```bash
+/// convert image.png -depth 1 gray:"image.raw"
+/// ```
 #[derive(Debug)]
 pub struct Image1BPP<'a, C> {
     /// Image width in pixels

--- a/embedded-graphics/src/image/image8bpp.rs
+++ b/embedded-graphics/src/image/image8bpp.rs
@@ -1,14 +1,3 @@
-//! 8 bit per pixel image. Each byte of input data defines the on/off state for each pixel. This
-//! currently only supports monochrome displays, so if the pixel value is 0, it's off, anything
-//! above 0 is on.
-//!
-//! You can convert an image to 8BPP for inclusion with `include_bytes!()` using the following
-//! Imagemagick command:
-//!
-//! ```bash
-//! convert image.png -depth 8 gray:"image.raw"
-//! ```
-
 use super::super::drawable::*;
 use super::super::transform::*;
 use super::Image;
@@ -17,7 +6,17 @@ use core::marker::PhantomData;
 use pixelcolor::PixelColor;
 use unsignedcoord::{ToSigned, UnsignedCoord};
 
-/// 8 bit per pixel image
+/// # 8 bits per pixel image
+///
+/// Each byte of input data defines the on/off state for each pixel. This currently only supports
+/// monochrome displays, so if the pixel value is 0, it's off, anything above 0 is on.
+///
+/// You can convert an image to 8BPP for inclusion with `include_bytes!()` using the following
+/// Imagemagick command:
+///
+/// ```bash
+/// convert image.png -depth 8 gray:"image.raw"
+/// ```
 #[derive(Debug)]
 pub struct Image8BPP<'a, C: PixelColor> {
     /// Image width

--- a/embedded-graphics/src/lib.rs
+++ b/embedded-graphics/src/lib.rs
@@ -3,13 +3,14 @@
 //! This crate aims to make drawing 2D graphics primitives super easy. It currently supports the
 //! following:
 //!
-//! * 1 bit-per-pixel images
-//! * 8 bit-per-pixel images
-//! * Primitives
+//! * [1 bit-per-pixel images](./image/struct.Image1BPP.html)
+//! * [8 bits-per-pixel images](./image/struct.Image8BPP.html)
+//! * [16 bits-per-pixel images](./image/struct.Image16BPP.html)
+//! * [Primitives](./primitives/index.html)
 //!     * Lines
 //!     * Rectangles (and squares)
 //!     * Circles
-//! * Text with multiple [fonts](./fonts/index.html)
+//! * [Text with multiple fonts](./fonts/index.html#types)
 //!
 //! A core goal is to do the above without using any buffers; the crate should work without a
 //! dynamic memory allocator and without pre-allocating large chunks of memory. To achieve this, it

--- a/embedded-graphics/src/pixelcolor.rs
+++ b/embedded-graphics/src/pixelcolor.rs
@@ -49,6 +49,10 @@ impl PixelColor for u16 {}
 impl PixelColor for u32 {}
 
 /// Pixel wrapper around `u8` type
+///
+/// See [`PixelColor`] for usage
+///
+/// [`PixelColor`]: ../pixelcolor/index.html
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub struct PixelColorU8(pub u8);
 
@@ -60,11 +64,14 @@ impl From<u8> for PixelColorU8 {
 
 impl PixelColorU8 {
     /// Get the inner value of the pixel
+    ///
+    /// ```
     /// #
-    /// # use pixelcolor::PixelColorU16;
+    /// # use embedded_graphics::pixelcolor::PixelColorU8;
     /// #
-    /// let color = PixelColoru16(100u16);
-    /// assert_eq!(color.into_inner(), 100u16);
+    /// let color = PixelColorU8(100u8);
+    /// assert_eq!(color.into_inner(), 100u8);
+    /// ```
     pub fn into_inner(self) -> u8 {
         self.0
     }
@@ -73,6 +80,10 @@ impl PixelColorU8 {
 impl PixelColor for PixelColorU8 {}
 
 /// Pixel wrapper around `u16` type
+///
+/// See [`PixelColor`] for usage
+///
+/// [`PixelColor`]: ../pixelcolor/index.html
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub struct PixelColorU16(pub u16);
 
@@ -90,11 +101,14 @@ impl From<u16> for PixelColorU16 {
 
 impl PixelColorU16 {
     /// Get the inner value of the pixel
+    ///
+    /// ```
     /// #
-    /// # use pixelcolor::PixelColorU8;
+    /// # use embedded_graphics::pixelcolor::PixelColorU16;
     /// #
-    /// let color = PixelColoru8(100u8);
-    /// assert_eq!(color.into_inner(), 100u8);
+    /// let color = PixelColorU16(100u16);
+    /// assert_eq!(color.into_inner(), 100u16);
+    /// ```
     pub fn into_inner(self) -> u16 {
         self.0
     }
@@ -103,6 +117,10 @@ impl PixelColorU16 {
 impl PixelColor for PixelColorU16 {}
 
 /// Pixel wrapper around `u32` type
+///
+/// See [`PixelColor`] for usage
+///
+/// [`PixelColor`]: ../pixelcolor/index.html
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub struct PixelColorU32(pub u32);
 
@@ -126,11 +144,14 @@ impl From<u32> for PixelColorU32 {
 
 impl PixelColorU32 {
     /// Get the inner value of the pixel
+    ///
+    /// ```
     /// #
-    /// # use pixelcolor::PixelColorU32;
+    /// # use embedded_graphics::pixelcolor::PixelColorU32;
     /// #
-    /// let color = PixelColoru32(100u32);
+    /// let color = PixelColorU32(100u32);
     /// assert_eq!(color.into_inner(), 100u32);
+    /// ```
     pub fn into_inner(self) -> u32 {
         self.0
     }

--- a/embedded-graphics/src/unsignedcoord.rs
+++ b/embedded-graphics/src/unsignedcoord.rs
@@ -1,8 +1,4 @@
-//! 2D unsigned coordinate in screen space
-//!
-//! As opposed to [`Coord`](../coord/index.html), this coordinate is unsigned. It is intended for
-//! use with [`Drawable`](../drawable/trait.Drawable.html) iterators to output valid _display pixel_
-//! coordinates, i.e. coordinates that are always positive.
+//! 2D unsigned coordinate
 
 use coord::Coord;
 
@@ -13,7 +9,11 @@ mod internal_unsigned_coord {
     use super::UnsignedCoordPart;
     use core::ops::{Add, AddAssign, Index, Sub, SubAssign};
 
-    /// 2D coordinate type
+    /// 2D unsigned coordinate in screen space
+    ///
+    /// As opposed to [`Coord`](../coord/index.html), this coordinate is unsigned. It is intended for
+    /// use with [`Drawable`](../drawable/trait.Drawable.html) iterators to output valid _display pixel_
+    /// coordinates, i.e. coordinates that are always positive.
     #[derive(Debug, Copy, Clone, Eq, PartialEq)]
     pub struct UnsignedCoord(pub UnsignedCoordPart, pub UnsignedCoordPart);
 


### PR DESCRIPTION
Some docs were missing in the generated docs.rs output due to being defined at the module level, instead of the struct level. This PR fixes that for images, and makes a few other small tweaks to improve the usability of the docs for this crate.

Closes #63 