### PR TITLE
Fix IntoIterator implementations

### DIFF
--- a/embedded-graphics/src/drawable.rs
+++ b/embedded-graphics/src/drawable.rs
@@ -9,7 +9,7 @@ use crate::unsignedcoord::UnsignedCoord;
 pub struct Pixel<C: PixelColor>(pub UnsignedCoord, pub C);
 
 /// Marks an object as "drawable". Must be implemented for all graphics objects
-pub trait Drawable: IntoIterator {}
+pub trait Drawable {}
 
 /// Adds the ability to get the dimensions/position of a graphics object
 ///

--- a/embedded-graphics/src/drawable.rs
+++ b/embedded-graphics/src/drawable.rs
@@ -9,7 +9,7 @@ use crate::unsignedcoord::UnsignedCoord;
 pub struct Pixel<C: PixelColor>(pub UnsignedCoord, pub C);
 
 /// Marks an object as "drawable". Must be implemented for all graphics objects
-pub trait Drawable {}
+pub trait Drawable: IntoIterator {}
 
 /// Adds the ability to get the dimensions/position of a graphics object
 ///

--- a/embedded-graphics/src/fonts/font12x16.rs
+++ b/embedded-graphics/src/fonts/font12x16.rs
@@ -71,11 +71,7 @@ mod tests {
     #[test]
     fn correct_m() {
         let mut display = Display::default();
-        display.draw(
-            Font12x16::render_str("Mm")
-                .with_stroke(Some(1u8.into()))
-                .into_iter(),
-        );
+        display.draw(Font12x16::render_str("Mm").with_stroke(Some(1u8.into())));
 
         assert_eq!(
             display,
@@ -103,11 +99,7 @@ mod tests {
     #[test]
     fn correct_ascii_borders() {
         let mut display = Display::default();
-        display.draw(
-            Font12x16::render_str(" ~")
-                .with_stroke(Some(1u8.into()))
-                .into_iter(),
-        );
+        display.draw(Font12x16::render_str(" ~").with_stroke(Some(1u8.into())));
 
         assert_eq!(
             display,
@@ -135,11 +127,7 @@ mod tests {
     #[test]
     fn correct_dollar_y() {
         let mut display = Display::default();
-        display.draw(
-            Font12x16::render_str("$y")
-                .with_stroke(Some(1u8.into()))
-                .into_iter(),
-        );
+        display.draw(Font12x16::render_str("$y").with_stroke(Some(1u8.into())));
 
         assert_eq!(
             display,
@@ -189,35 +177,19 @@ mod tests {
         );
 
         let mut display = Display::default();
-        display.draw(
-            Font12x16::render_str("\0\n")
-                .with_stroke(Some(1u8.into()))
-                .into_iter(),
-        );
+        display.draw(Font12x16::render_str("\0\n").with_stroke(Some(1u8.into())));
         assert_eq!(display, two_question_marks);
 
         let mut display = Display::default();
-        display.draw(
-            Font12x16::render_str("\x7F\u{A0}")
-                .with_stroke(Some(1u8.into()))
-                .into_iter(),
-        );
+        display.draw(Font12x16::render_str("\x7F\u{A0}").with_stroke(Some(1u8.into())));
         assert_eq!(display, two_question_marks);
 
         let mut display = Display::default();
-        display.draw(
-            Font12x16::render_str("¡ÿ")
-                .with_stroke(Some(1u8.into()))
-                .into_iter(),
-        );
+        display.draw(Font12x16::render_str("¡ÿ").with_stroke(Some(1u8.into())));
         assert_eq!(display, two_question_marks);
 
         let mut display = Display::default();
-        display.draw(
-            Font12x16::render_str("Ā💣")
-                .with_stroke(Some(1u8.into()))
-                .into_iter(),
-        );
+        display.draw(Font12x16::render_str("Ā💣").with_stroke(Some(1u8.into())));
         assert_eq!(display, two_question_marks);
     }
 }

--- a/embedded-graphics/src/fonts/font6x12.rs
+++ b/embedded-graphics/src/fonts/font6x12.rs
@@ -72,11 +72,7 @@ mod tests {
     #[test]
     fn correct_m() {
         let mut display = Display::default();
-        display.draw(
-            Font6x12::render_str("Mm")
-                .with_stroke(Some(1u8.into()))
-                .into_iter(),
-        );
+        display.draw(Font6x12::render_str("Mm").with_stroke(Some(1u8.into())));
 
         assert_eq!(
             display,
@@ -105,11 +101,7 @@ mod tests {
     #[test]
     fn correct_ascii_borders() {
         let mut display = Display::default();
-        display.draw(
-            Font6x12::render_str(" ~")
-                .with_stroke(Some(1u8.into()))
-                .into_iter(),
-        );
+        display.draw(Font6x12::render_str(" ~").with_stroke(Some(1u8.into())));
 
         assert_eq!(
             display,
@@ -138,11 +130,7 @@ mod tests {
     #[test]
     fn correct_dollar_y() {
         let mut display = Display::default();
-        display.draw(
-            Font6x12::render_str("$y")
-                .with_stroke(Some(1u8.into()))
-                .into_iter(),
-        );
+        display.draw(Font6x12::render_str("$y").with_stroke(Some(1u8.into())));
 
         assert_eq!(
             display,
@@ -194,35 +182,19 @@ mod tests {
         );
 
         let mut display = Display::default();
-        display.draw(
-            Font6x12::render_str("\0\n")
-                .with_stroke(Some(1u8.into()))
-                .into_iter(),
-        );
+        display.draw(Font6x12::render_str("\0\n").with_stroke(Some(1u8.into())));
         assert_eq!(display, two_question_marks);
 
         let mut display = Display::default();
-        display.draw(
-            Font6x12::render_str("\x7F\u{A0}")
-                .with_stroke(Some(1u8.into()))
-                .into_iter(),
-        );
+        display.draw(Font6x12::render_str("\x7F\u{A0}").with_stroke(Some(1u8.into())));
         assert_eq!(display, two_question_marks);
 
         let mut display = Display::default();
-        display.draw(
-            Font6x12::render_str("¡ÿ")
-                .with_stroke(Some(1u8.into()))
-                .into_iter(),
-        );
+        display.draw(Font6x12::render_str("¡ÿ").with_stroke(Some(1u8.into())));
         assert_eq!(display, two_question_marks);
 
         let mut display = Display::default();
-        display.draw(
-            Font6x12::render_str("Ā💣")
-                .with_stroke(Some(1u8.into()))
-                .into_iter(),
-        );
+        display.draw(Font6x12::render_str("Ā💣").with_stroke(Some(1u8.into())));
         assert_eq!(display, two_question_marks);
     }
 

--- a/embedded-graphics/src/fonts/font6x8.rs
+++ b/embedded-graphics/src/fonts/font6x8.rs
@@ -83,29 +83,20 @@ mod tests {
     #[test]
     fn default_style() {
         let mut display_default = Display::default();
-        display_default.draw(Font6x8::render_str("Mm").into_iter());
+        display_default.draw(Font6x8::render_str("Mm"));
 
         let mut display_full_style = Display::default();
         display_full_style.draw(
             Font6x8::render_str("Mm")
                 .with_stroke(Some(1u8.into()))
-                .with_fill(Some(0u8.into()))
-                .into_iter(),
+                .with_fill(Some(0u8.into())),
         );
 
         let mut display_stroke = Display::default();
-        display_stroke.draw(
-            Font6x8::render_str("Mm")
-                .with_stroke(Some(1u8.into()))
-                .into_iter(),
-        );
+        display_stroke.draw(Font6x8::render_str("Mm").with_stroke(Some(1u8.into())));
 
         let mut display_fill = Display::default();
-        display_fill.draw(
-            Font6x8::render_str("Mm")
-                .with_fill(Some(0u8.into()))
-                .into_iter(),
-        );
+        display_fill.draw(Font6x8::render_str("Mm").with_fill(Some(0u8.into())));
 
         assert_eq!(display_default, display_full_style);
         assert_eq!(display_default, display_stroke);
@@ -115,11 +106,7 @@ mod tests {
     #[test]
     fn correct_m() {
         let mut display = Display::default();
-        display.draw(
-            Font6x8::render_str("Mm")
-                .with_stroke(Some(1u8.into()))
-                .into_iter(),
-        );
+        display.draw(Font6x8::render_str("Mm").with_stroke(Some(1u8.into())));
 
         assert_eq!(
             display,
@@ -151,8 +138,7 @@ mod tests {
         display.draw(
             Font6x8::render_str("Mm")
                 .with_stroke(Some(0u8.into()))
-                .with_fill(Some(1u8.into()))
-                .into_iter(),
+                .with_fill(Some(1u8.into())),
         );
 
         assert_eq!(
@@ -186,16 +172,14 @@ mod tests {
         display_inverse.draw(
             Font6x8::render_str("Mm")
                 .with_stroke(Some(0u8.into()))
-                .with_fill(Some(1u8.into()))
-                .into_iter(),
+                .with_fill(Some(1u8.into())),
         );
 
         let mut display_normal = Display::default();
         display_normal.draw(
             Font6x8::render_str("Mm")
                 .with_stroke(Some(1u8.into()))
-                .with_fill(Some(0u8.into()))
-                .into_iter(),
+                .with_fill(Some(0u8.into())),
         );
 
         for (x, y) in display_inverse.0[0..8]
@@ -211,11 +195,7 @@ mod tests {
     #[test]
     fn correct_ascii_borders() {
         let mut display = Display::default();
-        display.draw(
-            Font6x8::render_str(" ~")
-                .with_stroke(Some(1u8.into()))
-                .into_iter(),
-        );
+        display.draw(Font6x8::render_str(" ~").with_stroke(Some(1u8.into())));
 
         assert_eq!(
             display,
@@ -244,11 +224,7 @@ mod tests {
     #[test]
     fn correct_dollar_y() {
         let mut display = Display::default();
-        display.draw(
-            Font6x8::render_str("$y")
-                .with_stroke(Some(1u8.into()))
-                .into_iter(),
-        );
+        display.draw(Font6x8::render_str("$y").with_stroke(Some(1u8.into())));
 
         assert_eq!(
             display,
@@ -277,11 +253,7 @@ mod tests {
     #[test]
     fn correct_latin1() {
         let mut display = Display::default();
-        display.draw(
-            Font6x8::render_str("¡ÿ")
-                .with_stroke(Some(1u8.into()))
-                .into_iter(),
-        );
+        display.draw(Font6x8::render_str("¡ÿ").with_stroke(Some(1u8.into())));
 
         assert_eq!(
             display,
@@ -333,27 +305,15 @@ mod tests {
         );
 
         let mut display = Display::default();
-        display.draw(
-            Font6x8::render_str("\0\n")
-                .with_stroke(Some(1u8.into()))
-                .into_iter(),
-        );
+        display.draw(Font6x8::render_str("\0\n").with_stroke(Some(1u8.into())));
         assert_eq!(display, two_question_marks);
 
         let mut display = Display::default();
-        display.draw(
-            Font6x8::render_str("\x7F\u{A0}")
-                .with_stroke(Some(1u8.into()))
-                .into_iter(),
-        );
+        display.draw(Font6x8::render_str("\x7F\u{A0}").with_stroke(Some(1u8.into())));
         assert_eq!(display, two_question_marks);
 
         let mut display = Display::default();
-        display.draw(
-            Font6x8::render_str("Ā💣")
-                .with_stroke(Some(1u8.into()))
-                .into_iter(),
-        );
+        display.draw(Font6x8::render_str("Ā💣").with_stroke(Some(1u8.into())));
         assert_eq!(display, two_question_marks);
     }
 }

--- a/embedded-graphics/src/fonts/font8x16.rs
+++ b/embedded-graphics/src/fonts/font8x16.rs
@@ -74,11 +74,7 @@ mod tests {
     #[test]
     fn correct_m() {
         let mut display = Display::default();
-        display.draw(
-            Font8x16::render_str("Mm")
-                .with_stroke(Some(1u8.into()))
-                .into_iter(),
-        );
+        display.draw(Font8x16::render_str("Mm").with_stroke(Some(1u8.into())));
 
         assert_eq!(
             display,
@@ -106,11 +102,7 @@ mod tests {
     #[test]
     fn correct_ascii_borders() {
         let mut display = Display::default();
-        display.draw(
-            Font8x16::render_str(" ~")
-                .with_stroke(Some(1u8.into()))
-                .into_iter(),
-        );
+        display.draw(Font8x16::render_str(" ~").with_stroke(Some(1u8.into())));
 
         assert_eq!(
             display,
@@ -138,11 +130,7 @@ mod tests {
     #[test]
     fn correct_dollar_y() {
         let mut display = Display::default();
-        display.draw(
-            Font8x16::render_str("$y")
-                .with_stroke(Some(1u8.into()))
-                .into_iter(),
-        );
+        display.draw(Font8x16::render_str("$y").with_stroke(Some(1u8.into())));
 
         assert_eq!(
             display,
@@ -170,11 +158,7 @@ mod tests {
     #[test]
     fn correct_latin1() {
         let mut display = Display::default();
-        display.draw(
-            Font8x16::render_str("¡ÿ")
-                .with_stroke(Some(1u8.into()))
-                .into_iter(),
-        );
+        display.draw(Font8x16::render_str("¡ÿ").with_stroke(Some(1u8.into())));
 
         assert_eq!(
             display,
@@ -224,27 +208,15 @@ mod tests {
         );
 
         let mut display = Display::default();
-        display.draw(
-            Font8x16::render_str("\0\n")
-                .with_stroke(Some(1u8.into()))
-                .into_iter(),
-        );
+        display.draw(Font8x16::render_str("\0\n").with_stroke(Some(1u8.into())));
         assert_eq!(display, two_question_marks);
 
         let mut display = Display::default();
-        display.draw(
-            Font8x16::render_str("\x7F\u{A0}")
-                .with_stroke(Some(1u8.into()))
-                .into_iter(),
-        );
+        display.draw(Font8x16::render_str("\x7F\u{A0}").with_stroke(Some(1u8.into())));
         assert_eq!(display, two_question_marks);
 
         let mut display = Display::default();
-        display.draw(
-            Font8x16::render_str("Ā💣")
-                .with_stroke(Some(1u8.into()))
-                .into_iter(),
-        );
+        display.draw(Font8x16::render_str("Ā💣").with_stroke(Some(1u8.into())));
         assert_eq!(display, two_question_marks);
     }
 }

--- a/embedded-graphics/src/fonts/font_builder.rs
+++ b/embedded-graphics/src/fonts/font_builder.rs
@@ -152,6 +152,28 @@ where
     _conf: PhantomData<Conf>,
 }
 
+impl<'a, C: 'a, Conf: 'a> IntoIterator for FontBuilder<'a, C, Conf>
+where
+    C: PixelColor,
+    Conf: FontBuilderConf,
+{
+    type Item = Pixel<C>;
+    type IntoIter = FontBuilderIterator<'a, C, Conf>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        Self::IntoIter {
+            current_char: self.text.chars().next(),
+            idx: 0,
+            text: self.text,
+            char_walk_x: 0,
+            char_walk_y: 0,
+            pos: self.pos,
+            style: self.style,
+            _conf: Default::default(),
+        }
+    }
+}
+
 impl<'a, C, Conf> IntoIterator for &'a FontBuilder<'a, C, Conf>
 where
     C: PixelColor,
@@ -250,7 +272,12 @@ where
     }
 }
 
-impl<'a, C, Conf> Drawable for FontBuilder<'a, C, Conf> where C: PixelColor {}
+impl<'a, C: 'a, Conf: 'a> Drawable for FontBuilder<'a, C, Conf>
+where
+    C: PixelColor,
+    Conf: FontBuilderConf,
+{
+}
 
 impl<'a, C, Conf> Transform for FontBuilder<'a, C, Conf>
 where

--- a/embedded-graphics/src/fonts/mod.rs
+++ b/embedded-graphics/src/fonts/mod.rs
@@ -25,15 +25,15 @@ where
     /// Defaults to 1u8 for stroke_color and 0u8 for fill_color
     ///
     /// ```rust
-    /// # use embedded_graphics::fonts::{Font, Font6x8};
-    /// # use embedded_graphics::prelude::*;
-    /// # use embedded_graphics::pixelcolor::PixelColorU8;
-    /// #
+    /// use embedded_graphics::prelude::*;
+    /// use embedded_graphics::fonts::Font6x8;
+    /// use embedded_graphics::pixelcolor::PixelColorU8;
+    ///
     /// # struct Display {}
     /// # impl Display {
     /// #     pub fn draw<T>(&self, item_pixels: T) -> Result<(), ()>
     /// #     where
-    /// #         T: Iterator<Item = Pixel<PixelColorU8>>,
+    /// #         T: IntoIterator<Item = Pixel<PixelColorU8>>,
     /// #     {
     /// #         Ok(())
     /// #     }
@@ -45,7 +45,7 @@ where
     ///     let text = Font6x8::render_str("Hello world")
     ///         .with_style(Style::with_stroke(1u8.into()));
     ///
-    ///     disp.draw(text.into_iter());
+    ///     disp.draw(text);
     /// }
     /// ```
     fn render_str(chars: &'a str) -> Self;

--- a/embedded-graphics/src/primitives/circle.rs
+++ b/embedded-graphics/src/primitives/circle.rs
@@ -87,6 +87,18 @@ where
     }
 }
 
+impl<C> IntoIterator for Circle<C>
+where
+    C: PixelColor,
+{
+    type Item = Pixel<C>;
+    type IntoIter = CircleIterator<C>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        (&self).into_iter()
+    }
+}
+
 impl<'a, C> IntoIterator for &'a Circle<C>
 where
     C: PixelColor,

--- a/embedded-graphics/src/primitives/line.rs
+++ b/embedded-graphics/src/primitives/line.rs
@@ -88,6 +88,18 @@ where
     }
 }
 
+impl<C> IntoIterator for Line<C>
+where
+    C: PixelColor,
+{
+    type Item = Pixel<C>;
+    type IntoIter = LineIterator<C>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        (&self).into_iter()
+    }
+}
+
 impl<'a, C: PixelColor> IntoIterator for &'a Line<C> {
     type Item = Pixel<C>;
     type IntoIter = LineIterator<C>;

--- a/embedded-graphics/src/primitives/rect.rs
+++ b/embedded-graphics/src/primitives/rect.rs
@@ -85,6 +85,18 @@ where
     }
 }
 
+impl<C> IntoIterator for Rect<C>
+where
+    C: PixelColor,
+{
+    type Item = Pixel<C>;
+    type IntoIter = RectIterator<C>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        (&self).into_iter()
+    }
+}
+
 impl<'a, C> IntoIterator for &'a Rect<C>
 where
     C: PixelColor,

--- a/embedded-graphics/src/primitives/triangle.rs
+++ b/embedded-graphics/src/primitives/triangle.rs
@@ -134,6 +134,18 @@ fn sort_yx(p1: Coord, p2: Coord, p3: Coord) -> (Coord, Coord, Coord) {
     (y1, y2, y3)
 }
 
+impl<C> IntoIterator for Triangle<C>
+where
+    C: PixelColor,
+{
+    type Item = Pixel<C>;
+    type IntoIter = TriangleIterator<C>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        (&self).into_iter()
+    }
+}
+
 impl<'a, C> IntoIterator for &'a Triangle<C>
 where
     C: PixelColor,

--- a/simulator/examples/bmp.rs
+++ b/simulator/examples/bmp.rs
@@ -25,7 +25,7 @@ fn main() {
 
     let mut display = DisplayBuilder::new().size(304, 128).scale(2).build();
 
-    display.draw(image.into_iter());
+    display.draw(&image);
 
     loop {
         let end = display.run_once();

--- a/simulator/examples/chaining.rs
+++ b/simulator/examples/chaining.rs
@@ -16,26 +16,16 @@ use simulator::{DisplayBuilder, DisplayTheme};
 fn main() {
     let mut display = DisplayBuilder::new().theme(DisplayTheme::OledBlue).build();
 
-    // FIXME: This has to be a separate variable due to usage of `.translate()` returning a new
-    // instance.
-    let text = Font6x8::render_str("Hello World!")
-        .with_stroke(Some(1u8.into()))
-        .translate(Coord::new(5, 50));
-
     let objects = Circle::new(Coord::new(64, 64), 64)
         .with_stroke(Some(1u8.into()))
         .into_iter()
+        .chain(Line::new(Coord::new(64, 64), Coord::new(0, 64)).with_stroke(Some(1u8.into())))
+        .chain(Line::new(Coord::new(64, 64), Coord::new(80, 80)).with_stroke(Some(1u8.into())))
         .chain(
-            Line::new(Coord::new(64, 64), Coord::new(0, 64))
+            Font6x8::render_str("Hello World!")
                 .with_stroke(Some(1u8.into()))
-                .into_iter(),
-        )
-        .chain(
-            Line::new(Coord::new(64, 64), Coord::new(80, 80))
-                .with_stroke(Some(1u8.into()))
-                .into_iter(),
-        )
-        .chain(text.into_iter());
+                .translate(Coord::new(5, 50)),
+        );
 
     display.draw(objects);
 

--- a/simulator/examples/fill.rs
+++ b/simulator/examples/fill.rs
@@ -17,24 +17,21 @@ fn main() {
 
     display.draw(
         Circle::new(Coord::new(CIRCLE_SIZE, CIRCLE_SIZE), CIRCLE_SIZE as u32)
-            .with_stroke(Some(1u8.into()))
-            .into_iter(),
+            .with_stroke(Some(1u8.into())),
     );
 
     display.draw(
         Circle::new(Coord::new(CIRCLE_SIZE, CIRCLE_SIZE), CIRCLE_SIZE as u32)
             .translate(Coord::new(16, 16))
             .with_stroke(Some(0u8.into()))
-            .with_fill(Some(1u8.into()))
-            .into_iter(),
+            .with_fill(Some(1u8.into())),
     );
 
     display.draw(
         Circle::new(Coord::new(CIRCLE_SIZE, CIRCLE_SIZE), CIRCLE_SIZE as u32)
             .translate(Coord::new(CIRCLE_SIZE, CIRCLE_SIZE))
             .with_stroke(Some(0u8.into()))
-            .with_fill(Some(0u8.into()))
-            .into_iter(),
+            .with_fill(Some(0u8.into())),
     );
 
     display.draw(
@@ -54,31 +51,27 @@ fn main() {
         Rect::new(Coord::new(0, 0), Coord::new(64, 64))
             .translate(Coord::new(96 + 32, 32))
             .with_stroke(Some(0u8.into()))
-            .with_fill(Some(0u8.into()))
-            .into_iter(),
+            .with_fill(Some(0u8.into())),
     );
 
     display.draw(
         Triangle::new(Coord::new(32, 0), Coord::new(0, 64), Coord::new(64, 64))
             .translate(Coord::new(96 * 2, 0))
-            .with_stroke(Some(1u8.into()))
-            .into_iter(),
+            .with_stroke(Some(1u8.into())),
     );
 
     display.draw(
         Triangle::new(Coord::new(32, 0), Coord::new(0, 64), Coord::new(64, 64))
             .translate(Coord::new(96 * 2 + 16, 16))
             .with_stroke(Some(0u8.into()))
-            .with_fill(Some(1u8.into()))
-            .into_iter(),
+            .with_fill(Some(1u8.into())),
     );
 
     display.draw(
         Triangle::new(Coord::new(32, 0), Coord::new(0, 64), Coord::new(64, 64))
             .translate(Coord::new(96 * 2 + 32, 32))
             .with_stroke(Some(0u8.into()))
-            .with_fill(Some(0u8.into()))
-            .into_iter(),
+            .with_fill(Some(0u8.into())),
     );
 
     loop {

--- a/simulator/examples/fill.rs
+++ b/simulator/examples/fill.rs
@@ -40,16 +40,14 @@ fn main() {
     display.draw(
         Rect::new(Coord::new(0, 0), Coord::new(64, 64))
             .translate(Coord::new(96, 0))
-            .with_stroke(Some(1u8.into()))
-            .into_iter(),
+            .with_stroke(Some(1u8.into())),
     );
 
     display.draw(
-        Rect::new(Coord::new(0, 0), Coord::new(64, 64))
+        &Rect::new(Coord::new(0, 0), Coord::new(64, 64))
             .translate(Coord::new(96 + 16, 16))
             .with_stroke(Some(0u8.into()))
-            .with_fill(Some(1u8.into()))
-            .into_iter(),
+            .with_fill(Some(1u8.into())),
     );
 
     display.draw(

--- a/simulator/examples/fonts.rs
+++ b/simulator/examples/fonts.rs
@@ -15,9 +15,7 @@ fn main() {
 
     // Show smallest font with black font on white background (default value for fonts)
     display.draw(
-        Font6x8::render_str("Hello World! - default style 6x8")
-            .translate(Coord::new(15, 15))
-            .into_iter(),
+        Font6x8::render_str("Hello World! - default style 6x8").translate(Coord::new(15, 15)),
     );
 
     // Show smallest font with white font on black background
@@ -25,30 +23,17 @@ fn main() {
         Font6x8::render_str("Hello World! - inverse 6x8")
             .with_stroke(Some(0u8.into()))
             .with_fill(Some(1u8.into()))
-            .translate(Coord::new(15, 30))
-            .into_iter(),
+            .translate(Coord::new(15, 30)),
     );
 
     // Show 6x12 Font
-    display.draw(
-        Font6x12::render_str("Hello 6x12!")
-            .translate(Coord::new(15, 45))
-            .into_iter(),
-    );
+    display.draw(Font6x12::render_str("Hello 6x12!").translate(Coord::new(15, 45)));
 
     // Show 8x16 Font
-    display.draw(
-        Font8x16::render_str("Hello 8x16!")
-            .translate(Coord::new(15, 70))
-            .into_iter(),
-    );
+    display.draw(Font8x16::render_str("Hello 8x16!").translate(Coord::new(15, 70)));
 
     // Show 12x16 Font
-    display.draw(
-        Font12x16::render_str("Hello 12x16!")
-            .translate(Coord::new(15, 95))
-            .into_iter(),
-    );
+    display.draw(Font12x16::render_str("Hello 12x16!").translate(Coord::new(15, 95)));
 
     loop {
         let end = display.run_once();

--- a/simulator/examples/hello.rs
+++ b/simulator/examples/hello.rs
@@ -15,29 +15,16 @@ fn main() {
     let mut display = DisplayBuilder::new().theme(DisplayTheme::OledBlue).build();
 
     // Outline
-    display.draw(
-        Circle::new(Coord::new(64, 64), 64)
-            .with_stroke(Some(1u8.into()))
-            .into_iter(),
-    );
+    display.draw(Circle::new(Coord::new(64, 64), 64).with_stroke(Some(1u8.into())));
 
     // Clock hands
-    display.draw(
-        Line::new(Coord::new(64, 64), Coord::new(0, 64))
-            .with_stroke(Some(1u8.into()))
-            .into_iter(),
-    );
-    display.draw(
-        Line::new(Coord::new(64, 64), Coord::new(80, 80))
-            .with_stroke(Some(1u8.into()))
-            .into_iter(),
-    );
+    display.draw(Line::new(Coord::new(64, 64), Coord::new(0, 64)).with_stroke(Some(1u8.into())));
+    display.draw(Line::new(Coord::new(64, 64), Coord::new(80, 80)).with_stroke(Some(1u8.into())));
 
     display.draw(
         Font6x8::render_str("Hello World!")
             .with_stroke(Some(1u8.into()))
-            .translate(Coord::new(5, 50))
-            .into_iter(),
+            .translate(Coord::new(5, 50)),
     );
 
     loop {

--- a/simulator/examples/offscreen.rs
+++ b/simulator/examples/offscreen.rs
@@ -17,8 +17,7 @@ fn main() {
     display.draw(
         Rect::new(Coord::new(0, 0), Coord::new(16, 16))
             .with_stroke(Some(1u8.into()))
-            .translate(Coord::new(-8, -8))
-            .into_iter(),
+            .translate(Coord::new(-8, -8)),
     );
 
     loop {

--- a/simulator/examples/stroke.rs
+++ b/simulator/examples/stroke.rs
@@ -44,19 +44,16 @@ fn main() {
             .into_iter()
             .chain(
                 rect.translate(Coord::new(0, 64 + PADDING))
-                    .with_stroke_width(3)
-                    .into_iter(),
+                    .with_stroke_width(3),
             )
             .chain(
                 line.translate(Coord::new(0, 64 + PADDING))
-                    .with_stroke_width(3)
-                    .into_iter(),
+                    .with_stroke_width(3),
             )
             .chain(
                 triangle
                     .translate(Coord::new(0, 64 + PADDING))
-                    .with_stroke_width(3)
-                    .into_iter(),
+                    .with_stroke_width(3),
             ),
     );
 
@@ -66,19 +63,16 @@ fn main() {
             .into_iter()
             .chain(
                 rect.translate(Coord::new(0, 128 + PADDING * 2))
-                    .with_stroke_width(10)
-                    .into_iter(),
+                    .with_stroke_width(10),
             )
             .chain(
                 line.translate(Coord::new(0, 128 + PADDING * 2))
-                    .with_stroke_width(10)
-                    .into_iter(),
+                    .with_stroke_width(10),
             )
             .chain(
                 triangle
                     .translate(Coord::new(0, 128 + PADDING * 2))
-                    .with_stroke_width(10)
-                    .into_iter(),
+                    .with_stroke_width(10),
             ),
     );
 

--- a/simulator/examples/tga.rs
+++ b/simulator/examples/tga.rs
@@ -25,7 +25,7 @@ fn main() {
 
     let mut display = DisplayBuilder::new().size(304, 128).scale(2).build();
 
-    display.draw(image.into_iter());
+    display.draw(&image);
 
     loop {
         let end = display.run_once();

--- a/simulator/examples/triangles.rs
+++ b/simulator/examples/triangles.rs
@@ -19,54 +19,47 @@ fn main() {
     display.draw(
         Triangle::new(Coord::new(0, 0), Coord::new(64, 10), Coord::new(15, 64))
             .translate(Coord::new(PAD, 0))
-            .with_stroke(Some(1u8.into()))
-            .into_iter(),
+            .with_stroke(Some(1u8.into())),
     );
 
     // flat top
     display.draw(
         Triangle::new(Coord::new(5, 0), Coord::new(30, 64), Coord::new(64, 0))
             .with_stroke(Some(1u8.into()))
-            .translate(Coord::new(64 + PAD, 0))
-            .into_iter(),
+            .translate(Coord::new(64 + PAD, 0)),
     );
 
     // flat left
     display.draw(
         Triangle::new(Coord::new(0, 0), Coord::new(0, 64), Coord::new(64, 30))
             .with_stroke(Some(1u8.into()))
-            .translate(Coord::new((64 + PAD) * 2, 0))
-            .into_iter(),
+            .translate(Coord::new((64 + PAD) * 2, 0)),
     );
 
     // flat bottom
     display.draw(
         Triangle::new(Coord::new(22, 0), Coord::new(0, 64), Coord::new(64, 64))
             .translate(Coord::new((64 + PAD) * 3, 0))
-            .with_stroke(Some(1u8.into()))
-            .into_iter(),
+            .with_stroke(Some(1u8.into())),
     );
 
     // flat right
     display.draw(
         Triangle::new(Coord::new(0, 22), Coord::new(64, 0), Coord::new(64, 64))
             .translate(Coord::new((64 + PAD) * 4, 0))
-            .with_stroke(Some(1u8.into()))
-            .into_iter(),
+            .with_stroke(Some(1u8.into())),
     );
 
     // draw filled above stroke, should not be visible
     display.draw(
         Triangle::new(Coord::new(0, 22), Coord::new(64, 0), Coord::new(64, 64))
             .translate(Coord::new((64 + PAD) * 5, 0))
-            .with_stroke(Some(1u8.into()))
-            .into_iter(),
+            .with_stroke(Some(1u8.into())),
     );
     display.draw(
         Triangle::new(Coord::new(0, 22), Coord::new(64, 0), Coord::new(64, 64))
             .translate(Coord::new((64 + PAD) * 5, 0))
-            .with_fill(Some(0u8.into()))
-            .into_iter(),
+            .with_fill(Some(0u8.into())),
     );
 
     loop {


### PR DESCRIPTION
Closes #25 
Closes #74 
Closes #99 - yes it can!

Much cleaner usage and chaining now:

```rust
let objects = Circle::new(Coord::new(64, 64), 64)
        .with_stroke(Some(1u8.into()))
        .into_iter()
        .chain(Line::new(Coord::new(64, 64), Coord::new(0, 64)).with_stroke(Some(1u8.into())))
        .chain(Line::new(Coord::new(64, 64), Coord::new(80, 80)).with_stroke(Some(1u8.into())))
        .chain(
            Font6x8::render_str("Hello World!")
                .with_stroke(Some(1u8.into()))
                .translate(Coord::new(5, 50)),
        );

    display.draw(objects);
```