### PR TITLE
Add list of drivers with e-g support to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,18 @@ fn main() {
 * `bmp` - use the [TinyBMP](https://crates.io/crates/tinybmp) crate for BMP image support.
 * `tga` - use the [TinyTGA](https://crates.io/crates/tinytga) crate for TGA image support.
 
+## Display drivers with embedded-graphics support
+
+* [ili9341](https://crates.io/crates/ili9341): A platform agnostic driver to interface with the ILI9341 (and ILI9340C) TFT LCD display
+* [ls010b7dh01](https://crates.io/crates/ls010b7dh01): A platform agnostic driver for the LS010B7DH01 memory LCD display
+* [sh1106](https://crates.io/crates/sh1106): I2C driver for the SH1106 OLED display
+* [ssd1306](https://crates.io/crates/ssd1306): I2C and SPI (4 wire) driver for the SSD1306 OLED display
+* [ssd1322](https://crates.io/crates/ssd1322): Pure Rust driver for the SSD1322 OLED display chip
+* [ssd1331](https://crates.io/crates/ssd1331): SPI (4 wire) driver for the SSD1331 OLED display
+* [ssd1351](https://crates.io/crates/ssd1351): SSD1351 driver
+* [ssd1675](https://crates.io/crates/ssd1675): Rust driver for the Solomon Systech SSD1675 e-Paper display (EPD) controller
+* [st7735-lcd](https://crates.io/crates/st7735-lcd): Rust library for displays using the ST7735 driver
+
 ## Attribution
 
 All source font PNGs are taken from the excellent [Uzebox Wiki page](http://uzebox.org/wiki/Font_Bitmaps).


### PR DESCRIPTION
I'm not sure if this list is complete and some drivers might not support the latest versions of e-g. But I think an overview of available drivers is useful anyway.