### PR TITLE
Add benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .vscode/
-/target/
+target/
 **/*.rs.bk
 Cargo.lock
 .DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,11 @@ rust:
   - beta
   - nightly
 
+addons:
+  apt:
+    packages:
+      libsdl2-dev
+
 matrix:
   include:
     # # Linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ script:
   - cargo test --release -p tinybmp
   - cargo test --release --all-features -p embedded-graphics
   - cargo test --release --all-features -p tinybmp
+  - cargo bench --no-run
 
 after_success:
   - cargo doc

--- a/embedded-graphics/Cargo.toml
+++ b/embedded-graphics/Cargo.toml
@@ -18,6 +18,12 @@ edition = "2018"
 [[bench]]
 harness = false
 name = "primitives"
+[[bench]]
+harness = false
+name = "fonts"
+[[bench]]
+harness = false
+name = "image"
 
 [badges]
 travis-ci = { repository = "jamwaffles/embedded-graphics", branch = "master" }

--- a/embedded-graphics/Cargo.toml
+++ b/embedded-graphics/Cargo.toml
@@ -15,6 +15,9 @@ exclude = [
 	"convert_1bpp.sh",
 ]
 edition = "2018"
+[[bench]]
+harness = false
+name = "primitives"
 
 [badges]
 travis-ci = { repository = "jamwaffles/embedded-graphics", branch = "master" }
@@ -26,3 +29,6 @@ tinybmp = "0.1.0"
 [features]
 default = []
 nalgebra_support = [ "nalgebra" ]
+
+[dev-dependencies]
+criterion = "0.2.10"

--- a/embedded-graphics/Cargo.toml
+++ b/embedded-graphics/Cargo.toml
@@ -23,7 +23,7 @@ name = "primitives"
 travis-ci = { repository = "jamwaffles/embedded-graphics", branch = "master" }
 
 [dependencies]
-nalgebra = { version = "0.16.0", optional = true, default-features = false }
+nalgebra = { version = "0.17.2", optional = true, default-features = false }
 tinybmp = "0.1.0"
 
 [features]

--- a/embedded-graphics/benches/fonts.rs
+++ b/embedded-graphics/benches/fonts.rs
@@ -1,0 +1,27 @@
+use criterion::*;
+use embedded_graphics::{
+    fonts::{Font12x16, Font6x8},
+    pixelcolor::PixelColorU8,
+    prelude::*,
+};
+
+fn font_6x8(c: &mut Criterion) {
+    c.bench_function("font 6x8 Hello world!", |b| {
+        let object: Font6x8<PixelColorU8> =
+            Font6x8::render_str("Hello world!").with_stroke(Some(10u8.into()));
+
+        b.iter(|| object.into_iter().collect::<Vec<Pixel<PixelColorU8>>>())
+    });
+}
+
+fn font_12x16(c: &mut Criterion) {
+    c.bench_function("font 12x16 Hello world!", |b| {
+        let object: Font12x16<PixelColorU8> =
+            Font12x16::render_str("Hello world!").with_stroke(Some(10u8.into()));
+
+        b.iter(|| object.into_iter().collect::<Vec<Pixel<PixelColorU8>>>())
+    });
+}
+
+criterion_group!(fonts, font_6x8, font_12x16);
+criterion_main!(fonts);

--- a/embedded-graphics/benches/image.rs
+++ b/embedded-graphics/benches/image.rs
@@ -1,0 +1,18 @@
+use criterion::*;
+use embedded_graphics::{image::ImageBmp, pixelcolor::PixelColorU16, prelude::*};
+
+fn image_bmp_4x4(c: &mut Criterion) {
+    c.bench_function("image BMP 4x4px", |b| {
+        let bytes = include_bytes!("../tests/chessboard-4px-colour-16bit.bmp");
+
+        b.iter(|| {
+            ImageBmp::new(bytes)
+                .unwrap()
+                .into_iter()
+                .collect::<Vec<Pixel<PixelColorU16>>>()
+        })
+    });
+}
+
+criterion_group!(fonts, image_bmp_4x4);
+criterion_main!(fonts);

--- a/embedded-graphics/benches/primitives.rs
+++ b/embedded-graphics/benches/primitives.rs
@@ -1,13 +1,47 @@
 use criterion::*;
-use embedded_graphics::{prelude::*, primitives::Circle};
+use embedded_graphics::{
+    pixelcolor::PixelColorU8,
+    prelude::*,
+    primitives::{Circle, Line, Rect},
+};
 
-fn circle(c: &mut Criterion) {
-    c.bench_function("circle", |b| {
-        let circle = Circle::new(Coord::new(10, 10), 10);
+fn filled_circle(c: &mut Criterion) {
+    c.bench_function("filled circle", |b| {
+        let object: Circle<PixelColorU8> = Circle::new(Coord::new(100, 100), 100)
+            .with_fill(Some(1u8.into()))
+            .with_stroke(Some(10u8.into()));
 
-        b.iter(|| circle.into_iter().collect())
+        b.iter(|| object.into_iter().collect::<Vec<Pixel<PixelColorU8>>>())
     });
 }
 
-criterion_group!(primitives, circle);
+fn filled_rect(c: &mut Criterion) {
+    c.bench_function("filled rectangle", |b| {
+        let object: Rect<PixelColorU8> = Rect::new(Coord::new(100, 100), Coord::new(200, 200))
+            .with_fill(Some(1u8.into()))
+            .with_stroke(Some(10u8.into()));
+
+        b.iter(|| object.into_iter().collect::<Vec<Pixel<PixelColorU8>>>())
+    });
+}
+
+fn empty_rect(c: &mut Criterion) {
+    c.bench_function("unfilled rectangle", |b| {
+        let object: Rect<PixelColorU8> =
+            Rect::new(Coord::new(100, 100), Coord::new(200, 200)).with_stroke(Some(10u8.into()));
+
+        b.iter(|| object.into_iter().collect::<Vec<Pixel<PixelColorU8>>>())
+    });
+}
+
+fn line(c: &mut Criterion) {
+    c.bench_function("line", |b| {
+        let object: Line<PixelColorU8> =
+            Line::new(Coord::new(100, 100), Coord::new(200, 200)).with_stroke(Some(10u8.into()));
+
+        b.iter(|| object.into_iter().collect::<Vec<Pixel<PixelColorU8>>>())
+    });
+}
+
+criterion_group!(primitives, filled_circle, filled_rect, empty_rect, line);
 criterion_main!(primitives);

--- a/embedded-graphics/benches/primitives.rs
+++ b/embedded-graphics/benches/primitives.rs
@@ -1,0 +1,13 @@
+use criterion::*;
+use embedded_graphics::{prelude::*, primitives::Circle};
+
+fn circle(c: &mut Criterion) {
+    c.bench_function("circle", |b| {
+        let circle = Circle::new(Coord::new(10, 10), 10);
+
+        b.iter(|| circle.into_iter().collect())
+    });
+}
+
+criterion_group!(primitives, circle);
+criterion_main!(primitives);

--- a/embedded-graphics/benches/primitives.rs
+++ b/embedded-graphics/benches/primitives.rs
@@ -2,7 +2,7 @@ use criterion::*;
 use embedded_graphics::{
     pixelcolor::PixelColorU8,
     prelude::*,
-    primitives::{Circle, Line, Rect},
+    primitives::{Circle, Line, Rect, Triangle},
 };
 
 fn filled_circle(c: &mut Criterion) {
@@ -43,5 +43,32 @@ fn line(c: &mut Criterion) {
     });
 }
 
-criterion_group!(primitives, filled_circle, filled_rect, empty_rect, line);
+fn triangle(c: &mut Criterion) {
+    c.bench_function("triangle", |b| {
+        let object: Triangle<PixelColorU8> =
+            Triangle::new(Coord::new(5, 10), Coord::new(15, 20), Coord::new(5, 20));
+
+        b.iter(|| object.into_iter().collect::<Vec<Pixel<PixelColorU8>>>())
+    });
+}
+
+fn filled_triangle(c: &mut Criterion) {
+    c.bench_function("filled_triangle", |b| {
+        let object: Triangle<PixelColorU8> =
+            Triangle::new(Coord::new(5, 10), Coord::new(15, 20), Coord::new(5, 20))
+                .with_fill(Some(1u8.into()));
+
+        b.iter(|| object.into_iter().collect::<Vec<Pixel<PixelColorU8>>>())
+    });
+}
+
+criterion_group!(
+    primitives,
+    filled_circle,
+    filled_rect,
+    empty_rect,
+    line,
+    triangle,
+    filled_triangle
+);
 criterion_main!(primitives);

--- a/simulator/Cargo.toml
+++ b/simulator/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
-sdl2 = "0.31.0"
+sdl2 = "0.32.1"
 
 [dependencies.embedded-graphics]
 path = "../embedded-graphics"

--- a/tinybmp/Cargo.toml
+++ b/tinybmp/Cargo.toml
@@ -16,5 +16,5 @@ exclude = [
 ]
 
 [dependencies.nom]
-version = "4.2.1"
+version = "4.2.2"
 default-features = false


### PR DESCRIPTION
Adds Criterion benchmarks for primitives, a couple of fonts and BMP images. These probably won't be representative of performance on a real device, but Criterion works on deltas anyway. The same delta on a desktop machine will hopefully yield a change in the same direction on a microcontroller :crossed_fingers: 