### PR TITLE
Fix path to header module

### DIFF
--- a/tinybmp/src/lib.rs
+++ b/tinybmp/src/lib.rs
@@ -7,8 +7,8 @@
 
 mod header;
 
-use header::parse_header;
-pub use header::{FileType, Header};
+use crate::header::parse_header;
+pub use crate::header::{FileType, Header};
 
 /// A BMP-format bitmap
 #[derive(Debug, Clone, PartialEq)]


### PR DESCRIPTION
This fixes an error that appears when compiling with Rust 1.31 (embedded-hal's MSRV):
```
error[E0658]: imports can only refer to extern crate names passed with `--extern` on stable channel (see issue #53130)
  --> /home/travis/.cargo/registry/src/github.com-1ecc6299db9ec823/tinybmp-0.1.0/src/lib.rs:10:5
   |
8  | mod header;
   | ----------- not an extern crate passed with `--extern`
9  | 
10 | use header::parse_header;
   |     ^^^^^^
   |
note: this import refers to the module defined here
  --> /home/travis/.cargo/registry/src/github.com-1ecc6299db9ec823/tinybmp-0.1.0/src/lib.rs:8:1
   |
8  | mod header;
   | ^^^^^^^^^^^
```
This bit me [here](https://travis-ci.org/eldruin/driver-examples/jobs/504247237)