### PR TITLE
Rename primitives macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ Some smaller breaking changes, mostly polish around public APIs
 
 * The simulator is now [available on crates.io](https://crates.io/crates/embedded-graphics-simulator) as a standalone crate. You can now create simulated displays for testing out embedded_graphics code or showing off cool examples.
 
+### Changed
+
+* **(breaking)** Primitives macros have been renamed. This is primarily to fix conflicts with `std`'s `line!()` macro, but I thought I'd take the opportunity to make the names a bit better/more consistent at the same time:
+  * `line` -> `egline`
+  * `triangle` -> `egtriangle`
+  * `rect` -> `egrectangle`
+  * `circle` -> `egcircle`
+
 ## 0.5.0
 
 A big release, focussed on ergonomics. There are new macros to make drawing and positioning primitives and text much less noisy, as well as changes to the `Drawing` trait to remove the explicit `.into_iter()` call when passing objects to it.

--- a/README.md
+++ b/README.md
@@ -67,10 +67,10 @@ fn main() {
     // This will be whichever display driver you decide to use, like the SSD1306, SSD1351, etc
     let mut display = Display::new();
 
-    display.draw(circle!((64, 64), 64, stroke = Some(1u8)));
-    display.draw(line!((64, 64), (0, 64), stroke = Some(1u8)));
-    display.draw(line!((64, 64), (80, 80), stroke = Some(1u8)));
-    display.draw(rect!((64, 64), (80, 80), stroke = None, fill = Some(2u8)));
+    display.draw(gcircle!((64, 64), 64, stroke = Some(1u8)));
+    display.draw(gline!((64, 64), (0, 64), stroke = Some(1u8)));
+    display.draw(gline!((64, 64), (80, 80), stroke = Some(1u8)));
+    display.draw(grect!((64, 64), (80, 80), stroke = None, fill = Some(2u8)));
     display.draw(text_6x8!("Hello world!", stroke = Some(1u8)).translate(icoord!(5, 50)));
 }
 ```

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ fn main() {
     display.draw(gcircle!((64, 64), 64, stroke = Some(1u8)));
     display.draw(gline!((64, 64), (0, 64), stroke = Some(1u8)));
     display.draw(gline!((64, 64), (80, 80), stroke = Some(1u8)));
-    display.draw(grect!((64, 64), (80, 80), stroke = None, fill = Some(2u8)));
+    display.draw(grectangle!((64, 64), (80, 80), stroke = None, fill = Some(2u8)));
     display.draw(text_6x8!("Hello world!", stroke = Some(1u8)).translate(icoord!(5, 50)));
 }
 ```

--- a/README.md
+++ b/README.md
@@ -67,10 +67,10 @@ fn main() {
     // This will be whichever display driver you decide to use, like the SSD1306, SSD1351, etc
     let mut display = Display::new();
 
-    display.draw(gcircle!((64, 64), 64, stroke = Some(1u8)));
-    display.draw(gline!((64, 64), (0, 64), stroke = Some(1u8)));
-    display.draw(gline!((64, 64), (80, 80), stroke = Some(1u8)));
-    display.draw(grectangle!((64, 64), (80, 80), stroke = None, fill = Some(2u8)));
+    display.draw(egcircle!((64, 64), 64, stroke = Some(1u8)));
+    display.draw(egline!((64, 64), (0, 64), stroke = Some(1u8)));
+    display.draw(egline!((64, 64), (80, 80), stroke = Some(1u8)));
+    display.draw(egrectangle!((64, 64), (80, 80), stroke = None, fill = Some(2u8)));
     display.draw(text_6x8!("Hello world!", stroke = Some(1u8)).translate(icoord!(5, 50)));
 }
 ```

--- a/embedded-graphics/benches/primitives.rs
+++ b/embedded-graphics/benches/primitives.rs
@@ -1,7 +1,7 @@
 use criterion::*;
 use embedded_graphics::{
     prelude::*,
-    primitives::{Circle, Line, Rect, Triangle},
+    primitives::{Circle, Line, Rectangle, Triangle},
 };
 
 fn filled_circle(c: &mut Criterion) {
@@ -16,7 +16,7 @@ fn filled_circle(c: &mut Criterion) {
 
 fn filled_rect(c: &mut Criterion) {
     c.bench_function("filled rectangle", |b| {
-        let object: Rect<u8> = Rect::new(Coord::new(100, 100), Coord::new(200, 200))
+        let object: Rectangle<u8> = Rectangle::new(Coord::new(100, 100), Coord::new(200, 200))
             .fill(Some(1u8.into()))
             .stroke(Some(10u8.into()));
 
@@ -26,8 +26,8 @@ fn filled_rect(c: &mut Criterion) {
 
 fn empty_rect(c: &mut Criterion) {
     c.bench_function("unfilled rectangle", |b| {
-        let object: Rect<u8> =
-            Rect::new(Coord::new(100, 100), Coord::new(200, 200)).stroke(Some(10u8.into()));
+        let object: Rectangle<u8> =
+            Rectangle::new(Coord::new(100, 100), Coord::new(200, 200)).stroke(Some(10u8.into()));
 
         b.iter(|| object.into_iter().collect::<Vec<Pixel<u8>>>())
     });

--- a/embedded-graphics/src/coord.rs
+++ b/embedded-graphics/src/coord.rs
@@ -33,7 +33,7 @@ mod internal_coord {
     /// `Coord` instead of this builtin implementation.
     ///
     /// [`UnsignedCoord`]: ../unsignedcoord/struct.UnsignedCoord.html
-    /// [`Rect`]: ../primitives/rect/struct.Rect.html
+    /// [`Rect`]: ../primitives/rectangle/struct.Rectangle.html
     /// [`Vector2<i32>`]: https://docs.rs/nalgebra/0.18.0/nalgebra/base/type.Vector2.html
     #[derive(Debug, Copy, Clone, Eq, PartialEq)]
     pub struct Coord(pub CoordPart, pub CoordPart);

--- a/embedded-graphics/src/lib.rs
+++ b/embedded-graphics/src/lib.rs
@@ -10,7 +10,7 @@
 //! * [TGA-format images](./image/struct.ImageTga.html) (with `tga` feature enabled)
 //! * [Primitives](./primitives/index.html)
 //!     * [Lines](./primitives/line/struct.Line.html)
-//!     * [Rectangles (and squares)](./primitives/rect/struct.Rect.html)
+//!     * [Rectangles (and squares)](./primitives/rectangle/struct.Rectangle.html)
 //!     * [Circles](./primitives/circle/struct.Circle.html)
 //!     * [Triangles](./primitives/triangle/struct.Triangle.html)
 //! * [Text with multiple fonts](./fonts/index.html#types)
@@ -115,11 +115,11 @@
 //!
 //! ```rust
 //! use embedded_graphics::prelude::*;
-//! use embedded_graphics::{text_6x8, gcircle, icoord, grect};
+//! use embedded_graphics::{text_6x8, gcircle, icoord, grectangle};
 //! # use embedded_graphics::mock_display::Display;
 //!
 //! fn build_thing(text: &'static str) -> impl Iterator<Item = Pixel<u8>> {
-//!     grect!((0, 0), (40, 40)).into_iter()
+//!     grectangle!((0, 0), (40, 40)).into_iter()
 //!         .chain(gcircle!((20, 20), 8, fill = Some(1u8)))
 //!         .chain(text_6x8!(text, fill = Some(20u8)).translate(icoord!(20, 16)))
 //! }

--- a/embedded-graphics/src/lib.rs
+++ b/embedded-graphics/src/lib.rs
@@ -98,11 +98,11 @@
 //!
 //! ```rust
 //! use embedded_graphics::prelude::*;
-//! use embedded_graphics::{text_6x8, circle, icoord};
+//! use embedded_graphics::{text_6x8, gcircle, icoord};
 //! # use embedded_graphics::mock_display::Display;
 //! # let mut display = Display::default();
 //!
-//! let c = circle!((20, 20), 8, fill = Some(1u8));
+//! let c = gcircle!((20, 20), 8, fill = Some(1u8));
 //! let t = text_6x8!("Hello Rust!", fill = Some(20u8)).translate(icoord!(20, 16));
 //!
 //! display.draw(c);
@@ -115,12 +115,12 @@
 //!
 //! ```rust
 //! use embedded_graphics::prelude::*;
-//! use embedded_graphics::{text_6x8, circle, icoord, rect};
+//! use embedded_graphics::{text_6x8, gcircle, icoord, grect};
 //! # use embedded_graphics::mock_display::Display;
 //!
 //! fn build_thing(text: &'static str) -> impl Iterator<Item = Pixel<u8>> {
-//!     rect!((0, 0), (40, 40)).into_iter()
-//!         .chain(circle!((20, 20), 8, fill = Some(1u8)))
+//!     grect!((0, 0), (40, 40)).into_iter()
+//!         .chain(gcircle!((20, 20), 8, fill = Some(1u8)))
 //!         .chain(text_6x8!(text, fill = Some(20u8)).translate(icoord!(20, 16)))
 //! }
 //!
@@ -183,7 +183,7 @@ use crate::pixelcolor::PixelColor;
 /// ```rust
 /// use embedded_graphics::prelude::*;
 /// use embedded_graphics::Drawing;
-/// use embedded_graphics::circle;
+/// use embedded_graphics::gcircle;
 ///
 /// # struct SPI1;
 /// #
@@ -228,7 +228,7 @@ use crate::pixelcolor::PixelColor;
 ///     };
 ///
 ///     // Draw a circle centered around `(32, 32)` with a radius of `10` and a stroke of `1u8`
-///     display.draw(circle!((32, 32), 10, stroke = Some(1u8)));
+///     display.draw(gcircle!((32, 32), 10, stroke = Some(1u8)));
 ///
 ///     // Update the display
 ///     display.flush().expect("Failed to send data to display");
@@ -258,7 +258,7 @@ where
 /// could be fixed by using a fixed length chunked buffering scheme.
 ///
 /// ```rust
-/// use embedded_graphics::circle;
+/// use embedded_graphics::gcircle;
 /// use embedded_graphics::prelude::*;
 /// use embedded_graphics::SizedDrawing;
 ///
@@ -315,7 +315,7 @@ where
 ///     };
 ///
 ///     // Draw a circle centered around `(32, 32)` with a radius of `10` and a stroke of `1u8`
-///     display.draw_sized(circle!((32, 32), 10, stroke = Some(1u8)));
+///     display.draw_sized(gcircle!((32, 32), 10, stroke = Some(1u8)));
 ///
 ///     // No `flush()` is required as `draw_sized()` sends the bytes directly
 /// }

--- a/embedded-graphics/src/lib.rs
+++ b/embedded-graphics/src/lib.rs
@@ -98,11 +98,11 @@
 //!
 //! ```rust
 //! use embedded_graphics::prelude::*;
-//! use embedded_graphics::{text_6x8, gcircle, icoord};
+//! use embedded_graphics::{text_6x8, egcircle, icoord};
 //! # use embedded_graphics::mock_display::Display;
 //! # let mut display = Display::default();
 //!
-//! let c = gcircle!((20, 20), 8, fill = Some(1u8));
+//! let c = egcircle!((20, 20), 8, fill = Some(1u8));
 //! let t = text_6x8!("Hello Rust!", fill = Some(20u8)).translate(icoord!(20, 16));
 //!
 //! display.draw(c);
@@ -115,12 +115,12 @@
 //!
 //! ```rust
 //! use embedded_graphics::prelude::*;
-//! use embedded_graphics::{text_6x8, gcircle, icoord, grectangle};
+//! use embedded_graphics::{text_6x8, egcircle, icoord, egrectangle};
 //! # use embedded_graphics::mock_display::Display;
 //!
 //! fn build_thing(text: &'static str) -> impl Iterator<Item = Pixel<u8>> {
-//!     grectangle!((0, 0), (40, 40)).into_iter()
-//!         .chain(gcircle!((20, 20), 8, fill = Some(1u8)))
+//!     egrectangle!((0, 0), (40, 40)).into_iter()
+//!         .chain(egcircle!((20, 20), 8, fill = Some(1u8)))
 //!         .chain(text_6x8!(text, fill = Some(20u8)).translate(icoord!(20, 16)))
 //! }
 //!
@@ -183,7 +183,7 @@ use crate::pixelcolor::PixelColor;
 /// ```rust
 /// use embedded_graphics::prelude::*;
 /// use embedded_graphics::Drawing;
-/// use embedded_graphics::gcircle;
+/// use embedded_graphics::egcircle;
 ///
 /// # struct SPI1;
 /// #
@@ -228,7 +228,7 @@ use crate::pixelcolor::PixelColor;
 ///     };
 ///
 ///     // Draw a circle centered around `(32, 32)` with a radius of `10` and a stroke of `1u8`
-///     display.draw(gcircle!((32, 32), 10, stroke = Some(1u8)));
+///     display.draw(egcircle!((32, 32), 10, stroke = Some(1u8)));
 ///
 ///     // Update the display
 ///     display.flush().expect("Failed to send data to display");
@@ -258,7 +258,7 @@ where
 /// could be fixed by using a fixed length chunked buffering scheme.
 ///
 /// ```rust
-/// use embedded_graphics::gcircle;
+/// use embedded_graphics::egcircle;
 /// use embedded_graphics::prelude::*;
 /// use embedded_graphics::SizedDrawing;
 ///
@@ -315,7 +315,7 @@ where
 ///     };
 ///
 ///     // Draw a circle centered around `(32, 32)` with a radius of `10` and a stroke of `1u8`
-///     display.draw_sized(gcircle!((32, 32), 10, stroke = Some(1u8)));
+///     display.draw_sized(egcircle!((32, 32), 10, stroke = Some(1u8)));
 ///
 ///     // No `flush()` is required as `draw_sized()` sends the bytes directly
 /// }

--- a/embedded-graphics/src/primitives/circle.rs
+++ b/embedded-graphics/src/primitives/circle.rs
@@ -13,7 +13,7 @@ use crate::unsignedcoord::{ToSigned, UnsignedCoord};
 ///
 /// # Examples
 ///
-/// The [macro examples](../../macro.circle.html) make for more concise code.
+/// The [macro examples](../../macro.gcircle.html) make for more concise code.
 ///
 /// ## Create some circles with different styles
 ///

--- a/embedded-graphics/src/primitives/circle.rs
+++ b/embedded-graphics/src/primitives/circle.rs
@@ -13,7 +13,7 @@ use crate::unsignedcoord::{ToSigned, UnsignedCoord};
 ///
 /// # Examples
 ///
-/// The [macro examples](../../macro.gcircle.html) make for more concise code.
+/// The [macro examples](../../macro.egcircle.html) make for more concise code.
 ///
 /// ## Create some circles with different styles
 ///

--- a/embedded-graphics/src/primitives/line.rs
+++ b/embedded-graphics/src/primitives/line.rs
@@ -13,7 +13,7 @@ use crate::unsignedcoord::{ToSigned, UnsignedCoord};
 ///
 /// # Examples
 ///
-/// The [macro examples](../../macro.line.html) make for more concise code.
+/// The [macro examples](../../macro.gline.html) make for more concise code.
 ///
 /// ## Create some lines with different styles
 ///

--- a/embedded-graphics/src/primitives/line.rs
+++ b/embedded-graphics/src/primitives/line.rs
@@ -13,7 +13,7 @@ use crate::unsignedcoord::{ToSigned, UnsignedCoord};
 ///
 /// # Examples
 ///
-/// The [macro examples](../../macro.gline.html) make for more concise code.
+/// The [macro examples](../../macro.egline.html) make for more concise code.
 ///
 /// ## Create some lines with different styles
 ///

--- a/embedded-graphics/src/primitives/mod.rs
+++ b/embedded-graphics/src/primitives/mod.rs
@@ -4,7 +4,7 @@ use crate::drawable::Dimensions;
 
 pub mod circle;
 pub mod line;
-pub mod rect;
+pub mod rectangle;
 pub mod triangle;
 
 /// Primitive trait
@@ -12,7 +12,7 @@ pub trait Primitive: Dimensions {}
 
 pub use self::circle::Circle;
 pub use self::line::Line;
-pub use self::rect::Rect;
+pub use self::rectangle::Rectangle;
 pub use self::triangle::Triangle;
 
 /// Create a [`Circle`](./primitives/circle/struct.Circle.html) with optional styling using a
@@ -82,15 +82,15 @@ macro_rules! gline {
     }};
 }
 
-/// Create a [`Rect`](./primitives/rect/struct.Rect.html) with optional styling using a
+/// Create a [`Rectangle`](./primitives/rectangle/struct.Rectangle.html) with optional styling using a
 /// convenient macro.
 ///
 /// ```rust
-/// use embedded_graphics::{grect, style::Style, primitives::Rect};
+/// use embedded_graphics::{grectangle, style::Style, primitives::Rectangle};
 ///
-/// let empty_rect: Rect<u8> = grect!((10, 20), (30, 40));
-/// let filled_rect: Rect<u8> = grect!((10, 20), (30, 40), stroke = Some(5u8), fill = Some(10u8));
-/// let rect_default_style: Rect<u8> = grect!((10, 20), (30, 40), style = Style::default());
+/// let empty_rect: Rectangle<u8> = grectangle!((10, 20), (30, 40));
+/// let filled_rect: Rectangle<u8> = grectangle!((10, 20), (30, 40), stroke = Some(5u8), fill = Some(10u8));
+/// let rect_default_style: Rectangle<u8> = grectangle!((10, 20), (30, 40), style = Style::default());
 /// ```
 ///
 /// Style properties like `stroke` map to the method calls on the
@@ -99,19 +99,19 @@ macro_rules! gline {
 ///
 /// ```rust
 /// use embedded_graphics::prelude::*;
-/// use embedded_graphics::{grect, style::Style, primitives::Rect};
+/// use embedded_graphics::{grectangle, style::Style, primitives::Rectangle};
 ///
-/// let Rect: Rect<u8> = grect!((10, 20), (30, 40), stroke = Some(5u8), fill = Some(10u8));
-/// let Rect: Rect<u8> = Rect::new(Coord::new(10, 20), Coord::new(30, 40))
+/// let Rectangle: Rectangle<u8> = grectangle!((10, 20), (30, 40), stroke = Some(5u8), fill = Some(10u8));
+/// let Rectangle: Rectangle<u8> = Rectangle::new(Coord::new(10, 20), Coord::new(30, 40))
 ///     .stroke(Some(5u8))
 ///     .fill(Some(10u8));
 /// ```
 #[macro_export]
-macro_rules! grect {
+macro_rules! grectangle {
     (($x1:expr, $y1:expr), ($x2:expr, $y2:expr) $(, $style_key:ident = $style_value:expr )* $(,)?) => {{
         #[allow(unused_imports)]
         use $crate::style::WithStyle;
-        $crate::primitives::Rect::new($crate::coord::Coord::new($x1, $y1), $crate::coord::Coord::new($x2, $y2))
+        $crate::primitives::Rectangle::new($crate::coord::Coord::new($x1, $y1), $crate::coord::Coord::new($x2, $y2))
             $( .$style_key($style_value) )*
     }};
 }
@@ -171,9 +171,10 @@ mod tests {
 
     #[test]
     fn rect() {
-        let _r: Rect<u8> = grect!((10, 20), (30, 40));
-        let _r: Rect<u8> = grect!((10, 20), (30, 40), stroke = Some(1u8), fill = Some(10u8));
-        let _r: Rect<u8> = grect!((10, 20), (30, 40), style = Style::default());
+        let _r: Rectangle<u8> = grectangle!((10, 20), (30, 40));
+        let _r: Rectangle<u8> =
+            grectangle!((10, 20), (30, 40), stroke = Some(1u8), fill = Some(10u8));
+        let _r: Rectangle<u8> = grectangle!((10, 20), (30, 40), style = Style::default());
     }
 
     #[test]

--- a/embedded-graphics/src/primitives/mod.rs
+++ b/embedded-graphics/src/primitives/mod.rs
@@ -19,11 +19,11 @@ pub use self::triangle::Triangle;
 /// convenient macro.
 ///
 /// ```rust
-/// use embedded_graphics::{circle, style::Style, primitives::Circle};
+/// use embedded_graphics::{gcircle, style::Style, primitives::Circle};
 ///
-/// let line_circle: Circle<u8> = circle!((10, 20), 30);
-/// let filled_circle: Circle<u8> = circle!((10, 20), 30, stroke = Some(5u8), fill = Some(10u8));
-/// let default_style: Circle<u8> = circle!((10, 20), 30, style = Style::default());
+/// let line_circle: Circle<u8> = gcircle!((10, 20), 30);
+/// let filled_circle: Circle<u8> = gcircle!((10, 20), 30, stroke = Some(5u8), fill = Some(10u8));
+/// let default_style: Circle<u8> = gcircle!((10, 20), 30, style = Style::default());
 /// ```
 ///
 /// Style properties like `stroke` map to the method calls on the
@@ -32,13 +32,13 @@ pub use self::triangle::Triangle;
 ///
 /// ```rust
 /// use embedded_graphics::prelude::*;
-/// use embedded_graphics::{circle, style::Style, primitives::Circle};
+/// use embedded_graphics::{gcircle, style::Style, primitives::Circle};
 ///
-/// let circle: Circle<u8> = circle!((10, 20), 30, stroke = Some(5u8), fill = Some(10u8));
+/// let circle: Circle<u8> = gcircle!((10, 20), 30, stroke = Some(5u8), fill = Some(10u8));
 /// let circle: Circle<u8> = Circle::new(Coord::new(10, 20), 30).stroke(Some(5u8)).fill(Some(10u8));
 /// ```
 #[macro_export]
-macro_rules! circle {
+macro_rules! gcircle {
     (($cx:expr, $cy:expr), $r:expr $(, $style_key:ident = $style_value:expr )* $(,)?) => {{
         #[allow(unused_imports)]
         use $crate::style::WithStyle;
@@ -53,10 +53,10 @@ macro_rules! circle {
 /// Note that only the `stroke` property has any effect on lines currently.
 ///
 /// ```rust
-/// use embedded_graphics::{line, style::Style, primitives::Line};
+/// use embedded_graphics::{gline, style::Style, primitives::Line};
 ///
-/// let line: Line<u8> = line!((10, 20), (30, 40));
-/// let stroke_line: Line<u8> = line!((10, 20), (30, 40), stroke = Some(5u8));
+/// let line: Line<u8> = gline!((10, 20), (30, 40));
+/// let stroke_line: Line<u8> = gline!((10, 20), (30, 40), stroke = Some(5u8));
 /// ```
 ///
 /// Style properties like `stroke` map to the method calls on the
@@ -65,15 +65,15 @@ macro_rules! circle {
 ///
 /// ```rust
 /// use embedded_graphics::prelude::*;
-/// use embedded_graphics::{line, style::Style, primitives::Line};
+/// use embedded_graphics::{gline, style::Style, primitives::Line};
 ///
-/// let Line: Line<u8> = line!((10, 20), (30, 40), stroke = Some(5u8), fill = Some(10u8));
+/// let Line: Line<u8> = gline!((10, 20), (30, 40), stroke = Some(5u8), fill = Some(10u8));
 /// let Line: Line<u8> = Line::new(Coord::new(10, 20), Coord::new(30, 40))
 ///     .stroke(Some(5u8))
 ///     .fill(Some(10u8));
 /// ```
 #[macro_export]
-macro_rules! line {
+macro_rules! gline {
     (($x1:expr, $y1:expr), ($x2:expr, $y2:expr) $(, $style_key:ident = $style_value:expr )* $(,)?) => {{
         #[allow(unused_imports)]
         use $crate::style::WithStyle;
@@ -86,11 +86,11 @@ macro_rules! line {
 /// convenient macro.
 ///
 /// ```rust
-/// use embedded_graphics::{rect, style::Style, primitives::Rect};
+/// use embedded_graphics::{grect, style::Style, primitives::Rect};
 ///
-/// let empty_rect: Rect<u8> = rect!((10, 20), (30, 40));
-/// let filled_rect: Rect<u8> = rect!((10, 20), (30, 40), stroke = Some(5u8), fill = Some(10u8));
-/// let rect_default_style: Rect<u8> = rect!((10, 20), (30, 40), style = Style::default());
+/// let empty_rect: Rect<u8> = grect!((10, 20), (30, 40));
+/// let filled_rect: Rect<u8> = grect!((10, 20), (30, 40), stroke = Some(5u8), fill = Some(10u8));
+/// let rect_default_style: Rect<u8> = grect!((10, 20), (30, 40), style = Style::default());
 /// ```
 ///
 /// Style properties like `stroke` map to the method calls on the
@@ -99,15 +99,15 @@ macro_rules! line {
 ///
 /// ```rust
 /// use embedded_graphics::prelude::*;
-/// use embedded_graphics::{rect, style::Style, primitives::Rect};
+/// use embedded_graphics::{grect, style::Style, primitives::Rect};
 ///
-/// let Rect: Rect<u8> = rect!((10, 20), (30, 40), stroke = Some(5u8), fill = Some(10u8));
+/// let Rect: Rect<u8> = grect!((10, 20), (30, 40), stroke = Some(5u8), fill = Some(10u8));
 /// let Rect: Rect<u8> = Rect::new(Coord::new(10, 20), Coord::new(30, 40))
 ///     .stroke(Some(5u8))
 ///     .fill(Some(10u8));
 /// ```
 #[macro_export]
-macro_rules! rect {
+macro_rules! grect {
     (($x1:expr, $y1:expr), ($x2:expr, $y2:expr) $(, $style_key:ident = $style_value:expr )* $(,)?) => {{
         #[allow(unused_imports)]
         use $crate::style::WithStyle;
@@ -120,11 +120,11 @@ macro_rules! rect {
 /// convenient macro.
 ///
 /// ```rust
-/// use embedded_graphics::{triangle, style::Style, primitives::Triangle};
+/// use embedded_graphics::{gtriangle, style::Style, primitives::Triangle};
 ///
-/// let empty_triangle: Triangle<u8> = triangle!((10, 20), (30, 40), (50, 60));
-/// let filled_triangle: Triangle<u8> = triangle!((10, 20), (30, 40), (50, 60), stroke = Some(5u8), fill = Some(10u8));
-/// let triangle_default_style: Triangle<u8> = triangle!((10, 20), (30, 40), (50, 60), style = Style::default());
+/// let empty_triangle: Triangle<u8> = gtriangle!((10, 20), (30, 40), (50, 60));
+/// let filled_triangle: Triangle<u8> = gtriangle!((10, 20), (30, 40), (50, 60), stroke = Some(5u8), fill = Some(10u8));
+/// let triangle_default_style: Triangle<u8> = gtriangle!((10, 20), (30, 40), (50, 60), style = Style::default());
 /// ```
 ///
 /// Style properties like `stroke` map to the method calls on the
@@ -133,15 +133,15 @@ macro_rules! rect {
 ///
 /// ```rust
 /// use embedded_graphics::prelude::*;
-/// use embedded_graphics::{triangle, style::Style, primitives::Triangle};
+/// use embedded_graphics::{gtriangle, style::Style, primitives::Triangle};
 ///
-/// let Triangle: Triangle<u8> = triangle!((10, 20), (30, 40), (50, 60), stroke = Some(5u8), fill = Some(10u8));
+/// let Triangle: Triangle<u8> = gtriangle!((10, 20), (30, 40), (50, 60), stroke = Some(5u8), fill = Some(10u8));
 /// let Triangle: Triangle<u8> = Triangle::new(Coord::new(10, 20), Coord::new(30, 40), Coord::new(50, 60))
 ///     .stroke(Some(5u8))
 ///     .fill(Some(10u8));
 /// ```
 #[macro_export]
-macro_rules! triangle {
+macro_rules! gtriangle {
     (($x1:expr, $y1:expr), ($x2:expr, $y2:expr), ($x3:expr, $y3:expr) $(, $style_key:ident = $style_value:expr )* $(,)?) => {{
         #[allow(unused_imports)]
         use $crate::style::WithStyle;
@@ -157,35 +157,35 @@ mod tests {
 
     #[test]
     fn circle() {
-        let _c: Circle<u8> = circle!((10, 20), 30);
-        let _c: Circle<u8> = circle!((10, 20), 30, stroke = Some(1u8), fill = Some(10u8));
-        let _c: Circle<u8> = circle!((10, 20), 30, style = Style::default());
+        let _c: Circle<u8> = gcircle!((10, 20), 30);
+        let _c: Circle<u8> = gcircle!((10, 20), 30, stroke = Some(1u8), fill = Some(10u8));
+        let _c: Circle<u8> = gcircle!((10, 20), 30, style = Style::default());
     }
 
     #[test]
     fn line() {
-        let _l: Line<u8> = line!((10, 20), (30, 40));
-        let _l: Line<u8> = line!((10, 20), (30, 40), stroke = Some(1u8), fill = Some(10u8));
-        let _l: Line<u8> = line!((10, 20), (30, 40), style = Style::default());
+        let _l: Line<u8> = gline!((10, 20), (30, 40));
+        let _l: Line<u8> = gline!((10, 20), (30, 40), stroke = Some(1u8), fill = Some(10u8));
+        let _l: Line<u8> = gline!((10, 20), (30, 40), style = Style::default());
     }
 
     #[test]
     fn rect() {
-        let _r: Rect<u8> = rect!((10, 20), (30, 40));
-        let _r: Rect<u8> = rect!((10, 20), (30, 40), stroke = Some(1u8), fill = Some(10u8));
-        let _r: Rect<u8> = rect!((10, 20), (30, 40), style = Style::default());
+        let _r: Rect<u8> = grect!((10, 20), (30, 40));
+        let _r: Rect<u8> = grect!((10, 20), (30, 40), stroke = Some(1u8), fill = Some(10u8));
+        let _r: Rect<u8> = grect!((10, 20), (30, 40), style = Style::default());
     }
 
     #[test]
     fn triangle() {
-        let _t: Triangle<u8> = triangle!((10, 20), (30, 40), (50, 60));
-        let _t: Triangle<u8> = triangle!(
+        let _t: Triangle<u8> = gtriangle!((10, 20), (30, 40), (50, 60));
+        let _t: Triangle<u8> = gtriangle!(
             (10, 20),
             (30, 40),
             (50, 60),
             stroke = Some(1u8),
             fill = Some(10u8)
         );
-        let _t: Triangle<u8> = triangle!((10, 20), (30, 40), (50, 60), style = Style::default());
+        let _t: Triangle<u8> = gtriangle!((10, 20), (30, 40), (50, 60), style = Style::default());
     }
 }

--- a/embedded-graphics/src/primitives/mod.rs
+++ b/embedded-graphics/src/primitives/mod.rs
@@ -19,11 +19,11 @@ pub use self::triangle::Triangle;
 /// convenient macro.
 ///
 /// ```rust
-/// use embedded_graphics::{gcircle, style::Style, primitives::Circle};
+/// use embedded_graphics::{egcircle, style::Style, primitives::Circle};
 ///
-/// let line_circle: Circle<u8> = gcircle!((10, 20), 30);
-/// let filled_circle: Circle<u8> = gcircle!((10, 20), 30, stroke = Some(5u8), fill = Some(10u8));
-/// let default_style: Circle<u8> = gcircle!((10, 20), 30, style = Style::default());
+/// let line_circle: Circle<u8> = egcircle!((10, 20), 30);
+/// let filled_circle: Circle<u8> = egcircle!((10, 20), 30, stroke = Some(5u8), fill = Some(10u8));
+/// let default_style: Circle<u8> = egcircle!((10, 20), 30, style = Style::default());
 /// ```
 ///
 /// Style properties like `stroke` map to the method calls on the
@@ -32,13 +32,13 @@ pub use self::triangle::Triangle;
 ///
 /// ```rust
 /// use embedded_graphics::prelude::*;
-/// use embedded_graphics::{gcircle, style::Style, primitives::Circle};
+/// use embedded_graphics::{egcircle, style::Style, primitives::Circle};
 ///
-/// let circle: Circle<u8> = gcircle!((10, 20), 30, stroke = Some(5u8), fill = Some(10u8));
+/// let circle: Circle<u8> = egcircle!((10, 20), 30, stroke = Some(5u8), fill = Some(10u8));
 /// let circle: Circle<u8> = Circle::new(Coord::new(10, 20), 30).stroke(Some(5u8)).fill(Some(10u8));
 /// ```
 #[macro_export]
-macro_rules! gcircle {
+macro_rules! egcircle {
     (($cx:expr, $cy:expr), $r:expr $(, $style_key:ident = $style_value:expr )* $(,)?) => {{
         #[allow(unused_imports)]
         use $crate::style::WithStyle;
@@ -53,10 +53,10 @@ macro_rules! gcircle {
 /// Note that only the `stroke` property has any effect on lines currently.
 ///
 /// ```rust
-/// use embedded_graphics::{gline, style::Style, primitives::Line};
+/// use embedded_graphics::{egline, style::Style, primitives::Line};
 ///
-/// let line: Line<u8> = gline!((10, 20), (30, 40));
-/// let stroke_line: Line<u8> = gline!((10, 20), (30, 40), stroke = Some(5u8));
+/// let line: Line<u8> = egline!((10, 20), (30, 40));
+/// let stroke_line: Line<u8> = egline!((10, 20), (30, 40), stroke = Some(5u8));
 /// ```
 ///
 /// Style properties like `stroke` map to the method calls on the
@@ -65,15 +65,15 @@ macro_rules! gcircle {
 ///
 /// ```rust
 /// use embedded_graphics::prelude::*;
-/// use embedded_graphics::{gline, style::Style, primitives::Line};
+/// use embedded_graphics::{egline, style::Style, primitives::Line};
 ///
-/// let Line: Line<u8> = gline!((10, 20), (30, 40), stroke = Some(5u8), fill = Some(10u8));
+/// let Line: Line<u8> = egline!((10, 20), (30, 40), stroke = Some(5u8), fill = Some(10u8));
 /// let Line: Line<u8> = Line::new(Coord::new(10, 20), Coord::new(30, 40))
 ///     .stroke(Some(5u8))
 ///     .fill(Some(10u8));
 /// ```
 #[macro_export]
-macro_rules! gline {
+macro_rules! egline {
     (($x1:expr, $y1:expr), ($x2:expr, $y2:expr) $(, $style_key:ident = $style_value:expr )* $(,)?) => {{
         #[allow(unused_imports)]
         use $crate::style::WithStyle;
@@ -86,11 +86,11 @@ macro_rules! gline {
 /// convenient macro.
 ///
 /// ```rust
-/// use embedded_graphics::{grectangle, style::Style, primitives::Rectangle};
+/// use embedded_graphics::{egrectangle, style::Style, primitives::Rectangle};
 ///
-/// let empty_rect: Rectangle<u8> = grectangle!((10, 20), (30, 40));
-/// let filled_rect: Rectangle<u8> = grectangle!((10, 20), (30, 40), stroke = Some(5u8), fill = Some(10u8));
-/// let rect_default_style: Rectangle<u8> = grectangle!((10, 20), (30, 40), style = Style::default());
+/// let empty_rect: Rectangle<u8> = egrectangle!((10, 20), (30, 40));
+/// let filled_rect: Rectangle<u8> = egrectangle!((10, 20), (30, 40), stroke = Some(5u8), fill = Some(10u8));
+/// let rect_default_style: Rectangle<u8> = egrectangle!((10, 20), (30, 40), style = Style::default());
 /// ```
 ///
 /// Style properties like `stroke` map to the method calls on the
@@ -99,15 +99,15 @@ macro_rules! gline {
 ///
 /// ```rust
 /// use embedded_graphics::prelude::*;
-/// use embedded_graphics::{grectangle, style::Style, primitives::Rectangle};
+/// use embedded_graphics::{egrectangle, style::Style, primitives::Rectangle};
 ///
-/// let Rectangle: Rectangle<u8> = grectangle!((10, 20), (30, 40), stroke = Some(5u8), fill = Some(10u8));
+/// let Rectangle: Rectangle<u8> = egrectangle!((10, 20), (30, 40), stroke = Some(5u8), fill = Some(10u8));
 /// let Rectangle: Rectangle<u8> = Rectangle::new(Coord::new(10, 20), Coord::new(30, 40))
 ///     .stroke(Some(5u8))
 ///     .fill(Some(10u8));
 /// ```
 #[macro_export]
-macro_rules! grectangle {
+macro_rules! egrectangle {
     (($x1:expr, $y1:expr), ($x2:expr, $y2:expr) $(, $style_key:ident = $style_value:expr )* $(,)?) => {{
         #[allow(unused_imports)]
         use $crate::style::WithStyle;
@@ -120,11 +120,11 @@ macro_rules! grectangle {
 /// convenient macro.
 ///
 /// ```rust
-/// use embedded_graphics::{gtriangle, style::Style, primitives::Triangle};
+/// use embedded_graphics::{egtriangle, style::Style, primitives::Triangle};
 ///
-/// let empty_triangle: Triangle<u8> = gtriangle!((10, 20), (30, 40), (50, 60));
-/// let filled_triangle: Triangle<u8> = gtriangle!((10, 20), (30, 40), (50, 60), stroke = Some(5u8), fill = Some(10u8));
-/// let triangle_default_style: Triangle<u8> = gtriangle!((10, 20), (30, 40), (50, 60), style = Style::default());
+/// let empty_triangle: Triangle<u8> = egtriangle!((10, 20), (30, 40), (50, 60));
+/// let filled_triangle: Triangle<u8> = egtriangle!((10, 20), (30, 40), (50, 60), stroke = Some(5u8), fill = Some(10u8));
+/// let triangle_default_style: Triangle<u8> = egtriangle!((10, 20), (30, 40), (50, 60), style = Style::default());
 /// ```
 ///
 /// Style properties like `stroke` map to the method calls on the
@@ -133,15 +133,15 @@ macro_rules! grectangle {
 ///
 /// ```rust
 /// use embedded_graphics::prelude::*;
-/// use embedded_graphics::{gtriangle, style::Style, primitives::Triangle};
+/// use embedded_graphics::{egtriangle, style::Style, primitives::Triangle};
 ///
-/// let Triangle: Triangle<u8> = gtriangle!((10, 20), (30, 40), (50, 60), stroke = Some(5u8), fill = Some(10u8));
+/// let Triangle: Triangle<u8> = egtriangle!((10, 20), (30, 40), (50, 60), stroke = Some(5u8), fill = Some(10u8));
 /// let Triangle: Triangle<u8> = Triangle::new(Coord::new(10, 20), Coord::new(30, 40), Coord::new(50, 60))
 ///     .stroke(Some(5u8))
 ///     .fill(Some(10u8));
 /// ```
 #[macro_export]
-macro_rules! gtriangle {
+macro_rules! egtriangle {
     (($x1:expr, $y1:expr), ($x2:expr, $y2:expr), ($x3:expr, $y3:expr) $(, $style_key:ident = $style_value:expr )* $(,)?) => {{
         #[allow(unused_imports)]
         use $crate::style::WithStyle;
@@ -157,36 +157,36 @@ mod tests {
 
     #[test]
     fn circle() {
-        let _c: Circle<u8> = gcircle!((10, 20), 30);
-        let _c: Circle<u8> = gcircle!((10, 20), 30, stroke = Some(1u8), fill = Some(10u8));
-        let _c: Circle<u8> = gcircle!((10, 20), 30, style = Style::default());
+        let _c: Circle<u8> = egcircle!((10, 20), 30);
+        let _c: Circle<u8> = egcircle!((10, 20), 30, stroke = Some(1u8), fill = Some(10u8));
+        let _c: Circle<u8> = egcircle!((10, 20), 30, style = Style::default());
     }
 
     #[test]
     fn line() {
-        let _l: Line<u8> = gline!((10, 20), (30, 40));
-        let _l: Line<u8> = gline!((10, 20), (30, 40), stroke = Some(1u8), fill = Some(10u8));
-        let _l: Line<u8> = gline!((10, 20), (30, 40), style = Style::default());
+        let _l: Line<u8> = egline!((10, 20), (30, 40));
+        let _l: Line<u8> = egline!((10, 20), (30, 40), stroke = Some(1u8), fill = Some(10u8));
+        let _l: Line<u8> = egline!((10, 20), (30, 40), style = Style::default());
     }
 
     #[test]
     fn rect() {
-        let _r: Rectangle<u8> = grectangle!((10, 20), (30, 40));
+        let _r: Rectangle<u8> = egrectangle!((10, 20), (30, 40));
         let _r: Rectangle<u8> =
-            grectangle!((10, 20), (30, 40), stroke = Some(1u8), fill = Some(10u8));
-        let _r: Rectangle<u8> = grectangle!((10, 20), (30, 40), style = Style::default());
+            egrectangle!((10, 20), (30, 40), stroke = Some(1u8), fill = Some(10u8));
+        let _r: Rectangle<u8> = egrectangle!((10, 20), (30, 40), style = Style::default());
     }
 
     #[test]
     fn triangle() {
-        let _t: Triangle<u8> = gtriangle!((10, 20), (30, 40), (50, 60));
-        let _t: Triangle<u8> = gtriangle!(
+        let _t: Triangle<u8> = egtriangle!((10, 20), (30, 40), (50, 60));
+        let _t: Triangle<u8> = egtriangle!(
             (10, 20),
             (30, 40),
             (50, 60),
             stroke = Some(1u8),
             fill = Some(10u8)
         );
-        let _t: Triangle<u8> = gtriangle!((10, 20), (30, 40), (50, 60), style = Style::default());
+        let _t: Triangle<u8> = egtriangle!((10, 20), (30, 40), (50, 60), style = Style::default());
     }
 }

--- a/embedded-graphics/src/primitives/rect.rs
+++ b/embedded-graphics/src/primitives/rect.rs
@@ -13,7 +13,7 @@ use crate::unsignedcoord::UnsignedCoord;
 ///
 /// # Examples
 ///
-/// The [macro examples](../../macro.rect.html) make for more concise code.
+/// The [macro examples](../../macro.grect.html) make for more concise code.
 ///
 /// ## Create some rectangles with different styles
 ///

--- a/embedded-graphics/src/primitives/rectangle.rs
+++ b/embedded-graphics/src/primitives/rectangle.rs
@@ -13,27 +13,27 @@ use crate::unsignedcoord::UnsignedCoord;
 ///
 /// # Examples
 ///
-/// The [macro examples](../../macro.grect.html) make for more concise code.
+/// The [macro examples](../../macro.grectangle.html) make for more concise code.
 ///
 /// ## Create some rectangles with different styles
 ///
 /// ```rust
 /// use embedded_graphics::prelude::*;
-/// use embedded_graphics::primitives::Rect;
+/// use embedded_graphics::primitives::Rectangle;
 /// # use embedded_graphics::mock_display::Display;
 /// # let mut display = Display::default();
 ///
 /// // Default rect from (10, 20) to (30, 40)
-/// let r1 = Rect::new(Coord::new(10, 20), Coord::new(30, 40));
+/// let r1 = Rectangle::new(Coord::new(10, 20), Coord::new(30, 40));
 ///
-/// // Rect with styled stroke and fill from (50, 20) to (60, 35)
-/// let r2 = Rect::new(Coord::new(50, 20), Coord::new(60, 35))
+/// // Rectangle with styled stroke and fill from (50, 20) to (60, 35)
+/// let r2 = Rectangle::new(Coord::new(50, 20), Coord::new(60, 35))
 ///     .stroke(Some(5u8))
 ///     .stroke_width(3)
 ///     .fill(Some(10u8));
 ///
-/// // Rect with translation applied
-/// let r3 = Rect::new(Coord::new(50, 20), Coord::new(60, 35))
+/// // Rectangle with translation applied
+/// let r3 = Rectangle::new(Coord::new(50, 20), Coord::new(60, 35))
 ///     .translate(Coord::new(65, 35));
 ///
 /// display.draw(r1);
@@ -41,7 +41,7 @@ use crate::unsignedcoord::UnsignedCoord;
 /// display.draw(r3);
 /// ```
 #[derive(Debug, Clone, Copy)]
-pub struct Rect<C: PixelColor> {
+pub struct Rectangle<C: PixelColor> {
     /// Top left point of the rect
     pub top_left: Coord,
 
@@ -52,9 +52,9 @@ pub struct Rect<C: PixelColor> {
     pub style: Style<C>,
 }
 
-impl<C> Primitive for Rect<C> where C: PixelColor {}
+impl<C> Primitive for Rectangle<C> where C: PixelColor {}
 
-impl<C> Dimensions for Rect<C>
+impl<C> Dimensions for Rectangle<C>
 where
     C: PixelColor,
 {
@@ -71,13 +71,13 @@ where
     }
 }
 
-impl<C> Rect<C>
+impl<C> Rectangle<C>
 where
     C: PixelColor,
 {
     /// Create a new rectangle from the top left point to the bottom right point with a given style
     pub fn new(top_left: Coord, bottom_right: Coord) -> Self {
-        Rect {
+        Rectangle {
             top_left,
             bottom_right,
             style: Style::default(),
@@ -85,7 +85,7 @@ where
     }
 }
 
-impl<C> WithStyle<C> for Rect<C>
+impl<C> WithStyle<C> for Rectangle<C>
 where
     C: PixelColor,
 {
@@ -114,27 +114,27 @@ where
     }
 }
 
-impl<C> IntoIterator for Rect<C>
+impl<C> IntoIterator for Rectangle<C>
 where
     C: PixelColor,
 {
     type Item = Pixel<C>;
-    type IntoIter = RectIterator<C>;
+    type IntoIter = RectangleIterator<C>;
 
     fn into_iter(self) -> Self::IntoIter {
         (&self).into_iter()
     }
 }
 
-impl<'a, C> IntoIterator for &'a Rect<C>
+impl<'a, C> IntoIterator for &'a Rectangle<C>
 where
     C: PixelColor,
 {
     type Item = Pixel<C>;
-    type IntoIter = RectIterator<C>;
+    type IntoIter = RectangleIterator<C>;
 
     fn into_iter(self) -> Self::IntoIter {
-        RectIterator {
+        RectangleIterator {
             top_left: self.top_left,
             bottom_right: self.bottom_right,
             style: self.style,
@@ -146,7 +146,7 @@ where
 
 /// Pixel iterator for each pixel in the rect border
 #[derive(Debug, Clone, Copy)]
-pub struct RectIterator<C: PixelColor>
+pub struct RectangleIterator<C: PixelColor>
 where
     C: PixelColor,
 {
@@ -157,7 +157,7 @@ where
     y: i32,
 }
 
-impl<C> Iterator for RectIterator<C>
+impl<C> Iterator for RectangleIterator<C>
 where
     C: PixelColor,
 {
@@ -227,22 +227,22 @@ where
     }
 }
 
-impl<C> Drawable for Rect<C> where C: PixelColor {}
+impl<C> Drawable for Rectangle<C> where C: PixelColor {}
 
-impl<C> Transform for Rect<C>
+impl<C> Transform for Rectangle<C>
 where
     C: PixelColor,
 {
     /// Translate the rect from its current position to a new position by (x, y) pixels, returning
-    /// a new `Rect`. For a mutating transform, see `translate_mut`.
+    /// a new `Rectangle`. For a mutating transform, see `translate_mut`.
     ///
     /// ```
-    /// # use embedded_graphics::primitives::Rect;
+    /// # use embedded_graphics::primitives::Rectangle;
     /// # use embedded_graphics::prelude::*;
     /// #
     /// # let style = Style::stroke(1u8);
     /// #
-    /// let rect = Rect::new(Coord::new(5, 10), Coord::new(15, 20))
+    /// let rect = Rectangle::new(Coord::new(5, 10), Coord::new(15, 20))
     /// #    .style(style);
     /// let moved = rect.translate(Coord::new(10, 10));
     ///
@@ -260,12 +260,12 @@ where
     /// Translate the rect from its current position to a new position by (x, y) pixels.
     ///
     /// ```
-    /// # use embedded_graphics::primitives::Rect;
+    /// # use embedded_graphics::primitives::Rectangle;
     /// # use embedded_graphics::prelude::*;
     /// #
     /// # let style = Style::stroke(1u8);
     /// #
-    /// let mut rect = Rect::new(Coord::new(5, 10), Coord::new(15, 20))
+    /// let mut rect = Rectangle::new(Coord::new(5, 10), Coord::new(15, 20))
     /// #    .style(style);
     /// rect.translate_mut(Coord::new(10, 10));
     ///
@@ -287,7 +287,7 @@ mod tests {
 
     #[test]
     fn dimensions() {
-        let rect: Rect<u8> = Rect::new(Coord::new(5, 10), Coord::new(15, 20));
+        let rect: Rectangle<u8> = Rectangle::new(Coord::new(5, 10), Coord::new(15, 20));
         let moved = rect.translate(Coord::new(-10, -10));
 
         assert_eq!(rect.top_left(), Coord::new(5, 10));
@@ -301,7 +301,7 @@ mod tests {
 
     #[test]
     fn it_can_be_translated() {
-        let rect: Rect<u8> = Rect::new(Coord::new(5, 10), Coord::new(15, 20));
+        let rect: Rectangle<u8> = Rectangle::new(Coord::new(5, 10), Coord::new(15, 20));
         let moved = rect.translate(Coord::new(10, 10));
 
         assert_eq!(moved.top_left, Coord::new(15, 20));
@@ -310,7 +310,7 @@ mod tests {
 
     #[test]
     fn it_draws_unfilled_rect() {
-        let mut rect: RectIterator<u8> = Rect::new(Coord::new(2, 2), Coord::new(4, 4))
+        let mut rect: RectangleIterator<u8> = Rectangle::new(Coord::new(2, 2), Coord::new(4, 4))
             .style(Style::stroke(1))
             .into_iter();
 
@@ -328,7 +328,7 @@ mod tests {
 
     #[test]
     fn it_can_be_negative() {
-        let mut rect: RectIterator<u8> = Rect::new(Coord::new(-2, -2), Coord::new(2, 2))
+        let mut rect: RectangleIterator<u8> = Rectangle::new(Coord::new(-2, -2), Coord::new(2, 2))
             .style(Style::stroke(1))
             .into_iter();
 

--- a/embedded-graphics/src/primitives/rectangle.rs
+++ b/embedded-graphics/src/primitives/rectangle.rs
@@ -13,7 +13,7 @@ use crate::unsignedcoord::UnsignedCoord;
 ///
 /// # Examples
 ///
-/// The [macro examples](../../macro.grectangle.html) make for more concise code.
+/// The [macro examples](../../macro.egrectangle.html) make for more concise code.
 ///
 /// ## Create some rectangles with different styles
 ///

--- a/embedded-graphics/src/primitives/triangle.rs
+++ b/embedded-graphics/src/primitives/triangle.rs
@@ -14,7 +14,7 @@ use crate::unsignedcoord::{ToSigned, UnsignedCoord};
 ///
 /// # Examples
 ///
-/// The [macro examples](../../macro.triangle.html) make for more concise code.
+/// The [macro examples](../../macro.gtriangle.html) make for more concise code.
 ///
 /// ## Create some triangles with different styles
 ///

--- a/embedded-graphics/src/primitives/triangle.rs
+++ b/embedded-graphics/src/primitives/triangle.rs
@@ -14,7 +14,7 @@ use crate::unsignedcoord::{ToSigned, UnsignedCoord};
 ///
 /// # Examples
 ///
-/// The [macro examples](../../macro.gtriangle.html) make for more concise code.
+/// The [macro examples](../../macro.egtriangle.html) make for more concise code.
 ///
 /// ## Create some triangles with different styles
 ///

--- a/embedded-graphics/tests/chaining.rs
+++ b/embedded-graphics/tests/chaining.rs
@@ -2,7 +2,7 @@ extern crate embedded_graphics;
 
 use embedded_graphics::coord::Coord;
 use embedded_graphics::prelude::*;
-use embedded_graphics::primitives::{Circle, Line, Rect};
+use embedded_graphics::primitives::{Circle, Line, Rectangle};
 use embedded_graphics::Drawing;
 
 struct FakeDisplay {}
@@ -31,7 +31,7 @@ impl Drawing<TestPixelColor> for FakeDisplay {
 fn it_supports_chaining() {
     let mut disp = FakeDisplay {};
 
-    let chained = Rect::new(Coord::new(0, 0), Coord::new(1, 1))
+    let chained = Rectangle::new(Coord::new(0, 0), Coord::new(1, 1))
         .into_iter()
         .chain(Circle::new(Coord::new(2, 2), 1).into_iter());
 
@@ -63,7 +63,7 @@ fn return_from_fn() {
 fn implicit_into_iter() {
     let mut disp = FakeDisplay {};
 
-    let chained = Rect::new(Coord::new(0, 0), Coord::new(1, 1))
+    let chained = Rectangle::new(Coord::new(0, 0), Coord::new(1, 1))
         .into_iter()
         .chain(Circle::new(Coord::new(2, 2), 1));
 

--- a/simulator/Cargo.toml
+++ b/simulator/Cargo.toml
@@ -24,5 +24,6 @@ circle-ci = { repository = "jamwaffles/embedded-graphics", branch = "master" }
 sdl2 = "0.32.2"
 
 [dependencies.embedded-graphics]
-version = "0.5.0"
+# version = "0.5.0"
+path = "../embedded-graphics"
 features = [ "bmp", "tga" ]

--- a/simulator/README.md
+++ b/simulator/README.md
@@ -23,10 +23,10 @@ fn main() {
 
  display.draw(text_6x8!("Hello World!"));
 
- display.draw(circle!((96, 32), 31, stroke = Some(1u8.into())));
+ display.draw(gcircle!((96, 32), 31, stroke = Some(1u8.into())));
 
- display.draw(line!((32, 32), (1, 32), stroke = Some(1u8.into())).translate(icoord!(64, 0)));
- display.draw(line!((32, 32), (40, 40), stroke = Some(1u8.into())).translate(icoord!(64, 0)));
+ display.draw(gline!((32, 32), (1, 32), stroke = Some(1u8.into())).translate(icoord!(64, 0)));
+ display.draw(gline!((32, 32), (40, 40), stroke = Some(1u8.into())).translate(icoord!(64, 0)));
 
  loop {
      let end = display.run_once();

--- a/simulator/README.md
+++ b/simulator/README.md
@@ -23,10 +23,10 @@ fn main() {
 
  display.draw(text_6x8!("Hello World!"));
 
- display.draw(gcircle!((96, 32), 31, stroke = Some(1u8.into())));
+ display.draw(egcircle!((96, 32), 31, stroke = Some(1u8.into())));
 
- display.draw(gline!((32, 32), (1, 32), stroke = Some(1u8.into())).translate(icoord!(64, 0)));
- display.draw(gline!((32, 32), (40, 40), stroke = Some(1u8.into())).translate(icoord!(64, 0)));
+ display.draw(egline!((32, 32), (1, 32), stroke = Some(1u8.into())).translate(icoord!(64, 0)));
+ display.draw(egline!((32, 32), (40, 40), stroke = Some(1u8.into())).translate(icoord!(64, 0)));
 
  loop {
      let end = display.run_once();

--- a/simulator/examples/fill-macros.rs
+++ b/simulator/examples/fill-macros.rs
@@ -2,7 +2,7 @@
 
 use embedded_graphics::icoord;
 use embedded_graphics::prelude::*;
-use embedded_graphics::{gcircle, gline, grectangle, gtriangle};
+use embedded_graphics::{egcircle, egline, egrectangle, egtriangle};
 use embedded_graphics_simulator::DisplayBuilder;
 use std::thread;
 use std::time::Duration;
@@ -12,14 +12,14 @@ static CIRCLE_SIZE: i32 = 32;
 fn main() {
     let mut display = DisplayBuilder::new().size(384, 128).scale(2).build();
 
-    display.draw(gcircle!(
+    display.draw(egcircle!(
         (CIRCLE_SIZE, CIRCLE_SIZE),
         CIRCLE_SIZE as u32,
         stroke = Some(1u8.into())
     ));
 
     display.draw(
-        gcircle!(
+        egcircle!(
             (CIRCLE_SIZE, CIRCLE_SIZE),
             CIRCLE_SIZE as u32,
             stroke = Some(0u8.into()),
@@ -29,7 +29,7 @@ fn main() {
     );
 
     display.draw(
-        gcircle!(
+        egcircle!(
             (CIRCLE_SIZE, CIRCLE_SIZE),
             CIRCLE_SIZE as u32,
             stroke = Some(0u8.into()),
@@ -39,10 +39,10 @@ fn main() {
     );
 
     display
-        .draw(grectangle!((0, 0), (64, 64), stroke = Some(1u8.into())).translate(icoord!(96, 0)));
+        .draw(egrectangle!((0, 0), (64, 64), stroke = Some(1u8.into())).translate(icoord!(96, 0)));
 
     display.draw(
-        &grectangle!(
+        &egrectangle!(
             (0, 0),
             (64, 64),
             stroke = Some(0u8.into()),
@@ -52,7 +52,7 @@ fn main() {
     );
 
     display.draw(
-        grectangle!(
+        egrectangle!(
             (0, 0),
             (64, 64),
             stroke = Some(0u8.into()),
@@ -62,12 +62,12 @@ fn main() {
     );
 
     display.draw(
-        gtriangle!((32, 0), (0, 64), (64, 64), stroke = Some(1u8.into()))
+        egtriangle!((32, 0), (0, 64), (64, 64), stroke = Some(1u8.into()))
             .translate(icoord!(96 * 2, 0)),
     );
 
     display.draw(
-        gtriangle!(
+        egtriangle!(
             (32, 0),
             (0, 64),
             (64, 64),
@@ -78,7 +78,7 @@ fn main() {
     );
 
     display.draw(
-        gtriangle!(
+        egtriangle!(
             (32, 0),
             (0, 64),
             (64, 64),
@@ -88,8 +88,9 @@ fn main() {
         .translate(icoord!(96 * 2 + 32, 32)),
     );
 
-    display
-        .draw(gline!((0, 0), (64, 64), stroke = Some(1u8.into()),).translate(icoord!(256 + 32, 0)));
+    display.draw(
+        egline!((0, 0), (64, 64), stroke = Some(1u8.into()),).translate(icoord!(256 + 32, 0)),
+    );
 
     loop {
         let end = display.run_once();

--- a/simulator/examples/fill-macros.rs
+++ b/simulator/examples/fill-macros.rs
@@ -2,7 +2,7 @@
 
 use embedded_graphics::icoord;
 use embedded_graphics::prelude::*;
-use embedded_graphics::{gcircle, gline, grect, gtriangle};
+use embedded_graphics::{gcircle, gline, grectangle, gtriangle};
 use embedded_graphics_simulator::DisplayBuilder;
 use std::thread;
 use std::time::Duration;
@@ -38,10 +38,11 @@ fn main() {
         .translate(icoord!(CIRCLE_SIZE, CIRCLE_SIZE)),
     );
 
-    display.draw(grect!((0, 0), (64, 64), stroke = Some(1u8.into())).translate(icoord!(96, 0)));
+    display
+        .draw(grectangle!((0, 0), (64, 64), stroke = Some(1u8.into())).translate(icoord!(96, 0)));
 
     display.draw(
-        &grect!(
+        &grectangle!(
             (0, 0),
             (64, 64),
             stroke = Some(0u8.into()),
@@ -51,7 +52,7 @@ fn main() {
     );
 
     display.draw(
-        grect!(
+        grectangle!(
             (0, 0),
             (64, 64),
             stroke = Some(0u8.into()),

--- a/simulator/examples/fill-macros.rs
+++ b/simulator/examples/fill-macros.rs
@@ -2,7 +2,7 @@
 
 use embedded_graphics::icoord;
 use embedded_graphics::prelude::*;
-use embedded_graphics::{circle, line, rect, triangle};
+use embedded_graphics::{gcircle, gline, grect, gtriangle};
 use embedded_graphics_simulator::DisplayBuilder;
 use std::thread;
 use std::time::Duration;
@@ -12,14 +12,14 @@ static CIRCLE_SIZE: i32 = 32;
 fn main() {
     let mut display = DisplayBuilder::new().size(384, 128).scale(2).build();
 
-    display.draw(circle!(
+    display.draw(gcircle!(
         (CIRCLE_SIZE, CIRCLE_SIZE),
         CIRCLE_SIZE as u32,
         stroke = Some(1u8.into())
     ));
 
     display.draw(
-        circle!(
+        gcircle!(
             (CIRCLE_SIZE, CIRCLE_SIZE),
             CIRCLE_SIZE as u32,
             stroke = Some(0u8.into()),
@@ -29,7 +29,7 @@ fn main() {
     );
 
     display.draw(
-        circle!(
+        gcircle!(
             (CIRCLE_SIZE, CIRCLE_SIZE),
             CIRCLE_SIZE as u32,
             stroke = Some(0u8.into()),
@@ -38,10 +38,10 @@ fn main() {
         .translate(icoord!(CIRCLE_SIZE, CIRCLE_SIZE)),
     );
 
-    display.draw(rect!((0, 0), (64, 64), stroke = Some(1u8.into())).translate(icoord!(96, 0)));
+    display.draw(grect!((0, 0), (64, 64), stroke = Some(1u8.into())).translate(icoord!(96, 0)));
 
     display.draw(
-        &rect!(
+        &grect!(
             (0, 0),
             (64, 64),
             stroke = Some(0u8.into()),
@@ -51,7 +51,7 @@ fn main() {
     );
 
     display.draw(
-        rect!(
+        grect!(
             (0, 0),
             (64, 64),
             stroke = Some(0u8.into()),
@@ -61,12 +61,12 @@ fn main() {
     );
 
     display.draw(
-        triangle!((32, 0), (0, 64), (64, 64), stroke = Some(1u8.into()))
+        gtriangle!((32, 0), (0, 64), (64, 64), stroke = Some(1u8.into()))
             .translate(icoord!(96 * 2, 0)),
     );
 
     display.draw(
-        triangle!(
+        gtriangle!(
             (32, 0),
             (0, 64),
             (64, 64),
@@ -77,7 +77,7 @@ fn main() {
     );
 
     display.draw(
-        triangle!(
+        gtriangle!(
             (32, 0),
             (0, 64),
             (64, 64),
@@ -88,7 +88,7 @@ fn main() {
     );
 
     display
-        .draw(line!((0, 0), (64, 64), stroke = Some(1u8.into()),).translate(icoord!(256 + 32, 0)));
+        .draw(gline!((0, 0), (64, 64), stroke = Some(1u8.into()),).translate(icoord!(256 + 32, 0)));
 
     loop {
         let end = display.run_once();

--- a/simulator/examples/fill.rs
+++ b/simulator/examples/fill.rs
@@ -1,6 +1,6 @@
 use embedded_graphics::icoord;
 use embedded_graphics::prelude::*;
-use embedded_graphics::primitives::{Circle, Rect, Triangle};
+use embedded_graphics::primitives::{Circle, Rectangle, Triangle};
 use embedded_graphics_simulator::DisplayBuilder;
 use std::thread;
 use std::time::Duration;
@@ -29,20 +29,20 @@ fn main() {
     );
 
     display.draw(
-        Rect::new(icoord!(0, 0), icoord!(64, 64))
+        Rectangle::new(icoord!(0, 0), icoord!(64, 64))
             .translate(icoord!(96, 0))
             .stroke(Some(1u8.into())),
     );
 
     display.draw(
-        &Rect::new(icoord!(0, 0), icoord!(64, 64))
+        &Rectangle::new(icoord!(0, 0), icoord!(64, 64))
             .translate(icoord!(96 + 16, 16))
             .stroke(Some(0u8.into()))
             .fill(Some(1u8.into())),
     );
 
     display.draw(
-        Rect::new(icoord!(0, 0), icoord!(64, 64))
+        Rectangle::new(icoord!(0, 0), icoord!(64, 64))
             .translate(icoord!(96 + 32, 32))
             .stroke(Some(0u8.into()))
             .fill(Some(0u8.into())),

--- a/simulator/examples/offscreen.rs
+++ b/simulator/examples/offscreen.rs
@@ -1,6 +1,6 @@
 use embedded_graphics::icoord;
 use embedded_graphics::prelude::*;
-use embedded_graphics::primitives::Rect;
+use embedded_graphics::primitives::Rectangle;
 use embedded_graphics_simulator::DisplayBuilder;
 use std::thread;
 use std::time::Duration;
@@ -10,7 +10,7 @@ fn main() {
 
     // Outline
     display.draw(
-        Rect::new(icoord!(0, 0), icoord!(16, 16))
+        Rectangle::new(icoord!(0, 0), icoord!(16, 16))
             .stroke(Some(1u8.into()))
             .translate(icoord!(-8, -8)),
     );

--- a/simulator/examples/stroke.rs
+++ b/simulator/examples/stroke.rs
@@ -1,6 +1,6 @@
 use embedded_graphics::icoord;
 use embedded_graphics::prelude::*;
-use embedded_graphics::primitives::{Circle, Line, Rect, Triangle};
+use embedded_graphics::primitives::{Circle, Line, Rectangle, Triangle};
 use embedded_graphics_simulator::{DisplayBuilder, SimPixelColor};
 use std::thread;
 use std::time::Duration;
@@ -14,7 +14,7 @@ fn main() {
         .translate(icoord!(0, 0))
         .stroke(Some(SimPixelColor(1, 1, 1)));
 
-    let rect = Rect::new(icoord!(0, 0), icoord!(64, 64))
+    let rect = Rectangle::new(icoord!(0, 0), icoord!(64, 64))
         .translate(icoord!(64 + PADDING, 0))
         .stroke(Some(SimPixelColor(1, 1, 1)));
 

--- a/simulator/examples/transparent-fonts.rs
+++ b/simulator/examples/transparent-fonts.rs
@@ -1,6 +1,5 @@
 use embedded_graphics::prelude::*;
-use embedded_graphics::text_6x8;
-use embedded_graphics::{circle, icoord, rect};
+use embedded_graphics::{gcircle, grect, icoord, text_6x8};
 use embedded_graphics_simulator::{DisplayBuilder, DisplayTheme};
 use std::thread;
 use std::time::Duration;
@@ -9,14 +8,14 @@ fn main() {
     let mut display = DisplayBuilder::new().theme(DisplayTheme::OledBlue).build();
 
     display.draw(
-        circle!(
+        gcircle!(
             (20, 20),
             20 as u32,
             stroke = Some(1u8.into()),
             fill = Some(1u8.into())
         )
         .into_iter()
-        .chain(rect!((20, 20), (100, 80), fill = Some(1u8.into()))),
+        .chain(grect!((20, 20), (100, 80), fill = Some(1u8.into()))),
     );
 
     display.draw(text_6x8!("Hello world! - no background").translate(icoord!(15, 15)));

--- a/simulator/examples/transparent-fonts.rs
+++ b/simulator/examples/transparent-fonts.rs
@@ -1,5 +1,5 @@
 use embedded_graphics::prelude::*;
-use embedded_graphics::{gcircle, grectangle, icoord, text_6x8};
+use embedded_graphics::{egcircle, egrectangle, icoord, text_6x8};
 use embedded_graphics_simulator::{DisplayBuilder, DisplayTheme};
 use std::thread;
 use std::time::Duration;
@@ -8,14 +8,14 @@ fn main() {
     let mut display = DisplayBuilder::new().theme(DisplayTheme::OledBlue).build();
 
     display.draw(
-        gcircle!(
+        egcircle!(
             (20, 20),
             20 as u32,
             stroke = Some(1u8.into()),
             fill = Some(1u8.into())
         )
         .into_iter()
-        .chain(grectangle!((20, 20), (100, 80), fill = Some(1u8.into()))),
+        .chain(egrectangle!((20, 20), (100, 80), fill = Some(1u8.into()))),
     );
 
     display.draw(text_6x8!("Hello world! - no background").translate(icoord!(15, 15)));

--- a/simulator/examples/transparent-fonts.rs
+++ b/simulator/examples/transparent-fonts.rs
@@ -1,5 +1,5 @@
 use embedded_graphics::prelude::*;
-use embedded_graphics::{gcircle, grect, icoord, text_6x8};
+use embedded_graphics::{gcircle, grectangle, icoord, text_6x8};
 use embedded_graphics_simulator::{DisplayBuilder, DisplayTheme};
 use std::thread;
 use std::time::Duration;
@@ -15,7 +15,7 @@ fn main() {
             fill = Some(1u8.into())
         )
         .into_iter()
-        .chain(grect!((20, 20), (100, 80), fill = Some(1u8.into()))),
+        .chain(grectangle!((20, 20), (100, 80), fill = Some(1u8.into()))),
     );
 
     display.draw(text_6x8!("Hello world! - no background").translate(icoord!(15, 15)));

--- a/simulator/src/lib.rs
+++ b/simulator/src/lib.rs
@@ -34,7 +34,7 @@
 //!
 //! ```rust,no_run
 //! use embedded_graphics::prelude::*;
-//! use embedded_graphics::{icoord, gcircle, gline, text_6x8};
+//! use embedded_graphics::{icoord, egcircle, egline, text_6x8};
 //! use embedded_graphics_simulator::{DisplayBuilder, DisplayTheme};
 //! use std::thread;
 //! use std::time::Duration;
@@ -47,11 +47,11 @@
 //!
 //!     display.draw(text_6x8!("Hello World!"));
 //!
-//!     display.draw(gcircle!((96, 32), 31, stroke = Some(1u8.into())));
+//!     display.draw(egcircle!((96, 32), 31, stroke = Some(1u8.into())));
 //!
-//!     display.draw(gline!((32, 32), (1, 32), stroke = Some(1u8.into()))
+//!     display.draw(egline!((32, 32), (1, 32), stroke = Some(1u8.into()))
 //!         .translate(icoord!(64, 0)));
-//!     display.draw(gline!((32, 32), (40, 40), stroke = Some(1u8.into()))
+//!     display.draw(egline!((32, 32), (40, 40), stroke = Some(1u8.into()))
 //!         .translate(icoord!(64, 0)));
 //!
 //!     loop {

--- a/simulator/src/lib.rs
+++ b/simulator/src/lib.rs
@@ -34,7 +34,7 @@
 //!
 //! ```rust,no_run
 //! use embedded_graphics::prelude::*;
-//! use embedded_graphics::{icoord, circle, line, text_6x8};
+//! use embedded_graphics::{icoord, gcircle, gline, text_6x8};
 //! use embedded_graphics_simulator::{DisplayBuilder, DisplayTheme};
 //! use std::thread;
 //! use std::time::Duration;
@@ -47,11 +47,11 @@
 //!
 //!     display.draw(text_6x8!("Hello World!"));
 //!
-//!     display.draw(circle!((96, 32), 31, stroke = Some(1u8.into())));
+//!     display.draw(gcircle!((96, 32), 31, stroke = Some(1u8.into())));
 //!
-//!     display.draw(line!((32, 32), (1, 32), stroke = Some(1u8.into()))
+//!     display.draw(gline!((32, 32), (1, 32), stroke = Some(1u8.into()))
 //!         .translate(icoord!(64, 0)));
-//!     display.draw(line!((32, 32), (40, 40), stroke = Some(1u8.into()))
+//!     display.draw(gline!((32, 32), (40, 40), stroke = Some(1u8.into()))
 //!         .translate(icoord!(64, 0)));
 //!
 //!     loop {


### PR DESCRIPTION
This primarily fixes #129 so that the `line!()` macro provided by std doesn't conflict with the `line!()` macro from Embedded Graphics. The macros are now renamed as such:

* `line` -> `egline`
* `triangle` -> `egtriangle`
* `rect` -> `egrectangle`
* `circle` -> `egcircle`

Note that `rect` is also now called `rectangle` for consistency with the other macros that use the shape's full name.