### PR TITLE
Fix off-by-one error for off-screen fonts

### DIFF
--- a/embedded-graphics/src/fonts/font6x12.rs
+++ b/embedded-graphics/src/fonts/font6x12.rs
@@ -30,6 +30,7 @@ mod tests {
     use crate::drawable::Dimensions;
     use crate::fonts::Font;
     use crate::mock_display::Display;
+    use crate::pixelcolor::PixelColorU16;
     use crate::style::Style;
     use crate::style::WithStyle;
     use crate::transform::Transform;
@@ -223,5 +224,29 @@ mod tests {
                 .into_iter(),
         );
         assert_eq!(display, two_question_marks);
+    }
+
+    #[test]
+    fn negative_y_no_infinite_loop() {
+        let text: Font6x12<PixelColorU16> = Font6x12::render_str("Testing string")
+            .with_stroke(Some(0xF1FA_u16.into()))
+            .translate(Coord::new(0, -12));
+
+        let mut it = text.into_iter();
+
+        // Font is completely off the top edge of the screen; no pixels should be rendered
+        assert_eq!(it.next(), None);
+    }
+
+    #[test]
+    fn negative_x_no_infinite_loop() {
+        let text: Font6x12<PixelColorU16> = Font6x12::render_str("A")
+            .with_stroke(Some(0xF1FA_u16.into()))
+            .translate(Coord::new(-6, 0));
+
+        let mut it = text.into_iter();
+
+        // Font is completely off the left edge of the screen; no pixels should be rendered
+        assert_eq!(it.next(), None);
     }
 }

--- a/embedded-graphics/src/fonts/font_builder.rs
+++ b/embedded-graphics/src/fonts/font_builder.rs
@@ -182,8 +182,8 @@ where
     type Item = Pixel<C>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.pos[0] + (self.text.len() as i32 * Conf::CHAR_WIDTH as i32) < 0
-            || self.pos[1] + (Conf::CHAR_HEIGHT as i32) < 0
+        if self.pos[0] + (self.text.len() as i32 * Conf::CHAR_WIDTH as i32) <= 0
+            || self.pos[1] + (Conf::CHAR_HEIGHT as i32) <= 0
         {
             return None;
         }


### PR DESCRIPTION
Closes #81 

If the font is translated by exactly the negative of its font height, the guard checking whether any pixels should be returned was failing, meaning the iterator spins indefinitely. This PR fixes that off-by-one error.

@MabezDev can you give this a test in your application and let me know if it fixes #81 properly? I'll wait to merge based on your feedback.