### PR TITLE
Change simulator to be publishable on crates.io

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -11,3 +11,4 @@ cargo doc --all-features
 linkchecker target/doc/embedded_graphics/index.html
 linkchecker target/doc/tinybmp/index.html
 linkchecker target/doc/tinytga/index.html
+linkchecker target/doc/embedded_graphics_simulator/index.html

--- a/embedded-graphics/Cargo.toml
+++ b/embedded-graphics/Cargo.toml
@@ -29,6 +29,7 @@ name = "fonts"
 [[bench]]
 harness = false
 name = "image"
+required-features = ["bmp"]
 
 [badges]
 circle-ci = { repository = "jamwaffles/embedded-graphics", branch = "master" }

--- a/embedded-graphics/src/lib.rs
+++ b/embedded-graphics/src/lib.rs
@@ -55,7 +55,7 @@
 //! git clone https://github.com/jamwaffles/embedded-graphics.git
 //! cd embedded-graphics
 //!
-//! cargo run -p simulator --example hello
+//! cargo run -p embedded-graphics-simulator --example hello
 //! ```
 //!
 //! [simulator]: https://github.com/jamwaffles/embedded-graphics/tree/c4f74c12dae9f0a0193fa48192f905a002bf8c9d/simulator

--- a/simulator/Cargo.toml
+++ b/simulator/Cargo.toml
@@ -17,6 +17,9 @@ exclude = [
     "convert_1bpp.sh",
 ]
 
+[badges]
+circle-ci = { repository = "jamwaffles/embedded-graphics", branch = "master" }
+
 [dependencies]
 sdl2 = "0.32.2"
 

--- a/simulator/Cargo.toml
+++ b/simulator/Cargo.toml
@@ -1,13 +1,25 @@
 [package]
-authors = ["Byron Wasti <byron.wasti@gmail.com>"]
-name = "simulator"
 version = "0.1.0"
-publish = false
+name = "embedded-graphics-simulator"
+description = "Embedded graphics simulator"
+authors = ["Byron Wasti <byron.wasti@gmail.com>", "James Waples <james@wapl.es>"]
+repository = "https://github.com/jamwaffles/embedded-graphics/tree/master/simulator"
+documentation = "https://docs.rs/embedded-graphics-simulator"
+categories = ["embedded", "no-std"]
+keywords = ["simulator", "graphics", "embedded"]
+readme = "./README.md"
+license = "MIT OR Apache-2.0"
 edition = "2018"
+exclude = [
+    ".circleci",
+    ".travis.yml",
+    ".gitignore",
+    "convert_1bpp.sh",
+]
 
 [dependencies]
 sdl2 = "0.32.2"
 
 [dependencies.embedded-graphics]
-path = "../embedded-graphics"
+version = "0.5.0"
 features = [ "bmp", "tga" ]

--- a/simulator/README.md
+++ b/simulator/README.md
@@ -1,0 +1,41 @@
+# Embedded graphics simulator
+
+![It can display all sorts of embedded-graphics test code.](https://raw.githubusercontent.com/jamwaffles/embedded-graphics/master/assets/simulator-demo.png)
+
+The simulator can be used to test and debug [embedded-graphics](https://crates.io/crates/embedded-graphics) code, or produce snazzy examples for people to try drivers out without needing physical hardware to run on.
+
+# Examples
+
+## Simulate a 128x64 SSD1306 OLED
+
+```rust
+use embedded_graphics::prelude::*;
+use embedded_graphics::{icoord, circle, line, text_6x8};
+use embedded_graphics_simulator::{DisplayBuilder, DisplayTheme};
+use std::thread;
+use std::time::Duration;
+
+fn main() {
+ let mut display = DisplayBuilder::new()
+     .theme(DisplayTheme::OledBlue)
+     .size(128, 64)
+     .build();
+
+ display.draw(text_6x8!("Hello World!"));
+
+ display.draw(circle!((96, 32), 31, stroke = Some(1u8.into())));
+
+ display.draw(line!((32, 32), (1, 32), stroke = Some(1u8.into())).translate(icoord!(64, 0)));
+ display.draw(line!((32, 32), (40, 40), stroke = Some(1u8.into())).translate(icoord!(64, 0)));
+
+ loop {
+     let end = display.run_once();
+
+     if end {
+         break;
+     }
+
+     thread::sleep(Duration::from_millis(200));
+ }
+}
+```

--- a/simulator/examples/bmp.rs
+++ b/simulator/examples/bmp.rs
@@ -9,17 +9,12 @@
 //! [dependencies]
 //! embedded-graphics = { version = "*", features = [ "bmp" ] }
 
-extern crate embedded_graphics;
-extern crate simulator;
-
-use std::thread;
-use std::time::Duration;
-
 use embedded_graphics::image::ImageBmp;
 use embedded_graphics::pixelcolor;
 use embedded_graphics::prelude::*;
-
-use simulator::{DisplayBuilder, DisplayTheme};
+use embedded_graphics_simulator::{DisplayBuilder, DisplayTheme};
+use std::thread;
+use std::time::Duration;
 
 fn main() {
     let image: ImageBmp<pixelcolor::Rgb565> =

--- a/simulator/examples/chaining.rs
+++ b/simulator/examples/chaining.rs
@@ -1,17 +1,12 @@
 //! Demonstrate the chaining abilities of embedded graphics iterators
 
-extern crate embedded_graphics;
-extern crate simulator;
-
-use std::thread;
-use std::time::Duration;
-
 use embedded_graphics::fonts::Font6x8;
 use embedded_graphics::icoord;
 use embedded_graphics::prelude::*;
 use embedded_graphics::primitives::{Circle, Line};
-
-use simulator::{DisplayBuilder, DisplayTheme};
+use embedded_graphics_simulator::{DisplayBuilder, DisplayTheme};
+use std::thread;
+use std::time::Duration;
 
 fn main() {
     let mut display = DisplayBuilder::new().theme(DisplayTheme::OledBlue).build();

--- a/simulator/examples/fill-macros.rs
+++ b/simulator/examples/fill-macros.rs
@@ -1,17 +1,11 @@
 //! Demonstrate usage of primitives like `fill.rs` but use macros instead for shorter code
 
-extern crate embedded_graphics;
-extern crate simulator;
-
-use std::thread;
-use std::time::Duration;
-
 use embedded_graphics::icoord;
 use embedded_graphics::prelude::*;
-
 use embedded_graphics::{circle, line, rect, triangle};
-
-use simulator::DisplayBuilder;
+use embedded_graphics_simulator::DisplayBuilder;
+use std::thread;
+use std::time::Duration;
 
 static CIRCLE_SIZE: i32 = 32;
 

--- a/simulator/examples/fill.rs
+++ b/simulator/examples/fill.rs
@@ -1,14 +1,9 @@
-extern crate embedded_graphics;
-extern crate simulator;
-
-use std::thread;
-use std::time::Duration;
-
 use embedded_graphics::icoord;
 use embedded_graphics::prelude::*;
 use embedded_graphics::primitives::{Circle, Rect, Triangle};
-
-use simulator::DisplayBuilder;
+use embedded_graphics_simulator::DisplayBuilder;
+use std::thread;
+use std::time::Duration;
 
 static CIRCLE_SIZE: i32 = 32;
 

--- a/simulator/examples/fonts.rs
+++ b/simulator/examples/fonts.rs
@@ -1,15 +1,10 @@
-extern crate embedded_graphics;
-extern crate simulator;
-
-use std::thread;
-use std::time::Duration;
-
 use embedded_graphics::fonts::{Font6x12, Font6x8, Font8x16};
 use embedded_graphics::icoord;
 use embedded_graphics::prelude::*;
 use embedded_graphics::{text_12x16, text_6x8};
-
-use simulator::DisplayBuilder;
+use embedded_graphics_simulator::DisplayBuilder;
+use std::thread;
+use std::time::Duration;
 
 fn main() {
     let mut display = DisplayBuilder::new().size(256, 128).build();

--- a/simulator/examples/hello.rs
+++ b/simulator/examples/hello.rs
@@ -1,15 +1,10 @@
-extern crate embedded_graphics;
-extern crate simulator;
-
-use std::thread;
-use std::time::Duration;
-
 use embedded_graphics::fonts::Font6x8;
 use embedded_graphics::icoord;
 use embedded_graphics::prelude::*;
 use embedded_graphics::primitives::{Circle, Line};
-
-use simulator::{DisplayBuilder, DisplayTheme};
+use embedded_graphics_simulator::{DisplayBuilder, DisplayTheme};
+use std::thread;
+use std::time::Duration;
 
 fn main() {
     let mut display = DisplayBuilder::new().theme(DisplayTheme::OledBlue).build();

--- a/simulator/examples/offscreen.rs
+++ b/simulator/examples/offscreen.rs
@@ -1,14 +1,9 @@
-extern crate embedded_graphics;
-extern crate simulator;
-
-use std::thread;
-use std::time::Duration;
-
 use embedded_graphics::icoord;
 use embedded_graphics::prelude::*;
 use embedded_graphics::primitives::Rect;
-
-use simulator::DisplayBuilder;
+use embedded_graphics_simulator::DisplayBuilder;
+use std::thread;
+use std::time::Duration;
 
 fn main() {
     let mut display = DisplayBuilder::new().size(32, 32).scale(4).build();

--- a/simulator/examples/stroke.rs
+++ b/simulator/examples/stroke.rs
@@ -1,14 +1,9 @@
-extern crate embedded_graphics;
-extern crate simulator;
-
-use std::thread;
-use std::time::Duration;
-
 use embedded_graphics::icoord;
 use embedded_graphics::prelude::*;
 use embedded_graphics::primitives::{Circle, Line, Rect, Triangle};
-
-use simulator::{DisplayBuilder, SimPixelColor};
+use embedded_graphics_simulator::{DisplayBuilder, SimPixelColor};
+use std::thread;
+use std::time::Duration;
 
 const PADDING: i32 = 16;
 

--- a/simulator/examples/tga.rs
+++ b/simulator/examples/tga.rs
@@ -9,16 +9,11 @@
 //! [dependencies]
 //! embedded-graphics = { version = "*", features = [ "tga" ] }
 
-extern crate embedded_graphics;
-extern crate simulator;
-
-use std::thread;
-use std::time::Duration;
-
 use embedded_graphics::image::ImageTga;
 use embedded_graphics::prelude::*;
-
-use simulator::DisplayBuilder;
+use embedded_graphics_simulator::DisplayBuilder;
+use std::thread;
+use std::time::Duration;
 
 fn main() {
     let image = ImageTga::new(include_bytes!("./rust-pride.tga")).unwrap();

--- a/simulator/examples/transparent-fonts.rs
+++ b/simulator/examples/transparent-fonts.rs
@@ -1,14 +1,9 @@
-extern crate embedded_graphics;
-extern crate simulator;
-
-use std::thread;
-use std::time::Duration;
-
 use embedded_graphics::prelude::*;
 use embedded_graphics::text_6x8;
 use embedded_graphics::{circle, icoord, rect};
-
-use simulator::{DisplayBuilder, DisplayTheme};
+use embedded_graphics_simulator::{DisplayBuilder, DisplayTheme};
+use std::thread;
+use std::time::Duration;
 
 fn main() {
     let mut display = DisplayBuilder::new().theme(DisplayTheme::OledBlue).build();

--- a/simulator/examples/triangles.rs
+++ b/simulator/examples/triangles.rs
@@ -1,14 +1,9 @@
-extern crate embedded_graphics;
-extern crate simulator;
-
-use std::thread;
-use std::time::Duration;
-
 use embedded_graphics::icoord;
 use embedded_graphics::prelude::*;
 use embedded_graphics::primitives::Triangle;
-
-use simulator::DisplayBuilder;
+use embedded_graphics_simulator::DisplayBuilder;
+use std::thread;
+use std::time::Duration;
 
 const PAD: i32 = 10;
 

--- a/simulator/src/display_builder.rs
+++ b/simulator/src/display_builder.rs
@@ -1,0 +1,92 @@
+use crate::display_theme::DisplayTheme;
+use crate::sim_pixel_color::SimPixelColor;
+use crate::Display;
+
+pub struct DisplayBuilder {
+    width: usize,
+    height: usize,
+    scale: usize,
+    pixel_spacing: usize,
+    theme: DisplayTheme,
+}
+
+impl DisplayBuilder {
+    pub fn new() -> Self {
+        Self {
+            width: 256,
+            height: 256,
+            scale: 1,
+            pixel_spacing: 0,
+            theme: DisplayTheme::Default,
+        }
+    }
+
+    pub fn size(&mut self, width: usize, height: usize) -> &mut Self {
+        if width == 0 || height == 0 {
+            panic!("with and height must be >= 0");
+        }
+
+        self.width = width;
+        self.height = height;
+
+        self
+    }
+
+    pub fn scale(&mut self, scale: usize) -> &mut Self {
+        if scale == 0 {
+            panic!("scale must be >= 0");
+        }
+
+        self.scale = scale;
+
+        self
+    }
+
+    pub fn theme(&mut self, theme: DisplayTheme) -> &mut Self {
+        self.theme = theme;
+
+        self.scale(3);
+        self.pixel_spacing(1);
+
+        self
+    }
+
+    pub fn pixel_spacing(&mut self, pixel_spacing: usize) -> &mut Self {
+        self.pixel_spacing = pixel_spacing;
+
+        self
+    }
+
+    pub fn build(&self) -> Display {
+        let sdl_context = sdl2::init().unwrap();
+        let video_subsystem = sdl_context.video().unwrap();
+
+        let window_width = self.width * self.scale + (self.width - 1) * self.pixel_spacing;
+        let window_height = self.height * self.scale + (self.height - 1) * self.pixel_spacing;
+
+        let window = video_subsystem
+            .window(
+                "graphics-emulator",
+                window_width as u32,
+                window_height as u32,
+            )
+            .position_centered()
+            .build()
+            .unwrap();
+
+        let pixels = vec![SimPixelColor(0, 0, 0); self.width * self.height];
+        let canvas = window.into_canvas().build().unwrap();
+        let event_pump = sdl_context.event_pump().unwrap();
+
+        Display {
+            width: self.width,
+            height: self.height,
+            scale: self.scale,
+            pixel_spacing: self.pixel_spacing,
+            theme: self.theme.clone(),
+            pixels: pixels.into_boxed_slice(),
+            canvas,
+            event_pump,
+        }
+    }
+}

--- a/simulator/src/display_builder.rs
+++ b/simulator/src/display_builder.rs
@@ -2,6 +2,7 @@ use crate::display_theme::DisplayTheme;
 use crate::sim_pixel_color::SimPixelColor;
 use crate::Display;
 
+/// Create a simulator display using the builder pattern
 pub struct DisplayBuilder {
     width: usize,
     height: usize,
@@ -11,6 +12,7 @@ pub struct DisplayBuilder {
 }
 
 impl DisplayBuilder {
+    /// Create a new display with default settings
     pub fn new() -> Self {
         Self {
             width: 256,
@@ -21,6 +23,7 @@ impl DisplayBuilder {
         }
     }
 
+    /// Set the width/height of the display in pixels
     pub fn size(&mut self, width: usize, height: usize) -> &mut Self {
         if width == 0 || height == 0 {
             panic!("with and height must be >= 0");
@@ -32,6 +35,9 @@ impl DisplayBuilder {
         self
     }
 
+    /// Set the pixel scale
+    ///
+    /// A scale of `2` or higher is useful for viewing the simulator on high DPI displays
     pub fn scale(&mut self, scale: usize) -> &mut Self {
         if scale == 0 {
             panic!("scale must be >= 0");
@@ -42,6 +48,7 @@ impl DisplayBuilder {
         self
     }
 
+    /// Set the theme for the display to use
     pub fn theme(&mut self, theme: DisplayTheme) -> &mut Self {
         self.theme = theme;
 
@@ -51,12 +58,14 @@ impl DisplayBuilder {
         self
     }
 
+    /// Add a gap between pixels, simulating the same effect of a physical display
     pub fn pixel_spacing(&mut self, pixel_spacing: usize) -> &mut Self {
         self.pixel_spacing = pixel_spacing;
 
         self
     }
 
+    /// Finish building the simulated display and open an SDL window to render it into
     pub fn build(&self) -> Display {
         let sdl_context = sdl2::init().unwrap();
         let video_subsystem = sdl_context.video().unwrap();

--- a/simulator/src/display_theme.rs
+++ b/simulator/src/display_theme.rs
@@ -1,0 +1,47 @@
+use crate::sim_pixel_color::SimPixelColor;
+use sdl2::pixels::Color;
+
+#[derive(Clone)]
+pub enum DisplayTheme {
+    Default,
+    LcdWhite,
+    LcdGreen,
+    LcdBlue,
+    OledWhite,
+    OledBlue,
+    ColorOled,
+}
+
+impl DisplayTheme {
+    pub fn pixel_color(&self, pixel: &SimPixelColor) -> Option<Color> {
+        match self {
+            DisplayTheme::ColorOled => Some(Color::RGB(pixel.0, pixel.1, pixel.2)),
+            theme => {
+                if *pixel != SimPixelColor(0, 0, 0) {
+                    match theme {
+                        DisplayTheme::Default => Some(Color::RGB(0, 0, 0)),
+                        DisplayTheme::LcdWhite => Some(Color::RGB(32, 32, 32)),
+                        DisplayTheme::LcdGreen => Some(Color::RGB(32, 32, 32)),
+                        DisplayTheme::LcdBlue => Some(Color::RGB(230, 230, 255)),
+                        DisplayTheme::OledBlue => Some(Color::RGB(0, 210, 255)),
+                        DisplayTheme::OledWhite => Some(Color::RGB(255, 255, 255)),
+                        _ => unreachable!(),
+                    }
+                } else {
+                    None
+                }
+            }
+        }
+    }
+
+    pub fn background_color(&self) -> Color {
+        match self {
+            DisplayTheme::Default => Color::RGB(255, 255, 255),
+            DisplayTheme::LcdWhite => Color::RGB(245, 245, 245),
+            DisplayTheme::LcdGreen => Color::RGB(120, 185, 50),
+            DisplayTheme::LcdBlue => Color::RGB(70, 80, 230),
+            DisplayTheme::OledBlue => Color::RGB(0, 20, 40),
+            DisplayTheme::OledWhite | DisplayTheme::ColorOled => Color::RGB(20, 20, 20),
+        }
+    }
+}

--- a/simulator/src/display_theme.rs
+++ b/simulator/src/display_theme.rs
@@ -1,18 +1,36 @@
 use crate::sim_pixel_color::SimPixelColor;
 use sdl2::pixels::Color;
 
+/// Display theme to use
 #[derive(Clone)]
 pub enum DisplayTheme {
+    /// A simple on/off, non-styled display with white background and black pixels
     Default,
+
+    /// An on/off classic LCD-like display with white background
     LcdWhite,
+
+    /// An on/off classic LCD-like display with green background and dark grey pixels
     LcdGreen,
+
+    /// An on/off LCD-like display with light blue background and blue-white pixels
     LcdBlue,
+
+    /// An on/off OLED-like display with a black background and white pixels
     OledWhite,
+
+    /// An on/off OLED-like display with a dark blue background and light blue pixels
     OledBlue,
+
+    /// An OLED-like display that supports 24 bit colour output
     ColorOled,
 }
 
 impl DisplayTheme {
+    /// Get the theme's pixel colour for a given pixel
+    ///
+    /// For on/off displays, a pixel value of `0, 0, 0` will be off, whilst any other value will be
+    /// interpreted as an "on" pixel.
     pub fn pixel_color(&self, pixel: &SimPixelColor) -> Option<Color> {
         match self {
             DisplayTheme::ColorOled => Some(Color::RGB(pixel.0, pixel.1, pixel.2)),
@@ -34,6 +52,7 @@ impl DisplayTheme {
         }
     }
 
+    /// Get the background colour for the current theme
     pub fn background_color(&self) -> Color {
         match self {
             DisplayTheme::Default => Color::RGB(255, 255, 255),

--- a/simulator/src/lib.rs
+++ b/simulator/src/lib.rs
@@ -49,8 +49,10 @@
 //!
 //!     display.draw(circle!((96, 32), 31, stroke = Some(1u8.into())));
 //!
-//!     display.draw(line!((32, 32), (1, 32), stroke = Some(1u8.into())).translate(icoord!(64, 0)));
-//!     display.draw(line!((32, 32), (40, 40), stroke = Some(1u8.into())).translate(icoord!(64, 0)));
+//!     display.draw(line!((32, 32), (1, 32), stroke = Some(1u8.into()))
+//!         .translate(icoord!(64, 0)));
+//!     display.draw(line!((32, 32), (40, 40), stroke = Some(1u8.into()))
+//!         .translate(icoord!(64, 0)));
 //!
 //!     loop {
 //!         let end = display.run_once();

--- a/simulator/src/lib.rs
+++ b/simulator/src/lib.rs
@@ -1,5 +1,8 @@
-extern crate embedded_graphics;
-extern crate sdl2;
+//! # Embedded graphics simulator
+//!
+//! ![It can display all sorts of embedded-graphics test code.](https://raw.githubusercontent.com/jamwaffles/embedded-graphics/master/assets/simulator-demo.png)
+
+#![deny(missing_docs)]
 
 mod display_builder;
 mod display_theme;
@@ -15,6 +18,11 @@ use sdl2::keyboard::Keycode;
 use sdl2::rect::Rect;
 use sdl2::render;
 
+/// Create a new window with a simulated display to draw into
+///
+/// You should use [`DisplayBuilder`] to create an instance of `Display`
+///
+/// [`DisplayBuilder`]: ./display_builder/struct.DisplayBuilder.html
 pub struct Display {
     width: usize,
     height: usize,
@@ -27,6 +35,7 @@ pub struct Display {
 }
 
 impl Display {
+    /// Update the display to show drawn pixels
     pub fn run_once(&mut self) -> bool {
         // Handle events
         for event in self.event_pump.poll_iter() {

--- a/simulator/src/lib.rs
+++ b/simulator/src/lib.rs
@@ -1,49 +1,19 @@
 extern crate embedded_graphics;
 extern crate sdl2;
 
-use embedded_graphics::drawable::Pixel;
-use embedded_graphics::pixelcolor::Rgb565;
-use embedded_graphics::prelude::*;
-use embedded_graphics::Drawing;
+mod display_builder;
+mod display_theme;
+mod sim_pixel_color;
 
+pub use crate::display_builder::DisplayBuilder;
+pub use crate::display_theme::DisplayTheme;
+pub use crate::sim_pixel_color::SimPixelColor;
+use embedded_graphics::drawable::Pixel;
+use embedded_graphics::Drawing;
 use sdl2::event::Event;
 use sdl2::keyboard::Keycode;
-use sdl2::pixels::Color;
 use sdl2::rect::Rect;
 use sdl2::render;
-
-#[derive(Clone, Copy, PartialEq)]
-pub struct SimPixelColor(pub u8, pub u8, pub u8);
-
-impl PixelColor for SimPixelColor {}
-
-impl From<u8> for SimPixelColor {
-    fn from(other: u8) -> Self {
-        SimPixelColor(other, other, other)
-    }
-}
-
-// Danger: Chops off upper bits
-impl From<u16> for SimPixelColor {
-    fn from(other: u16) -> Self {
-        SimPixelColor(other as u8, other as u8, other as u8)
-    }
-}
-
-// Danger: Chops off upper byte
-impl From<u32> for SimPixelColor {
-    fn from(other: u32) -> Self {
-        let [_, r, g, b] = other.to_be_bytes();
-
-        SimPixelColor(r, g, b)
-    }
-}
-
-impl From<Rgb565> for SimPixelColor {
-    fn from(other: Rgb565) -> Self {
-        SimPixelColor(other.r(), other.g(), other.b())
-    }
-}
 
 pub struct Display {
     width: usize,
@@ -106,140 +76,6 @@ impl Drawing<SimPixelColor> for Display {
             }
 
             self.pixels[y * self.width + x] = color;
-        }
-    }
-}
-
-#[derive(Clone)]
-pub enum DisplayTheme {
-    Default,
-    LcdWhite,
-    LcdGreen,
-    LcdBlue,
-    OledWhite,
-    OledBlue,
-    ColorOled,
-}
-
-impl DisplayTheme {
-    pub fn pixel_color(&self, pixel: &SimPixelColor) -> Option<Color> {
-        match self {
-            DisplayTheme::ColorOled => Some(Color::RGB(pixel.0, pixel.1, pixel.2)),
-            theme => {
-                if *pixel != SimPixelColor(0, 0, 0) {
-                    match theme {
-                        DisplayTheme::Default => Some(Color::RGB(0, 0, 0)),
-                        DisplayTheme::LcdWhite => Some(Color::RGB(32, 32, 32)),
-                        DisplayTheme::LcdGreen => Some(Color::RGB(32, 32, 32)),
-                        DisplayTheme::LcdBlue => Some(Color::RGB(230, 230, 255)),
-                        DisplayTheme::OledBlue => Some(Color::RGB(0, 210, 255)),
-                        DisplayTheme::OledWhite => Some(Color::RGB(255, 255, 255)),
-                        _ => unreachable!(),
-                    }
-                } else {
-                    None
-                }
-            }
-        }
-    }
-
-    pub fn background_color(&self) -> Color {
-        match self {
-            DisplayTheme::Default => Color::RGB(255, 255, 255),
-            DisplayTheme::LcdWhite => Color::RGB(245, 245, 245),
-            DisplayTheme::LcdGreen => Color::RGB(120, 185, 50),
-            DisplayTheme::LcdBlue => Color::RGB(70, 80, 230),
-            DisplayTheme::OledBlue => Color::RGB(0, 20, 40),
-            DisplayTheme::OledWhite | DisplayTheme::ColorOled => Color::RGB(20, 20, 20),
-        }
-    }
-}
-
-pub struct DisplayBuilder {
-    width: usize,
-    height: usize,
-    scale: usize,
-    pixel_spacing: usize,
-    theme: DisplayTheme,
-}
-
-impl DisplayBuilder {
-    pub fn new() -> Self {
-        Self {
-            width: 256,
-            height: 256,
-            scale: 1,
-            pixel_spacing: 0,
-            theme: DisplayTheme::Default,
-        }
-    }
-
-    pub fn size(&mut self, width: usize, height: usize) -> &mut Self {
-        if width == 0 || height == 0 {
-            panic!("with and height must be >= 0");
-        }
-
-        self.width = width;
-        self.height = height;
-
-        self
-    }
-
-    pub fn scale(&mut self, scale: usize) -> &mut Self {
-        if scale == 0 {
-            panic!("scale must be >= 0");
-        }
-
-        self.scale = scale;
-
-        self
-    }
-
-    pub fn theme(&mut self, theme: DisplayTheme) -> &mut Self {
-        self.theme = theme;
-
-        self.scale(3);
-        self.pixel_spacing(1);
-
-        self
-    }
-
-    pub fn pixel_spacing(&mut self, pixel_spacing: usize) -> &mut Self {
-        self.pixel_spacing = pixel_spacing;
-
-        self
-    }
-
-    pub fn build(&self) -> Display {
-        let sdl_context = sdl2::init().unwrap();
-        let video_subsystem = sdl_context.video().unwrap();
-
-        let window_width = self.width * self.scale + (self.width - 1) * self.pixel_spacing;
-        let window_height = self.height * self.scale + (self.height - 1) * self.pixel_spacing;
-
-        let window = video_subsystem
-            .window(
-                "graphics-emulator",
-                window_width as u32,
-                window_height as u32,
-            )
-            .position_centered()
-            .build()
-            .unwrap();
-
-        let pixels = vec![SimPixelColor(0, 0, 0); self.width * self.height];
-        let canvas = window.into_canvas().build().unwrap();
-        let event_pump = sdl_context.event_pump().unwrap();
-
-        Display {
-            width: self.width,
-            height: self.height,
-            scale: self.scale,
-            pixel_spacing: self.pixel_spacing,
-            theme: self.theme.clone(),
-            pixels: pixels.into_boxed_slice(),
-            canvas,
-            event_pump,
         }
     }
 }

--- a/simulator/src/lib.rs
+++ b/simulator/src/lib.rs
@@ -30,10 +30,12 @@ impl From<u16> for SimPixelColor {
     }
 }
 
-// Danger: Chops off upper bits
+// Danger: Chops off upper byte
 impl From<u32> for SimPixelColor {
     fn from(other: u32) -> Self {
-        SimPixelColor(other as u8, other as u8, other as u8)
+        let [_, r, g, b] = other.to_be_bytes();
+
+        SimPixelColor(r, g, b)
     }
 }
 

--- a/simulator/src/lib.rs
+++ b/simulator/src/lib.rs
@@ -1,6 +1,44 @@
 //! # Embedded graphics simulator
 //!
 //! ![It can display all sorts of embedded-graphics test code.](https://raw.githubusercontent.com/jamwaffles/embedded-graphics/master/assets/simulator-demo.png)
+//!
+//! The simulator can be used to test and debug [embedded-graphics](https://crates.io/crates/embedded-graphics) code, or produce snazzy examples for people to try drivers out without needing physical hardware to run on.
+//!
+//! # Examples
+//!
+//! ## Simulate a 128x64 SSD1306 OLED
+//!
+//! ```rust
+//! use embedded_graphics::prelude::*;
+//! use embedded_graphics::{icoord, circle, line, text_6x8};
+//! use embedded_graphics_simulator::{DisplayBuilder, DisplayTheme};
+//! use std::thread;
+//! use std::time::Duration;
+//!
+//! fn main() {
+//!     let mut display = DisplayBuilder::new()
+//!         .theme(DisplayTheme::OledBlue)
+//!         .size(128, 64)
+//!         .build();
+//!
+//!     display.draw(text_6x8!("Hello World!"));
+//!
+//!     display.draw(circle!((96, 32), 31, stroke = Some(1u8.into())));
+//!
+//!     display.draw(line!((32, 32), (1, 32), stroke = Some(1u8.into())).translate(icoord!(64, 0)));
+//!     display.draw(line!((32, 32), (40, 40), stroke = Some(1u8.into())).translate(icoord!(64, 0)));
+//!
+//!     loop {
+//!         let end = display.run_once();
+//!
+//!         if end {
+//!             break;
+//!         }
+//!
+//!         thread::sleep(Duration::from_millis(200));
+//!     }
+//! }
+//! ```
 
 #![deny(missing_docs)]
 

--- a/simulator/src/lib.rs
+++ b/simulator/src/lib.rs
@@ -2,7 +2,31 @@
 //!
 //! ![It can display all sorts of embedded-graphics test code.](https://raw.githubusercontent.com/jamwaffles/embedded-graphics/master/assets/simulator-demo.png)
 //!
-//! The simulator can be used to test and debug [embedded-graphics](https://crates.io/crates/embedded-graphics) code, or produce snazzy examples for people to try drivers out without needing physical hardware to run on.
+//! The simulator can be used to test and debug
+//! [embedded-graphics](https://crates.io/crates/embedded-graphics) code, or produce snazzy examples
+//! for people to try drivers out without needing physical hardware to run on.
+//!
+//! # Setup
+//!
+//! The simulator uses SDL and its development libraries which must be installed to build and run
+//! it.
+//!
+//! ## Linux (`apt`)
+//!
+//! ```bash
+//! sudo apt install libsdl2-dev
+//! ```
+//!
+//! ## macOS (`brew`)
+//!
+//! ```bash
+//! brew install sdl2
+//! ```
+//!
+//! ## Windows
+//!
+//! The Windows install process is a bit more involved, but it _does_ work. See [the SDL2
+//! wiki](https://wiki.libsdl.org/Installation#WinRT.2FWindows_8.2FWinPhone) for instructions.
 //!
 //! # Examples
 //!

--- a/simulator/src/lib.rs
+++ b/simulator/src/lib.rs
@@ -8,7 +8,7 @@
 //!
 //! ## Simulate a 128x64 SSD1306 OLED
 //!
-//! ```rust
+//! ```rust,no_run
 //! use embedded_graphics::prelude::*;
 //! use embedded_graphics::{icoord, circle, line, text_6x8};
 //! use embedded_graphics_simulator::{DisplayBuilder, DisplayTheme};

--- a/simulator/src/sim_pixel_color.rs
+++ b/simulator/src/sim_pixel_color.rs
@@ -1,6 +1,7 @@
 use embedded_graphics::pixelcolor::Rgb565;
 use embedded_graphics::prelude::*;
 
+/// 24 bit RGB pixel type used by the simulator display
 #[derive(Clone, Copy, PartialEq)]
 pub struct SimPixelColor(pub u8, pub u8, pub u8);
 

--- a/simulator/src/sim_pixel_color.rs
+++ b/simulator/src/sim_pixel_color.rs
@@ -1,0 +1,35 @@
+use embedded_graphics::pixelcolor::Rgb565;
+use embedded_graphics::prelude::*;
+
+#[derive(Clone, Copy, PartialEq)]
+pub struct SimPixelColor(pub u8, pub u8, pub u8);
+
+impl PixelColor for SimPixelColor {}
+
+impl From<u8> for SimPixelColor {
+    fn from(other: u8) -> Self {
+        SimPixelColor(other, other, other)
+    }
+}
+
+// Danger: Chops off upper bits
+impl From<u16> for SimPixelColor {
+    fn from(other: u16) -> Self {
+        SimPixelColor(other as u8, other as u8, other as u8)
+    }
+}
+
+// Danger: Chops off upper byte
+impl From<u32> for SimPixelColor {
+    fn from(other: u32) -> Self {
+        let [_, r, g, b] = other.to_be_bytes();
+
+        SimPixelColor(r, g, b)
+    }
+}
+
+impl From<Rgb565> for SimPixelColor {
+    fn from(other: Rgb565) -> Self {
+        SimPixelColor(other.r(), other.g(), other.b())
+    }
+}


### PR DESCRIPTION
This will set up the simulator to be publishable on crates.io under the `embeded-graphics-simulator` name. A bit of a mouthful, but will avoid collisions and ambiguity.

@rfuest Can you take a quick look at this and let me know if it's what you had in mind?

Closes #122 