### PR TITLE
Rename all .with_<prop>() to .<prop>() for styles

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,16 +34,7 @@ before_install:
   - pip install linkchecker --user
 
 script:
-  - cargo fmt --all -- --check
-  - cargo test --release
-  - cargo test --release --all-features
-  - cargo bench --no-run
-
-after_success:
-  - cargo doc --all-features
-  - linkchecker target/doc/embedded_graphics
-  - linkchecker target/doc/tinybmp
-  - linkchecker target/doc/tinytga
+  - ./build.sh
 
 cache: cargo
 before_cache:

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+cargo fmt --all -- --check
+cargo test --release
+cargo test --release --all-features
+cargo bench --no-run
+
+cargo doc --all-features
+linkchecker target/doc/embedded_graphics
+linkchecker target/doc/tinybmp
+linkchecker target/doc/tinytga

--- a/embedded-graphics/benches/fonts.rs
+++ b/embedded-graphics/benches/fonts.rs
@@ -8,7 +8,7 @@ use embedded_graphics::{
 fn font_6x8(c: &mut Criterion) {
     c.bench_function("font 6x8 Hello world!", |b| {
         let object: Font6x8<PixelColorU8> =
-            Font6x8::render_str("Hello world!").with_stroke(Some(10u8.into()));
+            Font6x8::render_str("Hello world!").stroke(Some(10u8.into()));
 
         b.iter(|| object.into_iter().collect::<Vec<Pixel<PixelColorU8>>>())
     });
@@ -17,7 +17,7 @@ fn font_6x8(c: &mut Criterion) {
 fn font_12x16(c: &mut Criterion) {
     c.bench_function("font 12x16 Hello world!", |b| {
         let object: Font12x16<PixelColorU8> =
-            Font12x16::render_str("Hello world!").with_stroke(Some(10u8.into()));
+            Font12x16::render_str("Hello world!").stroke(Some(10u8.into()));
 
         b.iter(|| object.into_iter().collect::<Vec<Pixel<PixelColorU8>>>())
     });

--- a/embedded-graphics/benches/primitives.rs
+++ b/embedded-graphics/benches/primitives.rs
@@ -8,8 +8,8 @@ use embedded_graphics::{
 fn filled_circle(c: &mut Criterion) {
     c.bench_function("filled circle", |b| {
         let object: Circle<PixelColorU8> = Circle::new(Coord::new(100, 100), 100)
-            .with_fill(Some(1u8.into()))
-            .with_stroke(Some(10u8.into()));
+            .fill(Some(1u8.into()))
+            .stroke(Some(10u8.into()));
 
         b.iter(|| object.into_iter().collect::<Vec<Pixel<PixelColorU8>>>())
     });
@@ -18,8 +18,8 @@ fn filled_circle(c: &mut Criterion) {
 fn filled_rect(c: &mut Criterion) {
     c.bench_function("filled rectangle", |b| {
         let object: Rect<PixelColorU8> = Rect::new(Coord::new(100, 100), Coord::new(200, 200))
-            .with_fill(Some(1u8.into()))
-            .with_stroke(Some(10u8.into()));
+            .fill(Some(1u8.into()))
+            .stroke(Some(10u8.into()));
 
         b.iter(|| object.into_iter().collect::<Vec<Pixel<PixelColorU8>>>())
     });
@@ -28,7 +28,7 @@ fn filled_rect(c: &mut Criterion) {
 fn empty_rect(c: &mut Criterion) {
     c.bench_function("unfilled rectangle", |b| {
         let object: Rect<PixelColorU8> =
-            Rect::new(Coord::new(100, 100), Coord::new(200, 200)).with_stroke(Some(10u8.into()));
+            Rect::new(Coord::new(100, 100), Coord::new(200, 200)).stroke(Some(10u8.into()));
 
         b.iter(|| object.into_iter().collect::<Vec<Pixel<PixelColorU8>>>())
     });
@@ -37,7 +37,7 @@ fn empty_rect(c: &mut Criterion) {
 fn line(c: &mut Criterion) {
     c.bench_function("line", |b| {
         let object: Line<PixelColorU8> =
-            Line::new(Coord::new(100, 100), Coord::new(200, 200)).with_stroke(Some(10u8.into()));
+            Line::new(Coord::new(100, 100), Coord::new(200, 200)).stroke(Some(10u8.into()));
 
         b.iter(|| object.into_iter().collect::<Vec<Pixel<PixelColorU8>>>())
     });
@@ -56,7 +56,7 @@ fn filled_triangle(c: &mut Criterion) {
     c.bench_function("filled_triangle", |b| {
         let object: Triangle<PixelColorU8> =
             Triangle::new(Coord::new(5, 10), Coord::new(15, 20), Coord::new(5, 20))
-                .with_fill(Some(1u8.into()));
+                .fill(Some(1u8.into()));
 
         b.iter(|| object.into_iter().collect::<Vec<Pixel<PixelColorU8>>>())
     });

--- a/embedded-graphics/src/fonts/font12x16.rs
+++ b/embedded-graphics/src/fonts/font12x16.rs
@@ -40,7 +40,7 @@ mod tests {
     fn off_screen_text_does_not_infinite_loop() {
         let text: Font12x16<TestPixelColor> = Font12x16::render_str("Hello World!")
             .translate(Coord::new(5, -20))
-            .with_style(Style::with_stroke(1u8.into()));
+            .style(Style::stroke(1u8.into()));
         let mut it = text.into_iter();
 
         assert_eq!(it.next(), None);
@@ -71,7 +71,7 @@ mod tests {
     #[test]
     fn correct_m() {
         let mut display = Display::default();
-        display.draw(Font12x16::render_str("Mm").with_stroke(Some(1u8.into())));
+        display.draw(Font12x16::render_str("Mm").stroke(Some(1u8.into())));
 
         assert_eq!(
             display,
@@ -99,7 +99,7 @@ mod tests {
     #[test]
     fn correct_ascii_borders() {
         let mut display = Display::default();
-        display.draw(Font12x16::render_str(" ~").with_stroke(Some(1u8.into())));
+        display.draw(Font12x16::render_str(" ~").stroke(Some(1u8.into())));
 
         assert_eq!(
             display,
@@ -127,7 +127,7 @@ mod tests {
     #[test]
     fn correct_dollar_y() {
         let mut display = Display::default();
-        display.draw(Font12x16::render_str("$y").with_stroke(Some(1u8.into())));
+        display.draw(Font12x16::render_str("$y").stroke(Some(1u8.into())));
 
         assert_eq!(
             display,
@@ -177,19 +177,19 @@ mod tests {
         );
 
         let mut display = Display::default();
-        display.draw(Font12x16::render_str("\0\n").with_stroke(Some(1u8.into())));
+        display.draw(Font12x16::render_str("\0\n").stroke(Some(1u8.into())));
         assert_eq!(display, two_question_marks);
 
         let mut display = Display::default();
-        display.draw(Font12x16::render_str("\x7F\u{A0}").with_stroke(Some(1u8.into())));
+        display.draw(Font12x16::render_str("\x7F\u{A0}").stroke(Some(1u8.into())));
         assert_eq!(display, two_question_marks);
 
         let mut display = Display::default();
-        display.draw(Font12x16::render_str("¡ÿ").with_stroke(Some(1u8.into())));
+        display.draw(Font12x16::render_str("¡ÿ").stroke(Some(1u8.into())));
         assert_eq!(display, two_question_marks);
 
         let mut display = Display::default();
-        display.draw(Font12x16::render_str("Ā💣").with_stroke(Some(1u8.into())));
+        display.draw(Font12x16::render_str("Ā💣").stroke(Some(1u8.into())));
         assert_eq!(display, two_question_marks);
     }
 }

--- a/embedded-graphics/src/fonts/font6x12.rs
+++ b/embedded-graphics/src/fonts/font6x12.rs
@@ -40,7 +40,7 @@ mod tests {
     #[test]
     fn off_screen_text_does_not_infinite_loop() {
         let text: Font6x12<TestPixelColor> = Font6x12::render_str("Hello World!")
-            .with_style(Style::with_stroke(1u8.into()))
+            .style(Style::stroke(1u8.into()))
             .translate(Coord::new(5, -20));
         let mut it = text.into_iter();
 
@@ -72,7 +72,7 @@ mod tests {
     #[test]
     fn correct_m() {
         let mut display = Display::default();
-        display.draw(Font6x12::render_str("Mm").with_stroke(Some(1u8.into())));
+        display.draw(Font6x12::render_str("Mm").stroke(Some(1u8.into())));
 
         assert_eq!(
             display,
@@ -101,7 +101,7 @@ mod tests {
     #[test]
     fn correct_ascii_borders() {
         let mut display = Display::default();
-        display.draw(Font6x12::render_str(" ~").with_stroke(Some(1u8.into())));
+        display.draw(Font6x12::render_str(" ~").stroke(Some(1u8.into())));
 
         assert_eq!(
             display,
@@ -130,7 +130,7 @@ mod tests {
     #[test]
     fn correct_dollar_y() {
         let mut display = Display::default();
-        display.draw(Font6x12::render_str("$y").with_stroke(Some(1u8.into())));
+        display.draw(Font6x12::render_str("$y").stroke(Some(1u8.into())));
 
         assert_eq!(
             display,
@@ -182,26 +182,26 @@ mod tests {
         );
 
         let mut display = Display::default();
-        display.draw(Font6x12::render_str("\0\n").with_stroke(Some(1u8.into())));
+        display.draw(Font6x12::render_str("\0\n").stroke(Some(1u8.into())));
         assert_eq!(display, two_question_marks);
 
         let mut display = Display::default();
-        display.draw(Font6x12::render_str("\x7F\u{A0}").with_stroke(Some(1u8.into())));
+        display.draw(Font6x12::render_str("\x7F\u{A0}").stroke(Some(1u8.into())));
         assert_eq!(display, two_question_marks);
 
         let mut display = Display::default();
-        display.draw(Font6x12::render_str("¡ÿ").with_stroke(Some(1u8.into())));
+        display.draw(Font6x12::render_str("¡ÿ").stroke(Some(1u8.into())));
         assert_eq!(display, two_question_marks);
 
         let mut display = Display::default();
-        display.draw(Font6x12::render_str("Ā💣").with_stroke(Some(1u8.into())));
+        display.draw(Font6x12::render_str("Ā💣").stroke(Some(1u8.into())));
         assert_eq!(display, two_question_marks);
     }
 
     #[test]
     fn negative_y_no_infinite_loop() {
         let text: Font6x12<PixelColorU16> = Font6x12::render_str("Testing string")
-            .with_stroke(Some(0xF1FA_u16.into()))
+            .stroke(Some(0xF1FA_u16.into()))
             .translate(Coord::new(0, -12));
 
         let mut it = text.into_iter();
@@ -213,7 +213,7 @@ mod tests {
     #[test]
     fn negative_x_no_infinite_loop() {
         let text: Font6x12<PixelColorU16> = Font6x12::render_str("A")
-            .with_stroke(Some(0xF1FA_u16.into()))
+            .stroke(Some(0xF1FA_u16.into()))
             .translate(Coord::new(-6, 0));
 
         let mut it = text.into_iter();

--- a/embedded-graphics/src/fonts/font6x8.rs
+++ b/embedded-graphics/src/fonts/font6x8.rs
@@ -42,7 +42,7 @@ mod tests {
     #[test]
     fn off_screen_text_does_not_infinite_loop() {
         let text: Font6x8<TestPixelColor> = Font6x8::render_str("Hello World!")
-            .with_style(Style::with_stroke(1u8.into()))
+            .style(Style::stroke(1u8.into()))
             .translate(Coord::new(5, -10));
         let mut it = text.into_iter();
 
@@ -52,7 +52,7 @@ mod tests {
     #[test]
     fn unstroked_text_does_not_infinite_loop() {
         let text: Font6x8<TestPixelColor> = Font6x8::render_str("Hello World!")
-            .with_style(Style::with_stroke(1u8.into()))
+            .style(Style::stroke(1u8.into()))
             .translate(Coord::new(5, -10));
         let mut it = text.into_iter();
 
@@ -88,15 +88,15 @@ mod tests {
         let mut display_full_style = Display::default();
         display_full_style.draw(
             Font6x8::render_str("Mm")
-                .with_stroke(Some(1u8.into()))
-                .with_fill(Some(0u8.into())),
+                .stroke(Some(1u8.into()))
+                .fill(Some(0u8.into())),
         );
 
         let mut display_stroke = Display::default();
-        display_stroke.draw(Font6x8::render_str("Mm").with_stroke(Some(1u8.into())));
+        display_stroke.draw(Font6x8::render_str("Mm").stroke(Some(1u8.into())));
 
         let mut display_fill = Display::default();
-        display_fill.draw(Font6x8::render_str("Mm").with_fill(Some(0u8.into())));
+        display_fill.draw(Font6x8::render_str("Mm").fill(Some(0u8.into())));
 
         assert_eq!(display_default, display_full_style);
         assert_eq!(display_default, display_stroke);
@@ -106,7 +106,7 @@ mod tests {
     #[test]
     fn correct_m() {
         let mut display = Display::default();
-        display.draw(Font6x8::render_str("Mm").with_stroke(Some(1u8.into())));
+        display.draw(Font6x8::render_str("Mm").stroke(Some(1u8.into())));
 
         assert_eq!(
             display,
@@ -137,8 +137,8 @@ mod tests {
         let mut display = Display::default();
         display.draw(
             Font6x8::render_str("Mm")
-                .with_stroke(Some(0u8.into()))
-                .with_fill(Some(1u8.into())),
+                .stroke(Some(0u8.into()))
+                .fill(Some(1u8.into())),
         );
 
         assert_eq!(
@@ -171,15 +171,15 @@ mod tests {
         let mut display_inverse = Display::default();
         display_inverse.draw(
             Font6x8::render_str("Mm")
-                .with_stroke(Some(0u8.into()))
-                .with_fill(Some(1u8.into())),
+                .stroke(Some(0u8.into()))
+                .fill(Some(1u8.into())),
         );
 
         let mut display_normal = Display::default();
         display_normal.draw(
             Font6x8::render_str("Mm")
-                .with_stroke(Some(1u8.into()))
-                .with_fill(Some(0u8.into())),
+                .stroke(Some(1u8.into()))
+                .fill(Some(0u8.into())),
         );
 
         for (x, y) in display_inverse.0[0..8]
@@ -195,7 +195,7 @@ mod tests {
     #[test]
     fn correct_ascii_borders() {
         let mut display = Display::default();
-        display.draw(Font6x8::render_str(" ~").with_stroke(Some(1u8.into())));
+        display.draw(Font6x8::render_str(" ~").stroke(Some(1u8.into())));
 
         assert_eq!(
             display,
@@ -224,7 +224,7 @@ mod tests {
     #[test]
     fn correct_dollar_y() {
         let mut display = Display::default();
-        display.draw(Font6x8::render_str("$y").with_stroke(Some(1u8.into())));
+        display.draw(Font6x8::render_str("$y").stroke(Some(1u8.into())));
 
         assert_eq!(
             display,
@@ -253,7 +253,7 @@ mod tests {
     #[test]
     fn correct_latin1() {
         let mut display = Display::default();
-        display.draw(Font6x8::render_str("¡ÿ").with_stroke(Some(1u8.into())));
+        display.draw(Font6x8::render_str("¡ÿ").stroke(Some(1u8.into())));
 
         assert_eq!(
             display,
@@ -305,15 +305,15 @@ mod tests {
         );
 
         let mut display = Display::default();
-        display.draw(Font6x8::render_str("\0\n").with_stroke(Some(1u8.into())));
+        display.draw(Font6x8::render_str("\0\n").stroke(Some(1u8.into())));
         assert_eq!(display, two_question_marks);
 
         let mut display = Display::default();
-        display.draw(Font6x8::render_str("\x7F\u{A0}").with_stroke(Some(1u8.into())));
+        display.draw(Font6x8::render_str("\x7F\u{A0}").stroke(Some(1u8.into())));
         assert_eq!(display, two_question_marks);
 
         let mut display = Display::default();
-        display.draw(Font6x8::render_str("Ā💣").with_stroke(Some(1u8.into())));
+        display.draw(Font6x8::render_str("Ā💣").stroke(Some(1u8.into())));
         assert_eq!(display, two_question_marks);
     }
 }

--- a/embedded-graphics/src/fonts/font8x16.rs
+++ b/embedded-graphics/src/fonts/font8x16.rs
@@ -42,7 +42,7 @@ mod tests {
     #[test]
     fn off_screen_text_does_not_infinite_loop() {
         let text: Font8x16<TestPixelColor> = Font8x16::render_str("Hello World!")
-            .with_style(Style::with_stroke(1u8.into()))
+            .style(Style::stroke(1u8.into()))
             .translate(Coord::new(5, -20));
         let mut it = text.into_iter();
 
@@ -74,7 +74,7 @@ mod tests {
     #[test]
     fn correct_m() {
         let mut display = Display::default();
-        display.draw(Font8x16::render_str("Mm").with_stroke(Some(1u8.into())));
+        display.draw(Font8x16::render_str("Mm").stroke(Some(1u8.into())));
 
         assert_eq!(
             display,
@@ -102,7 +102,7 @@ mod tests {
     #[test]
     fn correct_ascii_borders() {
         let mut display = Display::default();
-        display.draw(Font8x16::render_str(" ~").with_stroke(Some(1u8.into())));
+        display.draw(Font8x16::render_str(" ~").stroke(Some(1u8.into())));
 
         assert_eq!(
             display,
@@ -130,7 +130,7 @@ mod tests {
     #[test]
     fn correct_dollar_y() {
         let mut display = Display::default();
-        display.draw(Font8x16::render_str("$y").with_stroke(Some(1u8.into())));
+        display.draw(Font8x16::render_str("$y").stroke(Some(1u8.into())));
 
         assert_eq!(
             display,
@@ -158,7 +158,7 @@ mod tests {
     #[test]
     fn correct_latin1() {
         let mut display = Display::default();
-        display.draw(Font8x16::render_str("¡ÿ").with_stroke(Some(1u8.into())));
+        display.draw(Font8x16::render_str("¡ÿ").stroke(Some(1u8.into())));
 
         assert_eq!(
             display,
@@ -208,15 +208,15 @@ mod tests {
         );
 
         let mut display = Display::default();
-        display.draw(Font8x16::render_str("\0\n").with_stroke(Some(1u8.into())));
+        display.draw(Font8x16::render_str("\0\n").stroke(Some(1u8.into())));
         assert_eq!(display, two_question_marks);
 
         let mut display = Display::default();
-        display.draw(Font8x16::render_str("\x7F\u{A0}").with_stroke(Some(1u8.into())));
+        display.draw(Font8x16::render_str("\x7F\u{A0}").stroke(Some(1u8.into())));
         assert_eq!(display, two_question_marks);
 
         let mut display = Display::default();
-        display.draw(Font8x16::render_str("Ā💣").with_stroke(Some(1u8.into())));
+        display.draw(Font8x16::render_str("Ā💣").stroke(Some(1u8.into())));
         assert_eq!(display, two_question_marks);
     }
 }

--- a/embedded-graphics/src/fonts/font_builder.rs
+++ b/embedded-graphics/src/fonts/font_builder.rs
@@ -111,25 +111,25 @@ impl<'a, C, Conf> WithStyle<C> for FontBuilder<'a, C, Conf>
 where
     C: PixelColor,
 {
-    fn with_style(mut self, style: Style<C>) -> Self {
+    fn style(mut self, style: Style<C>) -> Self {
         self.style = style;
 
         self
     }
 
-    fn with_stroke(mut self, color: Option<C>) -> Self {
+    fn stroke(mut self, color: Option<C>) -> Self {
         self.style.stroke_color = color;
 
         self
     }
 
-    fn with_stroke_width(self, _width: u8) -> Self {
+    fn stroke_width(self, _width: u8) -> Self {
         // Noop
 
         self
     }
 
-    fn with_fill(mut self, color: Option<C>) -> Self {
+    fn fill(mut self, color: Option<C>) -> Self {
         self.style.fill_color = color;
 
         self
@@ -291,11 +291,11 @@ where
     /// # use embedded_graphics::dev::TestPixelColor;
     /// # use embedded_graphics::prelude::*;
     /// #
-    /// # let style: Style<TestPixelColor> = Style::with_stroke(TestPixelColor(1));
+    /// # let style: Style<TestPixelColor> = Style::stroke(TestPixelColor(1));
     /// #
     /// // 8px x 1px test image
     /// let text = Font8x16::render_str("Hello world")
-    /// #    .with_style(style);
+    /// #    .style(style);
     /// let moved = text.translate(Coord::new(25, 30));
     ///
     /// assert_eq!(text.pos, Coord::new(0, 0));
@@ -315,11 +315,11 @@ where
     /// # use embedded_graphics::dev::TestPixelColor;
     /// # use embedded_graphics::prelude::*;
     /// #
-    /// # let style: Style<TestPixelColor> = Style::with_stroke(TestPixelColor(1));
+    /// # let style: Style<TestPixelColor> = Style::stroke(TestPixelColor(1));
     /// #
     /// // 8px x 1px test image
     /// let mut text = Font8x16::render_str("Hello world")
-    /// #    .with_style(style);
+    /// #    .style(style);
     /// text.translate_mut(Coord::new(25, 30));
     ///
     /// assert_eq!(text.pos, Coord::new(25, 30));

--- a/embedded-graphics/src/fonts/mod.rs
+++ b/embedded-graphics/src/fonts/mod.rs
@@ -43,7 +43,7 @@ where
     ///     let disp: Display = Display {};
     ///     // Render a string with a 8bit color
     ///     let text = Font6x8::render_str("Hello world")
-    ///         .with_style(Style::with_stroke(1u8.into()));
+    ///         .style(Style::stroke(1u8.into()));
     ///
     ///     disp.draw(text);
     /// }

--- a/embedded-graphics/src/primitives/circle.rs
+++ b/embedded-graphics/src/primitives/circle.rs
@@ -62,25 +62,25 @@ impl<C> WithStyle<C> for Circle<C>
 where
     C: PixelColor,
 {
-    fn with_style(mut self, style: Style<C>) -> Self {
+    fn style(mut self, style: Style<C>) -> Self {
         self.style = style;
 
         self
     }
 
-    fn with_stroke(mut self, color: Option<C>) -> Self {
+    fn stroke(mut self, color: Option<C>) -> Self {
         self.style.stroke_color = color;
 
         self
     }
 
-    fn with_stroke_width(mut self, width: u8) -> Self {
+    fn stroke_width(mut self, width: u8) -> Self {
         self.style.stroke_width = width;
 
         self
     }
 
-    fn with_fill(mut self, color: Option<C>) -> Self {
+    fn fill(mut self, color: Option<C>) -> Self {
         self.style.fill_color = color;
 
         self
@@ -212,10 +212,10 @@ where
     /// # use embedded_graphics::dev::TestPixelColor;
     /// # use embedded_graphics::prelude::*;
     /// #
-    /// # let style: Style<TestPixelColor> = Style::with_stroke(TestPixelColor(1));
+    /// # let style: Style<TestPixelColor> = Style::stroke(TestPixelColor(1));
     /// #
     /// let circle = Circle::new(Coord::new(5, 10), 10)
-    /// #    .with_style(style);
+    /// #    .style(style);
     /// let moved = circle.translate(Coord::new(10, 10));
     ///
     /// assert_eq!(moved.center, Coord::new(15, 20));
@@ -234,10 +234,10 @@ where
     /// # use embedded_graphics::dev::TestPixelColor;
     /// # use embedded_graphics::prelude::*;
     /// #
-    /// # let style: Style<TestPixelColor> = Style::with_stroke(TestPixelColor(1));
+    /// # let style: Style<TestPixelColor> = Style::stroke(TestPixelColor(1));
     /// #
     /// let mut circle = Circle::new(Coord::new(5, 10), 10)
-    /// #    .with_style(style);
+    /// #    .style(style);
     /// circle.translate_mut(Coord::new(10, 10));
     ///
     /// assert_eq!(circle.center, Coord::new(15, 20));
@@ -285,7 +285,7 @@ mod tests {
     #[test]
     fn it_handles_offscreen_coords() {
         let mut circ: CircleIterator<TestPixelColor> = Circle::new(Coord::new(-10, -10), 5)
-            .with_style(Style::with_stroke(1u8.into()))
+            .style(Style::stroke(1u8.into()))
             .into_iter();
 
         assert_eq!(circ.next(), None);
@@ -294,7 +294,7 @@ mod tests {
     #[test]
     fn it_handles_partially_on_screen_coords() {
         let mut circ: CircleIterator<TestPixelColor> = Circle::new(Coord::new(-5, -5), 30)
-            .with_style(Style::with_stroke(1u8.into()))
+            .style(Style::stroke(1u8.into()))
             .into_iter();
 
         assert!(circ.next().is_some());

--- a/embedded-graphics/src/primitives/line.rs
+++ b/embedded-graphics/src/primitives/line.rs
@@ -63,25 +63,25 @@ impl<C> WithStyle<C> for Line<C>
 where
     C: PixelColor,
 {
-    fn with_style(mut self, style: Style<C>) -> Self {
+    fn style(mut self, style: Style<C>) -> Self {
         self.style = style;
 
         self
     }
 
-    fn with_stroke(mut self, color: Option<C>) -> Self {
+    fn stroke(mut self, color: Option<C>) -> Self {
         self.style.stroke_color = color;
 
         self
     }
 
-    fn with_stroke_width(mut self, width: u8) -> Self {
+    fn stroke_width(mut self, width: u8) -> Self {
         self.style.stroke_width = width;
 
         self
     }
 
-    fn with_fill(mut self, color: Option<C>) -> Self {
+    fn fill(mut self, color: Option<C>) -> Self {
         self.style.fill_color = color;
 
         self
@@ -198,10 +198,10 @@ where
     /// # use embedded_graphics::dev::TestPixelColor;
     /// # use embedded_graphics::prelude::*;
     /// #
-    /// # let style: Style<TestPixelColor> = Style::with_stroke(TestPixelColor(1));
+    /// # let style: Style<TestPixelColor> = Style::stroke(TestPixelColor(1));
     /// #
     /// let line = Line::new(Coord::new(5, 10), Coord::new(15, 20))
-    /// #    .with_style(style);
+    /// #    .style(style);
     /// let moved = line.translate(Coord::new(10, 10));
     ///
     /// assert_eq!(moved.start, Coord::new(15, 20));
@@ -222,10 +222,10 @@ where
     /// # use embedded_graphics::dev::TestPixelColor;
     /// # use embedded_graphics::prelude::*;
     /// #
-    /// # let style: Style<TestPixelColor> = Style::with_stroke(TestPixelColor(1));
+    /// # let style: Style<TestPixelColor> = Style::stroke(TestPixelColor(1));
     /// #
     /// let mut line = Line::new(Coord::new(5, 10), Coord::new(15, 20))
-    /// #    .with_style(style);
+    /// #    .style(style);
     /// line.translate_mut(Coord::new(10, 10));
     ///
     /// assert_eq!(line.start, Coord::new(15, 20));
@@ -249,7 +249,7 @@ mod tests {
     use crate::unsignedcoord::UnsignedCoord;
 
     fn test_expected_line(start: Coord, end: Coord, expected: &[(u32, u32)]) {
-        let line = Line::new(start, end).with_style(Style::with_stroke(PixelColorU8(1)));
+        let line = Line::new(start, end).style(Style::stroke(PixelColorU8(1)));
         let mut expected_iter = expected.iter();
         for Pixel(coord, _) in line.into_iter() {
             match expected_iter.next() {

--- a/embedded-graphics/src/primitives/rect.rs
+++ b/embedded-graphics/src/primitives/rect.rs
@@ -60,25 +60,25 @@ impl<C> WithStyle<C> for Rect<C>
 where
     C: PixelColor,
 {
-    fn with_style(mut self, style: Style<C>) -> Self {
+    fn style(mut self, style: Style<C>) -> Self {
         self.style = style;
 
         self
     }
 
-    fn with_stroke(mut self, color: Option<C>) -> Self {
+    fn stroke(mut self, color: Option<C>) -> Self {
         self.style.stroke_color = color;
 
         self
     }
 
-    fn with_stroke_width(mut self, width: u8) -> Self {
+    fn stroke_width(mut self, width: u8) -> Self {
         self.style.stroke_width = width;
 
         self
     }
 
-    fn with_fill(mut self, color: Option<C>) -> Self {
+    fn fill(mut self, color: Option<C>) -> Self {
         self.style.fill_color = color;
 
         self
@@ -212,10 +212,10 @@ where
     /// # use embedded_graphics::dev::TestPixelColor;
     /// # use embedded_graphics::prelude::*;
     /// #
-    /// # let style: Style<TestPixelColor> = Style::with_stroke(TestPixelColor(1));
+    /// # let style: Style<TestPixelColor> = Style::stroke(TestPixelColor(1));
     /// #
     /// let rect = Rect::new(Coord::new(5, 10), Coord::new(15, 20))
-    /// #    .with_style(style);
+    /// #    .style(style);
     /// let moved = rect.translate(Coord::new(10, 10));
     ///
     /// assert_eq!(moved.top_left, Coord::new(15, 20));
@@ -236,10 +236,10 @@ where
     /// # use embedded_graphics::dev::TestPixelColor;
     /// # use embedded_graphics::prelude::*;
     /// #
-    /// # let style: Style<TestPixelColor> = Style::with_stroke(TestPixelColor(1));
+    /// # let style: Style<TestPixelColor> = Style::stroke(TestPixelColor(1));
     /// #
     /// let mut rect = Rect::new(Coord::new(5, 10), Coord::new(15, 20))
-    /// #    .with_style(style);
+    /// #    .style(style);
     /// rect.translate_mut(Coord::new(10, 10));
     ///
     /// assert_eq!(rect.top_left, Coord::new(15, 20));
@@ -285,7 +285,7 @@ mod tests {
     #[test]
     fn it_draws_unfilled_rect() {
         let mut rect: RectIterator<TestPixelColor> = Rect::new(Coord::new(2, 2), Coord::new(4, 4))
-            .with_style(Style::with_stroke(1u8.into()))
+            .style(Style::stroke(1u8.into()))
             .into_iter();
 
         assert_eq!(rect.next(), Some(Pixel(UnsignedCoord::new(2, 2), 1.into())));
@@ -304,7 +304,7 @@ mod tests {
     fn it_can_be_negative() {
         let mut rect: RectIterator<TestPixelColor> =
             Rect::new(Coord::new(-2, -2), Coord::new(2, 2))
-                .with_style(Style::with_stroke(1u8.into()))
+                .style(Style::stroke(1u8.into()))
                 .into_iter();
 
         // TODO: Macro

--- a/embedded-graphics/src/primitives/triangle.rs
+++ b/embedded-graphics/src/primitives/triangle.rs
@@ -93,25 +93,25 @@ impl<C> WithStyle<C> for Triangle<C>
 where
     C: PixelColor,
 {
-    fn with_style(mut self, style: Style<C>) -> Self {
+    fn style(mut self, style: Style<C>) -> Self {
         self.style = style;
 
         self
     }
 
-    fn with_stroke(mut self, color: Option<C>) -> Self {
+    fn stroke(mut self, color: Option<C>) -> Self {
         self.style.stroke_color = color;
 
         self
     }
 
-    fn with_stroke_width(mut self, width: u8) -> Self {
+    fn stroke_width(mut self, width: u8) -> Self {
         self.style.stroke_width = width;
 
         self
     }
 
-    fn with_fill(mut self, color: Option<C>) -> Self {
+    fn fill(mut self, color: Option<C>) -> Self {
         self.style.fill_color = color;
 
         self
@@ -157,13 +157,13 @@ where
         let (v1, v2, v3) = sort_yx(self.p1, self.p2, self.p3);
 
         let mut line_a = Line::new(v1, v2)
-            .with_stroke(self.style.stroke_color.or(self.style.fill_color))
+            .stroke(self.style.stroke_color.or(self.style.fill_color))
             .into_iter();
         let mut line_b = Line::new(v1, v3)
-            .with_stroke(self.style.stroke_color.or(self.style.fill_color))
+            .stroke(self.style.stroke_color.or(self.style.fill_color))
             .into_iter();
         let mut line_c = Line::new(v2, v3)
-            .with_stroke(self.style.stroke_color.or(self.style.fill_color))
+            .stroke(self.style.stroke_color.or(self.style.fill_color))
             .into_iter();
         let next_ac = line_a
             .next()
@@ -334,10 +334,10 @@ where
     /// # use embedded_graphics::dev::TestPixelColor;
     /// # use embedded_graphics::prelude::*;
     /// #
-    /// # let style: Style<TestPixelColor> = Style::with_stroke(TestPixelColor(1));
+    /// # let style: Style<TestPixelColor> = Style::stroke(TestPixelColor(1));
     /// #
     /// let tri = Triangle::new(Coord::new(5, 10), Coord::new(15, 20), Coord::new(8, 15))
-    /// #    .with_style(style);
+    /// #    .style(style);
     /// let moved = tri.translate(Coord::new(10, 10));
     ///
     /// assert_eq!(moved.p1, Coord::new(15, 20));
@@ -360,10 +360,10 @@ where
     /// # use embedded_graphics::dev::TestPixelColor;
     /// # use embedded_graphics::prelude::*;
     /// #
-    /// # let style: Style<TestPixelColor> = Style::with_stroke(TestPixelColor(1));
+    /// # let style: Style<TestPixelColor> = Style::stroke(TestPixelColor(1));
     /// #
     /// let mut tri = Triangle::new(Coord::new(5, 10), Coord::new(15, 20), Coord::new(10, 15))
-    /// #    .with_style(style);
+    /// #    .style(style);
     /// tri.translate_mut(Coord::new(10, 10));
     ///
     /// assert_eq!(tri.p1, Coord::new(15, 20));
@@ -417,7 +417,7 @@ mod tests {
     fn it_draws_unfilled_tri_line_y() {
         let mut tri: TriangleIterator<TestPixelColor> =
             Triangle::new(Coord::new(2, 2), Coord::new(2, 4), Coord::new(2, 4))
-                .with_style(Style::with_stroke(1u8.into()))
+                .style(Style::stroke(1u8.into()))
                 .into_iter();
 
         // Nodes are returned twice. first line a and b yield the same point.
@@ -435,7 +435,7 @@ mod tests {
     fn it_draws_unfilled_tri_line_x() {
         let mut tri: TriangleIterator<TestPixelColor> =
             Triangle::new(Coord::new(2, 2), Coord::new(4, 2), Coord::new(4, 2))
-                .with_style(Style::with_stroke(1u8.into()))
+                .style(Style::stroke(1u8.into()))
                 .into_iter();
 
         assert_eq!(tri.next(), Some(Pixel(UnsignedCoord::new(2, 2), 1.into())));
@@ -451,7 +451,7 @@ mod tests {
     fn it_can_be_negative() {
         let mut tri: TriangleIterator<TestPixelColor> =
             Triangle::new(Coord::new(-2, -2), Coord::new(2, 0), Coord::new(-2, 0))
-                .with_style(Style::with_stroke(1u8.into()))
+                .style(Style::stroke(1u8.into()))
                 .into_iter();
 
         // TODO: Macro

--- a/embedded-graphics/src/style.rs
+++ b/embedded-graphics/src/style.rs
@@ -26,7 +26,7 @@ where
     P: PixelColor,
 {
     /// Create a new style with a given stroke value and defaults for everything else
-    pub fn with_stroke(stroke_color: P) -> Self {
+    pub fn stroke(stroke_color: P) -> Self {
         Self {
             stroke_color: Some(stroke_color),
             ..Style::default()
@@ -53,20 +53,20 @@ where
     C: PixelColor,
 {
     /// Add a complete style to the object
-    fn with_style(self, style: Style<C>) -> Self;
+    fn style(self, style: Style<C>) -> Self;
 
     /// Set the stroke colour for the object
     ///
     /// This can be a noop
-    fn with_stroke(self, stroke: Option<C>) -> Self;
+    fn stroke(self, stroke: Option<C>) -> Self;
 
     /// Set the stroke width for the object
     ///
     /// A stroke with a width of zero will not be rendered
-    fn with_stroke_width(self, width: u8) -> Self;
+    fn stroke_width(self, width: u8) -> Self;
 
     /// Set the fill property of the object's style
     ///
     /// This can be a noop
-    fn with_fill(self, stroke: Option<C>) -> Self;
+    fn fill(self, stroke: Option<C>) -> Self;
 }

--- a/embedded-graphics/tests/chaining.rs
+++ b/embedded-graphics/tests/chaining.rs
@@ -40,11 +40,11 @@ fn it_supports_chaining() {
 
 fn multi() -> impl Iterator<Item = Pixel<TestPixelColor>> {
     let line = Line::new(Coord::new(0, 1), Coord::new(2, 3))
-        .with_stroke(Some(1u8.into()))
+        .stroke(Some(1u8.into()))
         .into_iter();
 
     let circle = Circle::new(Coord::new(5, 5), 3)
-        .with_stroke(Some(1u8.into()))
+        .stroke(Some(1u8.into()))
         .into_iter();
 
     line.chain(circle)

--- a/simulator/examples/chaining.rs
+++ b/simulator/examples/chaining.rs
@@ -17,13 +17,13 @@ fn main() {
     let mut display = DisplayBuilder::new().theme(DisplayTheme::OledBlue).build();
 
     let objects = Circle::new(Coord::new(64, 64), 64)
-        .with_stroke(Some(1u8.into()))
+        .stroke(Some(1u8.into()))
         .into_iter()
-        .chain(Line::new(Coord::new(64, 64), Coord::new(0, 64)).with_stroke(Some(1u8.into())))
-        .chain(Line::new(Coord::new(64, 64), Coord::new(80, 80)).with_stroke(Some(1u8.into())))
+        .chain(Line::new(Coord::new(64, 64), Coord::new(0, 64)).stroke(Some(1u8.into())))
+        .chain(Line::new(Coord::new(64, 64), Coord::new(80, 80)).stroke(Some(1u8.into())))
         .chain(
             Font6x8::render_str("Hello World!")
-                .with_stroke(Some(1u8.into()))
+                .stroke(Some(1u8.into()))
                 .translate(Coord::new(5, 50)),
         );
 

--- a/simulator/examples/fill.rs
+++ b/simulator/examples/fill.rs
@@ -17,61 +17,61 @@ fn main() {
 
     display.draw(
         Circle::new(Coord::new(CIRCLE_SIZE, CIRCLE_SIZE), CIRCLE_SIZE as u32)
-            .with_stroke(Some(1u8.into())),
+            .stroke(Some(1u8.into())),
     );
 
     display.draw(
         Circle::new(Coord::new(CIRCLE_SIZE, CIRCLE_SIZE), CIRCLE_SIZE as u32)
             .translate(Coord::new(16, 16))
-            .with_stroke(Some(0u8.into()))
-            .with_fill(Some(1u8.into())),
+            .stroke(Some(0u8.into()))
+            .fill(Some(1u8.into())),
     );
 
     display.draw(
         Circle::new(Coord::new(CIRCLE_SIZE, CIRCLE_SIZE), CIRCLE_SIZE as u32)
             .translate(Coord::new(CIRCLE_SIZE, CIRCLE_SIZE))
-            .with_stroke(Some(0u8.into()))
-            .with_fill(Some(0u8.into())),
+            .stroke(Some(0u8.into()))
+            .fill(Some(0u8.into())),
     );
 
     display.draw(
         Rect::new(Coord::new(0, 0), Coord::new(64, 64))
             .translate(Coord::new(96, 0))
-            .with_stroke(Some(1u8.into())),
+            .stroke(Some(1u8.into())),
     );
 
     display.draw(
         &Rect::new(Coord::new(0, 0), Coord::new(64, 64))
             .translate(Coord::new(96 + 16, 16))
-            .with_stroke(Some(0u8.into()))
-            .with_fill(Some(1u8.into())),
+            .stroke(Some(0u8.into()))
+            .fill(Some(1u8.into())),
     );
 
     display.draw(
         Rect::new(Coord::new(0, 0), Coord::new(64, 64))
             .translate(Coord::new(96 + 32, 32))
-            .with_stroke(Some(0u8.into()))
-            .with_fill(Some(0u8.into())),
+            .stroke(Some(0u8.into()))
+            .fill(Some(0u8.into())),
     );
 
     display.draw(
         Triangle::new(Coord::new(32, 0), Coord::new(0, 64), Coord::new(64, 64))
             .translate(Coord::new(96 * 2, 0))
-            .with_stroke(Some(1u8.into())),
+            .stroke(Some(1u8.into())),
     );
 
     display.draw(
         Triangle::new(Coord::new(32, 0), Coord::new(0, 64), Coord::new(64, 64))
             .translate(Coord::new(96 * 2 + 16, 16))
-            .with_stroke(Some(0u8.into()))
-            .with_fill(Some(1u8.into())),
+            .stroke(Some(0u8.into()))
+            .fill(Some(1u8.into())),
     );
 
     display.draw(
         Triangle::new(Coord::new(32, 0), Coord::new(0, 64), Coord::new(64, 64))
             .translate(Coord::new(96 * 2 + 32, 32))
-            .with_stroke(Some(0u8.into()))
-            .with_fill(Some(0u8.into())),
+            .stroke(Some(0u8.into()))
+            .fill(Some(0u8.into())),
     );
 
     loop {

--- a/simulator/examples/fonts.rs
+++ b/simulator/examples/fonts.rs
@@ -21,8 +21,8 @@ fn main() {
     // Show smallest font with white font on black background
     display.draw(
         Font6x8::render_str("Hello World! - inverse 6x8")
-            .with_stroke(Some(0u8.into()))
-            .with_fill(Some(1u8.into()))
+            .stroke(Some(0u8.into()))
+            .fill(Some(1u8.into()))
             .translate(Coord::new(15, 30)),
     );
 

--- a/simulator/examples/hello.rs
+++ b/simulator/examples/hello.rs
@@ -15,15 +15,15 @@ fn main() {
     let mut display = DisplayBuilder::new().theme(DisplayTheme::OledBlue).build();
 
     // Outline
-    display.draw(Circle::new(Coord::new(64, 64), 64).with_stroke(Some(1u8.into())));
+    display.draw(Circle::new(Coord::new(64, 64), 64).stroke(Some(1u8.into())));
 
     // Clock hands
-    display.draw(Line::new(Coord::new(64, 64), Coord::new(0, 64)).with_stroke(Some(1u8.into())));
-    display.draw(Line::new(Coord::new(64, 64), Coord::new(80, 80)).with_stroke(Some(1u8.into())));
+    display.draw(Line::new(Coord::new(64, 64), Coord::new(0, 64)).stroke(Some(1u8.into())));
+    display.draw(Line::new(Coord::new(64, 64), Coord::new(80, 80)).stroke(Some(1u8.into())));
 
     display.draw(
         Font6x8::render_str("Hello World!")
-            .with_stroke(Some(1u8.into()))
+            .stroke(Some(1u8.into()))
             .translate(Coord::new(5, 50)),
     );
 

--- a/simulator/examples/offscreen.rs
+++ b/simulator/examples/offscreen.rs
@@ -16,7 +16,7 @@ fn main() {
     // Outline
     display.draw(
         Rect::new(Coord::new(0, 0), Coord::new(16, 16))
-            .with_stroke(Some(1u8.into()))
+            .stroke(Some(1u8.into()))
             .translate(Coord::new(-8, -8)),
     );
 

--- a/simulator/examples/stroke.rs
+++ b/simulator/examples/stroke.rs
@@ -17,19 +17,19 @@ fn main() {
 
     let triangle = Triangle::new(Coord::new(0, 64), Coord::new(64, 0), Coord::new(64, 64))
         .translate(Coord::new(0, 0))
-        .with_stroke(Some(SimPixelColor(true)));
+        .stroke(Some(SimPixelColor(true)));
 
     let rect = Rect::new(Coord::new(0, 0), Coord::new(64, 64))
         .translate(Coord::new(64 + PADDING, 0))
-        .with_stroke(Some(SimPixelColor(true)));
+        .stroke(Some(SimPixelColor(true)));
 
     let line = Line::new(Coord::new(0, 0), Coord::new(64, 64))
         .translate(Coord::new(128 + PADDING * 2, 0))
-        .with_stroke(Some(SimPixelColor(true)));
+        .stroke(Some(SimPixelColor(true)));
 
     let circ = Circle::new(Coord::new(32, 32), 32)
         .translate(Coord::new(192 + PADDING * 3, 0))
-        .with_stroke(Some(SimPixelColor(true)));
+        .stroke(Some(SimPixelColor(true)));
 
     display.draw(
         circ.into_iter()
@@ -40,39 +40,33 @@ fn main() {
 
     display.draw(
         circ.translate(Coord::new(0, 64 + PADDING))
-            .with_stroke_width(3)
+            .stroke_width(3)
             .into_iter()
-            .chain(
-                rect.translate(Coord::new(0, 64 + PADDING))
-                    .with_stroke_width(3),
-            )
-            .chain(
-                line.translate(Coord::new(0, 64 + PADDING))
-                    .with_stroke_width(3),
-            )
+            .chain(rect.translate(Coord::new(0, 64 + PADDING)).stroke_width(3))
+            .chain(line.translate(Coord::new(0, 64 + PADDING)).stroke_width(3))
             .chain(
                 triangle
                     .translate(Coord::new(0, 64 + PADDING))
-                    .with_stroke_width(3),
+                    .stroke_width(3),
             ),
     );
 
     display.draw(
         circ.translate(Coord::new(0, 128 + PADDING * 2))
-            .with_stroke_width(10)
+            .stroke_width(10)
             .into_iter()
             .chain(
                 rect.translate(Coord::new(0, 128 + PADDING * 2))
-                    .with_stroke_width(10),
+                    .stroke_width(10),
             )
             .chain(
                 line.translate(Coord::new(0, 128 + PADDING * 2))
-                    .with_stroke_width(10),
+                    .stroke_width(10),
             )
             .chain(
                 triangle
                     .translate(Coord::new(0, 128 + PADDING * 2))
-                    .with_stroke_width(10),
+                    .stroke_width(10),
             ),
     );
 

--- a/simulator/examples/triangles.rs
+++ b/simulator/examples/triangles.rs
@@ -19,20 +19,20 @@ fn main() {
     display.draw(
         Triangle::new(Coord::new(0, 0), Coord::new(64, 10), Coord::new(15, 64))
             .translate(Coord::new(PAD, 0))
-            .with_stroke(Some(1u8.into())),
+            .stroke(Some(1u8.into())),
     );
 
     // flat top
     display.draw(
         Triangle::new(Coord::new(5, 0), Coord::new(30, 64), Coord::new(64, 0))
-            .with_stroke(Some(1u8.into()))
+            .stroke(Some(1u8.into()))
             .translate(Coord::new(64 + PAD, 0)),
     );
 
     // flat left
     display.draw(
         Triangle::new(Coord::new(0, 0), Coord::new(0, 64), Coord::new(64, 30))
-            .with_stroke(Some(1u8.into()))
+            .stroke(Some(1u8.into()))
             .translate(Coord::new((64 + PAD) * 2, 0)),
     );
 
@@ -40,26 +40,26 @@ fn main() {
     display.draw(
         Triangle::new(Coord::new(22, 0), Coord::new(0, 64), Coord::new(64, 64))
             .translate(Coord::new((64 + PAD) * 3, 0))
-            .with_stroke(Some(1u8.into())),
+            .stroke(Some(1u8.into())),
     );
 
     // flat right
     display.draw(
         Triangle::new(Coord::new(0, 22), Coord::new(64, 0), Coord::new(64, 64))
             .translate(Coord::new((64 + PAD) * 4, 0))
-            .with_stroke(Some(1u8.into())),
+            .stroke(Some(1u8.into())),
     );
 
     // draw filled above stroke, should not be visible
     display.draw(
         Triangle::new(Coord::new(0, 22), Coord::new(64, 0), Coord::new(64, 64))
             .translate(Coord::new((64 + PAD) * 5, 0))
-            .with_stroke(Some(1u8.into())),
+            .stroke(Some(1u8.into())),
     );
     display.draw(
         Triangle::new(Coord::new(0, 22), Coord::new(64, 0), Coord::new(64, 64))
             .translate(Coord::new((64 + PAD) * 5, 0))
-            .with_fill(Some(0u8.into())),
+            .fill(Some(0u8.into())),
     );
 
     loop {


### PR DESCRIPTION
Closes #104 

BREAKING CHANGE: All style methods no longer have a `with_` prefix. Call them like `.fill()`, `.stroke()`, etc.