### PR TITLE
Fix simulator TGA example

### DIFF
--- a/simulator/src/lib.rs
+++ b/simulator/src/lib.rs
@@ -30,10 +30,12 @@ impl From<u16> for SimPixelColor {
     }
 }
 
-// Danger: Chops off upper bits
+// Danger: Chops off upper byte
 impl From<u32> for SimPixelColor {
     fn from(other: u32) -> Self {
-        SimPixelColor(other as u8, other as u8, other as u8)
+        let [_, r, g, b] = other.to_be_bytes();
+
+        SimPixelColor(r, g, b)
     }
 }
 


### PR DESCRIPTION
This makes a bunch of assumptions about what's in the `u32`, but for the purposes of the simulator, it works fine. I think there needs to be a better story around pixel conversions, so let's see where that goes before fixing this forward with it.

Closes #120