### PR TITLE
Simulator themes

### DIFF
--- a/simulator/examples/fill.rs
+++ b/simulator/examples/fill.rs
@@ -8,12 +8,12 @@ use embedded_graphics::coord::Coord;
 use embedded_graphics::prelude::*;
 use embedded_graphics::primitives::{Circle, Rect};
 
-use simulator::Display;
+use simulator::DisplayBuilder;
 
 static CIRCLE_SIZE: i32 = 32;
 
 fn main() {
-    let mut display = Display::new(256, 128);
+    let mut display = DisplayBuilder::new().size(256, 128).scale(2).build();
 
     display.draw(
         Circle::new(Coord::new(CIRCLE_SIZE, CIRCLE_SIZE), CIRCLE_SIZE as u32)

--- a/simulator/examples/fill.rs
+++ b/simulator/examples/fill.rs
@@ -13,7 +13,7 @@ use simulator::Display;
 static CIRCLE_SIZE: i32 = 32;
 
 fn main() {
-    let mut display = Display::new();
+    let mut display = Display::new(256, 128);
 
     display.draw(
         Circle::new(Coord::new(CIRCLE_SIZE, CIRCLE_SIZE), CIRCLE_SIZE as u32)

--- a/simulator/examples/fonts.rs
+++ b/simulator/examples/fonts.rs
@@ -11,7 +11,7 @@ use embedded_graphics::prelude::*;
 use simulator::Display;
 
 fn main() {
-    let mut display = Display::new();
+    let mut display = Display::new(256, 128);
 
     // Show smallest font with black font on white background (default value for fonts)
     display.draw(

--- a/simulator/examples/fonts.rs
+++ b/simulator/examples/fonts.rs
@@ -8,10 +8,10 @@ use embedded_graphics::coord::Coord;
 use embedded_graphics::fonts::{Font12x16, Font6x12, Font6x8, Font8x16};
 use embedded_graphics::prelude::*;
 
-use simulator::Display;
+use simulator::DisplayBuilder;
 
 fn main() {
-    let mut display = Display::new(256, 128);
+    let mut display = DisplayBuilder::new().size(256, 128).build();
 
     // Show smallest font with black font on white background (default value for fonts)
     display.draw(

--- a/simulator/examples/hello.rs
+++ b/simulator/examples/hello.rs
@@ -12,7 +12,7 @@ use embedded_graphics::primitives::{Circle, Line};
 use simulator::Display;
 
 fn main() {
-    let mut display = Display::new();
+    let mut display = Display::new(256, 256);
 
     // Outline
     display.draw(

--- a/simulator/examples/hello.rs
+++ b/simulator/examples/hello.rs
@@ -9,10 +9,10 @@ use embedded_graphics::fonts::Font6x8;
 use embedded_graphics::prelude::*;
 use embedded_graphics::primitives::{Circle, Line};
 
-use simulator::Display;
+use simulator::DisplayBuilder;
 
 fn main() {
-    let mut display = Display::new(256, 256);
+    let mut display = DisplayBuilder::new().build();
 
     // Outline
     display.draw(

--- a/simulator/examples/hello.rs
+++ b/simulator/examples/hello.rs
@@ -9,10 +9,10 @@ use embedded_graphics::fonts::Font6x8;
 use embedded_graphics::prelude::*;
 use embedded_graphics::primitives::{Circle, Line};
 
-use simulator::DisplayBuilder;
+use simulator::{DisplayBuilder, DisplayTheme};
 
 fn main() {
-    let mut display = DisplayBuilder::new().build();
+    let mut display = DisplayBuilder::new().theme(DisplayTheme::OledBlue).build();
 
     // Outline
     display.draw(

--- a/simulator/examples/offscreen.rs
+++ b/simulator/examples/offscreen.rs
@@ -11,7 +11,7 @@ use embedded_graphics::primitives::Rect;
 use simulator::Display;
 
 fn main() {
-    let mut display = Display::new();
+    let mut display = Display::new(32, 32);
 
     // Outline
     display.draw(

--- a/simulator/examples/offscreen.rs
+++ b/simulator/examples/offscreen.rs
@@ -8,10 +8,10 @@ use embedded_graphics::coord::Coord;
 use embedded_graphics::prelude::*;
 use embedded_graphics::primitives::Rect;
 
-use simulator::Display;
+use simulator::DisplayBuilder;
 
 fn main() {
-    let mut display = Display::new(32, 32);
+    let mut display = DisplayBuilder::new().size(32, 32).scale(4).build();
 
     // Outline
     display.draw(

--- a/simulator/examples/stroke.rs
+++ b/simulator/examples/stroke.rs
@@ -13,7 +13,7 @@ use simulator::{Display, SimPixelColor};
 const PADDING: i32 = 16;
 
 fn main() {
-    let mut display = Display::new();
+    let mut display = Display::new(256, 256);
 
     let circ = Circle::new(Coord::new(32, 32), 32).with_stroke(Some(SimPixelColor(true)));
 

--- a/simulator/examples/stroke.rs
+++ b/simulator/examples/stroke.rs
@@ -8,12 +8,12 @@ use embedded_graphics::coord::Coord;
 use embedded_graphics::prelude::*;
 use embedded_graphics::primitives::{Circle, Line, Rect};
 
-use simulator::{Display, SimPixelColor};
+use simulator::{DisplayBuilder, SimPixelColor};
 
 const PADDING: i32 = 16;
 
 fn main() {
-    let mut display = Display::new(256, 256);
+    let mut display = DisplayBuilder::new().build();
 
     let circ = Circle::new(Coord::new(32, 32), 32).with_stroke(Some(SimPixelColor(true)));
 

--- a/simulator/src/lib.rs
+++ b/simulator/src/lib.rs
@@ -154,7 +154,7 @@ impl DisplayBuilder {
             DisplayTheme::LcdWhite => {
                 self.background_color(245, 245, 245);
                 self.pixel_color(32, 32, 32);
-            },
+            }
             DisplayTheme::LcdGreen => {
                 self.background_color(120, 185, 50);
                 self.pixel_color(32, 32, 32);
@@ -190,7 +190,7 @@ impl DisplayBuilder {
         let video_subsystem = sdl_context.video().unwrap();
 
         let window_width = self.width * self.scale + (self.width - 1) * self.pixel_spacing;
-        let window_height = self.height * self.scale + (self.height - 1 ) * self.pixel_spacing;
+        let window_height = self.height * self.scale + (self.height - 1) * self.pixel_spacing;
 
         let window = video_subsystem
             .window(


### PR DESCRIPTION
The current 1:1 pixel scaling of the simulator makes it hard to use for typical monochrome OLED or LCD module resolutions (especially on HiDPI displays).

This PR adds the ability to scale the pixels and add spacing between them. It additionally adds some basic themes with colors and default scaling for different common types of OLED and LCD modules.