### PR TITLE
Require IntoIterator trait instead of Iterator

### DIFF
--- a/embedded-graphics/src/lib.rs
+++ b/embedded-graphics/src/lib.rs
@@ -70,5 +70,5 @@ where
     /// Draw an object from an iterator over its pixels
     fn draw<T>(&mut self, item_pixels: T)
     where
-        T: Iterator<Item = drawable::Pixel<C>>;
+        T: IntoIterator<Item = drawable::Pixel<C>>;
 }

--- a/embedded-graphics/src/mock_display.rs
+++ b/embedded-graphics/src/mock_display.rs
@@ -13,7 +13,7 @@ impl Default for Display {
 impl Drawing<u8> for Display {
     fn draw<T>(&mut self, item_pixels: T)
     where
-        T: Iterator<Item = Pixel<u8>>,
+        T: IntoIterator<Item = Pixel<u8>>,
     {
         for Pixel(coord, color) in item_pixels {
             if coord[0] >= 24 || coord[1] >= 16 {

--- a/embedded-graphics/tests/chaining.rs
+++ b/embedded-graphics/tests/chaining.rs
@@ -21,7 +21,7 @@ impl From<u8> for TestPixelColor {
 impl Drawing<TestPixelColor> for FakeDisplay {
     fn draw<T>(&mut self, _item_pixels: T)
     where
-        T: Iterator<Item = Pixel<TestPixelColor>>,
+        T: IntoIterator<Item = Pixel<TestPixelColor>>,
     {
         // Noop
     }

--- a/embedded-graphics/tests/chaining.rs
+++ b/embedded-graphics/tests/chaining.rs
@@ -2,7 +2,7 @@ extern crate embedded_graphics;
 
 use embedded_graphics::coord::Coord;
 use embedded_graphics::prelude::*;
-use embedded_graphics::primitives::{Circle, Rect};
+use embedded_graphics::primitives::{Circle, Line, Rect};
 use embedded_graphics::Drawing;
 
 struct FakeDisplay {}
@@ -34,6 +34,27 @@ fn it_supports_chaining() {
     let chained = Rect::new(Coord::new(0, 0), Coord::new(1, 1))
         .into_iter()
         .chain(Circle::new(Coord::new(2, 2), 1).into_iter());
+
+    disp.draw(chained);
+}
+
+fn multi() -> impl Iterator<Item = Pixel<TestPixelColor>> {
+    let line = Line::new(Coord::new(0, 1), Coord::new(2, 3))
+        .with_stroke(Some(1u8.into()))
+        .into_iter();
+
+    let circle = Circle::new(Coord::new(5, 5), 3)
+        .with_stroke(Some(1u8.into()))
+        .into_iter();
+
+    line.chain(circle)
+}
+
+#[test]
+fn return_from_fn() {
+    let mut disp = FakeDisplay {};
+
+    let chained = multi();
 
     disp.draw(chained);
 }

--- a/simulator/src/lib.rs
+++ b/simulator/src/lib.rs
@@ -78,7 +78,7 @@ impl Display {
 impl Drawing<SimPixelColor> for Display {
     fn draw<T>(&mut self, item_pixels: T)
     where
-        T: Iterator<Item = Pixel<SimPixelColor>>,
+        T: IntoIterator<Item = Pixel<SimPixelColor>>,
     {
         for Pixel(coord, color) in item_pixels {
             let x = coord[0] as usize;


### PR DESCRIPTION
This PR is spurred by https://github.com/jamwaffles/embedded-graphics/issues/80#issuecomment-475977383 and should make e_g a little more ergonomic to use by removing the `.into_iter()` call requirement.

This is a breaking change for e_g implementors, so will require a semver minor version bump.

Closes #80 
Closes #74 