### PR TITLE
Add colour support to simulator

### DIFF
--- a/simulator/examples/bmp.rs
+++ b/simulator/examples/bmp.rs
@@ -1,7 +1,7 @@
 //! Draw a 16BPP BMP image onto a monochrome display
 //!
-//! This example uses `impl From<u16> for SimPixelColor` from `src/lib` to convert the image into
-//! a black and white pixel iterator. The simulator doesn't currently support drawing with colour.
+//! This example uses `impl From<Rgb565> for SimPixelColor` from `src/lib` to convert the image into
+//! a colour pixel iterator. The simulator uses the `ColorOled` theme to display the image in colour
 //!
 //! Note that this requires the `bmp` feature to be turned on for `embedded-graphics`. Turn it on
 //! with the following in `Cargo.toml`:
@@ -16,16 +16,24 @@ use std::thread;
 use std::time::Duration;
 
 use embedded_graphics::image::ImageBmp;
+use embedded_graphics::pixelcolor;
 use embedded_graphics::prelude::*;
 
-use simulator::DisplayBuilder;
+use simulator::{DisplayBuilder, DisplayTheme};
 
 fn main() {
-    let image = ImageBmp::new(include_bytes!("./rust-pride.bmp")).unwrap();
+    let image: ImageBmp<pixelcolor::Rgb565> =
+        ImageBmp::new(include_bytes!("./rust-pride.bmp")).unwrap();
 
-    let mut display = DisplayBuilder::new().size(304, 128).scale(2).build();
+    let mut display = DisplayBuilder::new()
+        .size(304, 128)
+        .theme(DisplayTheme::ColorOled)
+        .scale(2)
+        .build();
 
-    display.draw(&image);
+    // Image has a pixel type of `pixelcolor::Rgb565`. This needs to be converted to a
+    // `SimPixelColor` using the `.map()` below.
+    display.draw(image.into_iter().map(|p| Pixel(p.0, p.1.into())));
 
     loop {
         let end = display.run_once();

--- a/simulator/examples/stroke.rs
+++ b/simulator/examples/stroke.rs
@@ -17,19 +17,19 @@ fn main() {
 
     let triangle = Triangle::new(icoord!(0, 64), icoord!(64, 0), icoord!(64, 64))
         .translate(icoord!(0, 0))
-        .stroke(Some(SimPixelColor(true)));
+        .stroke(Some(SimPixelColor(1, 1, 1)));
 
     let rect = Rect::new(icoord!(0, 0), icoord!(64, 64))
         .translate(icoord!(64 + PADDING, 0))
-        .stroke(Some(SimPixelColor(true)));
+        .stroke(Some(SimPixelColor(1, 1, 1)));
 
     let line = Line::new(icoord!(0, 0), icoord!(64, 64))
         .translate(icoord!(128 + PADDING * 2, 0))
-        .stroke(Some(SimPixelColor(true)));
+        .stroke(Some(SimPixelColor(1, 1, 1)));
 
     let circ = Circle::new(icoord!(32, 32), 32)
         .translate(icoord!(192 + PADDING * 3, 0))
-        .stroke(Some(SimPixelColor(true)));
+        .stroke(Some(SimPixelColor(1, 1, 1)));
 
     display.draw(
         circ.into_iter()


### PR DESCRIPTION
`cargo run --example bmp` now shows the Rust logo in rainbow colours.

Closes #113 