### PR TITLE
Use character patterns in MockDisplay

### DIFF
--- a/embedded-graphics/src/fonts/font12x16.rs
+++ b/embedded-graphics/src/fonts/font12x16.rs
@@ -100,14 +100,12 @@ mod tests {
     use crate::transform::Transform;
     use crate::unsignedcoord::UnsignedCoord;
     use crate::Drawing;
-    use BinaryColor::Off as C0;
-    use BinaryColor::On as C1;
 
     #[test]
     fn off_screen_text_does_not_infinite_loop() {
         let text: Font12x16<BinaryColor> = Font12x16::render_str("Hello World!")
             .translate(Coord::new(5, -20))
-            .style(Style::stroke(C1));
+            .style(Style::stroke(BinaryColor::On));
         let mut it = text.into_iter();
 
         assert_eq!(it.next(), None);
@@ -136,129 +134,123 @@ mod tests {
 
     #[test]
     fn correct_m() {
-        let mut display = MockDisplay::default();
-        display.draw(Font12x16::render_str("Mm").stroke(Some(C1)));
+        let mut display = MockDisplay::new();
+        display.draw(Font12x16::render_str("Mm").stroke(Some(BinaryColor::On)));
 
-        #[cfg_attr(rustfmt, rustfmt_skip)]
         assert_eq!(
             display,
-            MockDisplay::new([
-                [C1, C1, C0, C0, C0, C0, C0, C0, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C1, C1, C0, C0, C0, C0, C0, C0, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C1, C1, C1, C1, C0, C0, C1, C1, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C1, C1, C1, C1, C0, C0, C1, C1, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C1, C1, C0, C0, C1, C1, C0, C0, C1, C1, C0, C0, C1, C1, C1, C1, C0, C0, C1, C1, C0, C0, C0, C0],
-                [C1, C1, C0, C0, C1, C1, C0, C0, C1, C1, C0, C0, C1, C1, C1, C1, C0, C0, C1, C1, C0, C0, C0, C0],
-                [C1, C1, C0, C0, C1, C1, C0, C0, C1, C1, C0, C0, C1, C1, C0, C0, C1, C1, C0, C0, C1, C1, C0, C0],
-                [C1, C1, C0, C0, C1, C1, C0, C0, C1, C1, C0, C0, C1, C1, C0, C0, C1, C1, C0, C0, C1, C1, C0, C0],
-                [C1, C1, C0, C0, C0, C0, C0, C0, C1, C1, C0, C0, C1, C1, C0, C0, C0, C0, C0, C0, C1, C1, C0, C0],
-                [C1, C1, C0, C0, C0, C0, C0, C0, C1, C1, C0, C0, C1, C1, C0, C0, C0, C0, C0, C0, C1, C1, C0, C0],
-                [C1, C1, C0, C0, C0, C0, C0, C0, C1, C1, C0, C0, C1, C1, C0, C0, C0, C0, C0, C0, C1, C1, C0, C0],
-                [C1, C1, C0, C0, C0, C0, C0, C0, C1, C1, C0, C0, C1, C1, C0, C0, C0, C0, C0, C0, C1, C1, C0, C0],
-                [C1, C1, C0, C0, C0, C0, C0, C0, C1, C1, C0, C0, C1, C1, C0, C0, C0, C0, C0, C0, C1, C1, C0, C0],
-                [C1, C1, C0, C0, C0, C0, C0, C0, C1, C1, C0, C0, C1, C1, C0, C0, C0, C0, C0, C0, C1, C1, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
+            MockDisplay::from_pattern(&[
+                "##      ##              ",
+                "##      ##              ",
+                "####  ####              ",
+                "####  ####              ",
+                "##  ##  ##  ####  ##    ",
+                "##  ##  ##  ####  ##    ",
+                "##  ##  ##  ##  ##  ##  ",
+                "##  ##  ##  ##  ##  ##  ",
+                "##      ##  ##      ##  ",
+                "##      ##  ##      ##  ",
+                "##      ##  ##      ##  ",
+                "##      ##  ##      ##  ",
+                "##      ##  ##      ##  ",
+                "##      ##  ##      ##  ",
+                "                        ",
+                "                        ",
             ])
         );
     }
 
     #[test]
     fn correct_ascii_borders() {
-        let mut display = MockDisplay::default();
-        display.draw(Font12x16::render_str(" ~").stroke(Some(C1)));
+        let mut display = MockDisplay::new();
+        display.draw(Font12x16::render_str(" ~").stroke(Some(BinaryColor::On)));
 
-        #[cfg_attr(rustfmt, rustfmt_skip)]
         assert_eq!(
             display,
-            MockDisplay::new([
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C1, C1, C1, C1, C0, C0, C1, C1, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C1, C1, C1, C1, C0, C0, C1, C1, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C1, C1, C0, C0, C0, C0, C1, C1, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C1, C1, C0, C0, C0, C0, C1, C1, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
+            MockDisplay::from_pattern(&[
+                "              ####  ##  ",
+                "              ####  ##  ",
+                "            ##    ##    ",
+                "            ##    ##    ",
+                "                        ",
+                "                        ",
+                "                        ",
+                "                        ",
+                "                        ",
+                "                        ",
+                "                        ",
+                "                        ",
+                "                        ",
+                "                        ",
+                "                        ",
+                "                        ",
             ])
         );
     }
 
     #[test]
     fn correct_dollar_y() {
-        let mut display = MockDisplay::default();
-        display.draw(Font12x16::render_str("$y").stroke(Some(C1)));
+        let mut display = MockDisplay::new();
+        display.draw(Font12x16::render_str("$y").stroke(Some(BinaryColor::On)));
 
-        #[cfg_attr(rustfmt, rustfmt_skip)]
         assert_eq!(
             display,
-            MockDisplay::new([
-                [C0, C0, C0, C0, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C1, C1, C1, C1, C1, C1, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C1, C1, C1, C1, C1, C1, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C1, C1, C0, C0, C1, C1, C0, C0, C0, C0, C0, C0, C1, C1, C0, C0, C0, C0, C0, C0, C1, C1, C0, C0],
-                [C1, C1, C0, C0, C1, C1, C0, C0, C0, C0, C0, C0, C1, C1, C0, C0, C0, C0, C0, C0, C1, C1, C0, C0],
-                [C0, C0, C1, C1, C1, C1, C1, C1, C0, C0, C0, C0, C1, C1, C0, C0, C0, C0, C0, C0, C1, C1, C0, C0],
-                [C0, C0, C1, C1, C1, C1, C1, C1, C0, C0, C0, C0, C1, C1, C0, C0, C0, C0, C0, C0, C1, C1, C0, C0],
-                [C0, C0, C0, C0, C1, C1, C0, C0, C1, C1, C0, C0, C1, C1, C0, C0, C0, C0, C0, C0, C1, C1, C0, C0],
-                [C0, C0, C0, C0, C1, C1, C0, C0, C1, C1, C0, C0, C1, C1, C0, C0, C0, C0, C0, C0, C1, C1, C0, C0],
-                [C1, C1, C1, C1, C1, C1, C1, C1, C0, C0, C0, C0, C0, C0, C1, C1, C1, C1, C1, C1, C1, C1, C0, C0],
-                [C1, C1, C1, C1, C1, C1, C1, C1, C0, C0, C0, C0, C0, C0, C1, C1, C1, C1, C1, C1, C1, C1, C0, C0],
-                [C0, C0, C0, C0, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C1, C1, C0, C0],
-                [C0, C0, C0, C0, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C1, C1, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C1, C1, C1, C1, C1, C1, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C1, C1, C1, C1, C1, C1, C0, C0, C0, C0],
+            MockDisplay::from_pattern(&[
+                "    ##                  ",
+                "    ##                  ",
+                "  ########              ",
+                "  ########              ",
+                "##  ##      ##      ##  ",
+                "##  ##      ##      ##  ",
+                "  ######    ##      ##  ",
+                "  ######    ##      ##  ",
+                "    ##  ##  ##      ##  ",
+                "    ##  ##  ##      ##  ",
+                "########      ########  ",
+                "########      ########  ",
+                "    ##              ##  ",
+                "    ##              ##  ",
+                "              ######    ",
+                "              ######    ",
             ])
         );
     }
 
     #[test]
     fn dont_panic() {
-        #[cfg_attr(rustfmt, rustfmt_skip)]
-        let two_question_marks = MockDisplay::new(
-            [
-                [C0, C0, C1, C1, C1, C1, C1, C1, C0, C0, C0, C0, C0, C0, C1, C1, C1, C1, C1, C1, C0, C0, C0, C0],
-                [C0, C0, C1, C1, C1, C1, C1, C1, C0, C0, C0, C0, C0, C0, C1, C1, C1, C1, C1, C1, C0, C0, C0, C0],
-                [C1, C1, C0, C0, C0, C0, C0, C0, C1, C1, C0, C0, C1, C1, C0, C0, C0, C0, C0, C0, C1, C1, C0, C0],
-                [C1, C1, C0, C0, C0, C0, C0, C0, C1, C1, C0, C0, C1, C1, C0, C0, C0, C0, C0, C0, C1, C1, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C1, C1, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C1, C1, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C1, C1, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C1, C1, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C1, C1, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C1, C1, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C1, C1, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C1, C1, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-            ]
-        );
+        let two_question_marks = MockDisplay::from_pattern(&[
+            "  ######      ######    ",
+            "  ######      ######    ",
+            "##      ##  ##      ##  ",
+            "##      ##  ##      ##  ",
+            "        ##          ##  ",
+            "        ##          ##  ",
+            "      ##          ##    ",
+            "      ##          ##    ",
+            "    ##          ##      ",
+            "    ##          ##      ",
+            "                        ",
+            "                        ",
+            "    ##          ##      ",
+            "    ##          ##      ",
+            "                        ",
+            "                        ",
+        ]);
 
-        let mut display = MockDisplay::default();
-        display.draw(Font12x16::render_str("\0\n").stroke(Some(C1)));
+        let mut display = MockDisplay::new();
+        display.draw(Font12x16::render_str("\0\n").stroke(Some(BinaryColor::On)));
         assert_eq!(display, two_question_marks);
 
-        let mut display = MockDisplay::default();
-        display.draw(Font12x16::render_str("\x7F\u{A0}").stroke(Some(C1)));
+        let mut display = MockDisplay::new();
+        display.draw(Font12x16::render_str("\x7F\u{A0}").stroke(Some(BinaryColor::On)));
         assert_eq!(display, two_question_marks);
 
-        let mut display = MockDisplay::default();
-        display.draw(Font12x16::render_str("¡ÿ").stroke(Some(C1)));
+        let mut display = MockDisplay::new();
+        display.draw(Font12x16::render_str("¡ÿ").stroke(Some(BinaryColor::On)));
         assert_eq!(display, two_question_marks);
 
-        let mut display = MockDisplay::default();
-        display.draw(Font12x16::render_str("Ā💣").stroke(Some(C1)));
+        let mut display = MockDisplay::new();
+        display.draw(Font12x16::render_str("Ā💣").stroke(Some(BinaryColor::On)));
         assert_eq!(display, two_question_marks);
     }
 }

--- a/embedded-graphics/src/fonts/font6x12.rs
+++ b/embedded-graphics/src/fonts/font6x12.rs
@@ -100,13 +100,11 @@ mod tests {
     use crate::transform::Transform;
     use crate::unsignedcoord::UnsignedCoord;
     use crate::Drawing;
-    use BinaryColor::Off as C0;
-    use BinaryColor::On as C1;
 
     #[test]
     fn off_screen_text_does_not_infinite_loop() {
         let text: Font6x12<BinaryColor> = Font6x12::render_str("Hello World!")
-            .style(Style::stroke(C1))
+            .style(Style::stroke(BinaryColor::On))
             .translate(Coord::new(5, -20));
         let mut it = text.into_iter();
 
@@ -136,140 +134,114 @@ mod tests {
 
     #[test]
     fn correct_m() {
-        let mut display = MockDisplay::default();
-        display.draw(Font6x12::render_str("Mm").stroke(Some(C1)));
+        let mut display = MockDisplay::new();
+        display.draw(Font6x12::render_str("Mm").stroke(Some(BinaryColor::On)));
 
-        #[cfg_attr(rustfmt, rustfmt_skip)]
         assert_eq!(
             display,
-            MockDisplay::new([
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C1, C0, C0, C0, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C1, C1, C0, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C1, C1, C0, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C1, C0, C1, C0, C1, C0, C1, C1, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C1, C0, C1, C0, C1, C0, C1, C0, C1, C0, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C1, C0, C0, C0, C1, C0, C1, C0, C1, C0, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C1, C0, C0, C0, C1, C0, C1, C0, C1, C0, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C1, C0, C0, C0, C1, C0, C1, C0, C1, C0, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C1, C0, C0, C0, C1, C0, C1, C0, C1, C0, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                //
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
+            MockDisplay::from_pattern(&[
+                "            ",
+                "#   #       ",
+                "## ##       ",
+                "## ##       ",
+                "# # # ####  ",
+                "# # # # # # ",
+                "#   # # # # ",
+                "#   # # # # ",
+                "#   # # # # ",
+                "#   # # # # ",
+                "            ",
+                "            ",
             ])
         );
     }
 
     #[test]
     fn correct_ascii_borders() {
-        let mut display = MockDisplay::default();
-        display.draw(Font6x12::render_str(" ~").stroke(Some(C1)));
+        let mut display = MockDisplay::new();
+        display.draw(Font6x12::render_str(" ~").stroke(Some(BinaryColor::On)));
 
-        #[cfg_attr(rustfmt, rustfmt_skip)]
         assert_eq!(
             display,
-            MockDisplay::new([
-                [C0, C0, C0, C0, C0, C0, C0, C0, C1, C0, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C1, C1, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C1, C0, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                //
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
+            MockDisplay::from_pattern(&[
+                "        # # ",
+                "       #### ",
+                "       # #  ",
+                "            ",
+                "            ",
+                "            ",
+                "            ",
+                "            ",
+                "            ",
+                "            ",
+                "            ",
+                "            ",
             ])
         );
     }
 
     #[test]
     fn correct_dollar_y() {
-        let mut display = MockDisplay::default();
-        display.draw(Font6x12::render_str("$y").stroke(Some(C1)));
+        let mut display = MockDisplay::new();
+        display.draw(Font6x12::render_str("$y").stroke(Some(BinaryColor::On)));
 
-        #[cfg_attr(rustfmt, rustfmt_skip)]
         assert_eq!(
             display,
-            MockDisplay::new([
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C1, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C1, C0, C1, C0, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C1, C0, C1, C0, C0, C0, C0, C1, C0, C0, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C1, C1, C1, C0, C0, C0, C1, C0, C0, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C1, C0, C1, C0, C0, C1, C0, C0, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C1, C0, C1, C0, C0, C1, C0, C0, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C1, C0, C1, C0, C1, C0, C0, C1, C0, C0, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C1, C1, C1, C0, C0, C0, C0, C1, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C1, C0, C0, C0, C0, C0, C0, C0, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                //
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
+            MockDisplay::from_pattern(&[
+                "            ",
+                "  #         ",
+                " ###        ",
+                "# # #       ",
+                "# #    #  # ",
+                " ###   #  # ",
+                "  # #  #  # ",
+                "  # #  #  # ",
+                "# # #  #  # ",
+                " ###    ### ",
+                "  #       # ",
+                "        ##  ",
             ])
         );
     }
 
     #[test]
     fn dont_panic() {
-        #[cfg_attr(rustfmt, rustfmt_skip)]
-        let two_question_marks = MockDisplay::new(
-            [
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C1, C1, C0, C0, C0, C0, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C1, C0, C0, C1, C0, C0, C1, C0, C0, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C1, C0, C0, C1, C0, C0, C1, C0, C0, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C1, C0, C0, C0, C0, C0, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C1, C0, C0, C0, C0, C0, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C1, C0, C0, C0, C0, C0, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C1, C0, C0, C0, C0, C0, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C1, C0, C0, C0, C0, C0, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                //
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-            ]
-        );
+        let two_question_marks = MockDisplay::from_pattern(&[
+            "            ",
+            "  ##    ##  ",
+            " #  #  #  # ",
+            " #  #  #  # ",
+            "    #     # ",
+            "   #     #  ",
+            "  #     #   ",
+            "  #     #   ",
+            "            ",
+            "  #     #   ",
+            "            ",
+            "            ",
+        ]);
 
-        let mut display = MockDisplay::default();
-        display.draw(Font6x12::render_str("\0\n").stroke(Some(C1)));
+        let mut display = MockDisplay::new();
+        display.draw(Font6x12::render_str("\0\n").stroke(Some(BinaryColor::On)));
         assert_eq!(display, two_question_marks);
 
-        let mut display = MockDisplay::default();
-        display.draw(Font6x12::render_str("\x7F\u{A0}").stroke(Some(C1)));
+        let mut display = MockDisplay::new();
+        display.draw(Font6x12::render_str("\x7F\u{A0}").stroke(Some(BinaryColor::On)));
         assert_eq!(display, two_question_marks);
 
-        let mut display = MockDisplay::default();
-        display.draw(Font6x12::render_str("¡ÿ").stroke(Some(C1)));
+        let mut display = MockDisplay::new();
+        display.draw(Font6x12::render_str("¡ÿ").stroke(Some(BinaryColor::On)));
         assert_eq!(display, two_question_marks);
 
-        let mut display = MockDisplay::default();
-        display.draw(Font6x12::render_str("Ā💣").stroke(Some(C1)));
+        let mut display = MockDisplay::new();
+        display.draw(Font6x12::render_str("Ā💣").stroke(Some(BinaryColor::On)));
         assert_eq!(display, two_question_marks);
     }
 
     #[test]
     fn negative_y_no_infinite_loop() {
         let text: Font6x12<BinaryColor> = Font6x12::render_str("Testing string")
-            .stroke(Some(C1))
+            .stroke(Some(BinaryColor::On))
             .translate(Coord::new(0, -12));
 
         let mut it = text.into_iter();
@@ -281,7 +253,7 @@ mod tests {
     #[test]
     fn negative_x_no_infinite_loop() {
         let text: Font6x12<BinaryColor> = Font6x12::render_str("A")
-            .stroke(Some(C1))
+            .stroke(Some(BinaryColor::On))
             .translate(Coord::new(-6, 0));
 
         let mut it = text.into_iter();

--- a/embedded-graphics/src/fonts/font6x8.rs
+++ b/embedded-graphics/src/fonts/font6x8.rs
@@ -103,13 +103,11 @@ mod tests {
     use crate::transform::Transform;
     use crate::unsignedcoord::UnsignedCoord;
     use crate::Drawing;
-    use BinaryColor::Off as C0;
-    use BinaryColor::On as C1;
 
     #[test]
     fn off_screen_text_does_not_infinite_loop() {
         let text: Font6x8<BinaryColor> = Font6x8::render_str("Hello World!")
-            .style(Style::stroke(C1))
+            .style(Style::stroke(BinaryColor::On))
             .translate(Coord::new(5, -10));
         let mut it = text.into_iter();
 
@@ -119,7 +117,7 @@ mod tests {
     #[test]
     fn unstroked_text_does_not_infinite_loop() {
         let text: Font6x8<BinaryColor> = Font6x8::render_str("Hello World!")
-            .style(Style::stroke(C1))
+            .style(Style::stroke(BinaryColor::On))
             .translate(Coord::new(5, -10));
         let mut it = text.into_iter();
 
@@ -148,80 +146,45 @@ mod tests {
     }
 
     #[test]
-    fn default_style() {
-        let mut display_default = MockDisplay::default();
-        display_default.draw(Font6x8::render_str("Mm"));
-
-        let mut display_full_style = MockDisplay::default();
-        display_full_style.draw(Font6x8::render_str("Mm").stroke(Some(C1)).fill(Some(C0)));
-
-        let mut display_stroke = MockDisplay::default();
-        display_stroke.draw(Font6x8::render_str("Mm").stroke(Some(C1)));
-
-        let mut display_fill = MockDisplay::default();
-        display_fill.draw(Font6x8::render_str("Mm").fill(Some(C0)));
-
-        assert_eq!(display_default, display_full_style);
-        assert_eq!(display_default, display_stroke);
-        assert_eq!(display_default, display_fill);
-    }
-
-    #[test]
     fn correct_m() {
-        let mut display = MockDisplay::default();
-        display.draw(Font6x8::render_str("Mm").stroke(Some(C1)));
+        let mut display = MockDisplay::new();
+        display.draw(Font6x8::render_str("Mm").stroke(Some(BinaryColor::On)));
 
-        #[cfg_attr(rustfmt, rustfmt_skip)]
         assert_eq!(
             display,
-            MockDisplay::new([
-                [C1, C0, C0, C0, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C1, C1, C0, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C1, C0, C1, C0, C1, C0, C1, C1, C0, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C1, C0, C1, C0, C1, C0, C1, C0, C1, C0, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C1, C0, C0, C0, C1, C0, C1, C0, C0, C0, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C1, C0, C0, C0, C1, C0, C1, C0, C0, C0, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C1, C0, C0, C0, C1, C0, C1, C0, C0, C0, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                //
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
+            MockDisplay::from_pattern(&[
+                "#   #       ",
+                "## ##       ",
+                "# # # ## #  ",
+                "# # # # # # ",
+                "#   # #   # ",
+                "#   # #   # ",
+                "#   # #   # ",
+                "            ",
             ])
         );
     }
 
     #[test]
     fn correct_inverse_coloured_m() {
-        let mut display = MockDisplay::default();
-        display.draw(Font6x8::render_str("Mm").stroke(Some(C0)).fill(Some(C1)));
+        let mut display = MockDisplay::new();
+        display.draw(
+            Font6x8::render_str("Mm")
+                .stroke(Some(BinaryColor::Off))
+                .fill(Some(BinaryColor::On)),
+        );
 
-        #[cfg_attr(rustfmt, rustfmt_skip)]
         assert_eq!(
             display,
-            MockDisplay::new([
-                [C0, C1, C1, C1, C0, C1, C1, C1, C1, C1, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C1, C0, C0, C1, C1, C1, C1, C1, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C1, C0, C1, C0, C1, C0, C0, C1, C0, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C1, C0, C1, C0, C1, C0, C1, C0, C1, C0, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C1, C1, C1, C0, C1, C0, C1, C1, C1, C0, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C1, C1, C1, C0, C1, C0, C1, C1, C1, C0, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C1, C1, C1, C0, C1, C0, C1, C1, C1, C0, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C1, C1, C1, C1, C1, C1, C1, C1, C1, C1, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                //
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
+            MockDisplay::from_pattern(&[
+                ".###.#######",
+                "..#..#######",
+                ".#.#.#..#.##",
+                ".#.#.#.#.#.#",
+                ".###.#.###.#",
+                ".###.#.###.#",
+                ".###.#.###.#",
+                "############",
             ])
         );
     }
@@ -229,177 +192,116 @@ mod tests {
     // tests if black on white has really the same behaviour as white on black
     #[test]
     fn compare_inverse_coloured_m() {
-        let mut display_inverse = MockDisplay::default();
-        display_inverse.draw(Font6x8::render_str("Mm").stroke(Some(C0)).fill(Some(C1)));
+        let mut display_inverse = MockDisplay::new();
+        display_inverse.draw(
+            Font6x8::render_str("Mm")
+                .stroke(Some(BinaryColor::Off))
+                .fill(Some(BinaryColor::On)),
+        );
 
-        let mut display_normal = MockDisplay::default();
-        display_normal.draw(Font6x8::render_str("Mm").stroke(Some(C1)).fill(Some(C0)));
+        let mut display_normal = MockDisplay::new();
+        display_normal.draw(
+            Font6x8::render_str("Mm")
+                .stroke(Some(BinaryColor::On))
+                .fill(Some(BinaryColor::Off)),
+        );
 
-        for (x, y) in display_inverse.0[0..8]
-            .iter()
-            .zip(display_normal.0[0..8].iter())
-        {
-            for (x2, y2) in x[0..12].iter().zip(y[0..12].iter()) {
-                assert_ne!(x2, y2);
-            }
-        }
+        let inverted_display_normal = display_normal.pixels().map(|p| p.map(|c| c.invert()));
+
+        assert!(inverted_display_normal.eq(display_inverse.pixels()));
     }
 
     #[test]
     fn correct_ascii_borders() {
-        let mut display = MockDisplay::default();
-        display.draw(Font6x8::render_str(" ~").stroke(Some(C1)));
+        let mut display = MockDisplay::new();
+        display.draw(Font6x8::render_str(" ~").stroke(Some(BinaryColor::On)));
 
-        #[cfg_attr(rustfmt, rustfmt_skip)]
         assert_eq!(
             display,
-            MockDisplay::new([
-                [C0, C0, C0, C0, C0, C0, C0, C1, C1, C0, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C1, C0, C0, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                //
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
+            MockDisplay::from_pattern(&[
+                "       ## # ",
+                "      #  #  ",
+                "            ",
+                "            ",
+                "            ",
+                "            ",
+                "            ",
+                "            ",
             ])
         );
     }
 
     #[test]
     fn no_fill_doesnt_hang() {
-        let mut display = MockDisplay::default();
-        display.draw(Font6x8::render_str(" ").stroke(Some(C1)));
+        let mut display = MockDisplay::new();
+        display.draw(Font6x8::render_str(" ").stroke(Some(BinaryColor::On)));
 
-        #[cfg_attr(rustfmt, rustfmt_skip)]
-        assert_eq!(
-            display,
-            MockDisplay::new([
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                //
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-            ])
-        );
+        assert_eq!(display, MockDisplay::new());
     }
 
     #[test]
     fn correct_dollar_y() {
-        let mut display = MockDisplay::default();
-        display.draw(Font6x8::render_str("$y").stroke(Some(C1)));
+        let mut display = MockDisplay::new();
+        display.draw(Font6x8::render_str("$y").stroke(Some(BinaryColor::On)));
 
-        #[cfg_attr(rustfmt, rustfmt_skip)]
         assert_eq!(
             display,
-            MockDisplay::new([
-                [C0, C0, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C1, C1, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C1, C0, C1, C0, C0, C0, C1, C0, C0, C0, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C1, C1, C1, C0, C0, C1, C0, C0, C0, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C1, C0, C1, C0, C1, C0, C0, C0, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C1, C1, C1, C1, C0, C0, C0, C1, C1, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C1, C0, C0, C0, C0, C0, C0, C0, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C1, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                //
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
+            MockDisplay::from_pattern(&[
+                "  #         ",
+                " ####       ",
+                "# #   #   # ",
+                " ###  #   # ",
+                "  # # #   # ",
+                "####   #### ",
+                "  #       # ",
+                "       ###  ",
             ])
         );
     }
 
     #[test]
     fn correct_latin1() {
-        let mut display = MockDisplay::default();
-        display.draw(Font6x8::render_str("¡ÿ").stroke(Some(C1)));
+        let mut display = MockDisplay::new();
+        display.draw(Font6x8::render_str("¡ÿ").stroke(Some(BinaryColor::On)));
 
-        #[cfg_attr(rustfmt, rustfmt_skip)]
         assert_eq!(
             display,
-            MockDisplay::new([
-                [C0, C0, C1, C0, C0, C0, C0, C1, C0, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C1, C0, C0, C0, C1, C0, C0, C0, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C1, C0, C0, C0, C1, C0, C0, C0, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C1, C0, C0, C0, C1, C0, C0, C0, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C1, C0, C0, C0, C0, C1, C1, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C1, C0, C0, C0, C0, C0, C0, C0, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C1, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                //
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
+            MockDisplay::from_pattern(&[
+                "  #    # #  ",
+                "            ",
+                "  #   #   # ",
+                "  #   #   # ",
+                "  #   #   # ",
+                "  #    #### ",
+                "  #       # ",
+                "       ###  ",
+                "            ",
             ])
         );
     }
 
     #[test]
     fn dont_panic() {
-        #[cfg_attr(rustfmt, rustfmt_skip)]
-        let two_question_marks = MockDisplay::new(
-            [
-                [C0, C1, C1, C1, C0, C0, C0, C1, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C1, C0, C0, C0, C1, C0, C1, C0, C0, C0, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C1, C0, C0, C0, C0, C0, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C1, C0, C0, C0, C0, C0, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C1, C0, C0, C0, C0, C0, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C1, C0, C0, C0, C0, C0, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                //
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-            ]
-        );
+        let two_question_marks = MockDisplay::from_pattern(&[
+            " ###   ### ",
+            "#   # #   #",
+            "    #     #",
+            "   #     # ",
+            "  #     #  ",
+            "           ",
+            "  #     #  ",
+        ]);
 
-        let mut display = MockDisplay::default();
-        display.draw(Font6x8::render_str("\0\n").stroke(Some(C1)));
+        let mut display = MockDisplay::new();
+        display.draw(Font6x8::render_str("\0\n").stroke(Some(BinaryColor::On)));
         assert_eq!(display, two_question_marks);
 
-        let mut display = MockDisplay::default();
-        display.draw(Font6x8::render_str("\x7F\u{A0}").stroke(Some(C1)));
+        let mut display = MockDisplay::new();
+        display.draw(Font6x8::render_str("\x7F\u{A0}").stroke(Some(BinaryColor::On)));
         assert_eq!(display, two_question_marks);
 
-        let mut display = MockDisplay::default();
-        display.draw(Font6x8::render_str("Ā💣").stroke(Some(C1)));
+        let mut display = MockDisplay::new();
+        display.draw(Font6x8::render_str("Ā💣").stroke(Some(BinaryColor::On)));
         assert_eq!(display, two_question_marks);
     }
 }

--- a/embedded-graphics/src/fonts/font6x8.rs
+++ b/embedded-graphics/src/fonts/font6x8.rs
@@ -206,9 +206,16 @@ mod tests {
                 .fill(Some(BinaryColor::Off)),
         );
 
-        let inverted_display_normal = display_normal.pixels().map(|p| p.map(|c| c.invert()));
+        for y in 0..display_inverse.height() {
+            for x in 0..display_inverse.width() {
+                let p = UnsignedCoord::new(x as u32, y as u32);
 
-        assert!(inverted_display_normal.eq(display_inverse.pixels()));
+                let inverse_color = display_inverse.get_pixel(p);
+                let normal_color = display_normal.get_pixel(p);
+
+                assert_eq!(inverse_color, normal_color.map(|c| c.invert()));
+            }
+        }
     }
 
     #[test]

--- a/embedded-graphics/src/fonts/font8x16.rs
+++ b/embedded-graphics/src/fonts/font8x16.rs
@@ -103,13 +103,11 @@ mod tests {
     use crate::transform::Transform;
     use crate::unsignedcoord::UnsignedCoord;
     use crate::Drawing;
-    use BinaryColor::Off as C0;
-    use BinaryColor::On as C1;
 
     #[test]
     fn off_screen_text_does_not_infinite_loop() {
         let text: Font8x16<BinaryColor> = Font8x16::render_str("Hello World!")
-            .style(Style::stroke(C1))
+            .style(Style::stroke(BinaryColor::On))
             .translate(Coord::new(5, -20));
         let mut it = text.into_iter();
 
@@ -139,154 +137,147 @@ mod tests {
 
     #[test]
     fn correct_m() {
-        let mut display = MockDisplay::default();
-        display.draw(Font8x16::render_str("Mm").stroke(Some(C1)));
+        let mut display = MockDisplay::new();
+        display.draw(Font8x16::render_str("Mm").stroke(Some(BinaryColor::On)));
 
-        #[cfg_attr(rustfmt, rustfmt_skip)]
         assert_eq!(
             display,
-            MockDisplay::new([
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C1, C1, C0, C0, C0, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C1, C1, C1, C0, C1, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C1, C1, C1, C1, C1, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C1, C1, C1, C1, C1, C1, C1, C0, C1, C1, C1, C0, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C1, C1, C0, C1, C0, C1, C1, C0, C1, C1, C1, C1, C1, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C1, C1, C0, C0, C0, C1, C1, C0, C1, C1, C0, C1, C0, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C1, C1, C0, C0, C0, C1, C1, C0, C1, C1, C0, C1, C0, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C1, C1, C0, C0, C0, C1, C1, C0, C1, C1, C0, C1, C0, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C1, C1, C0, C0, C0, C1, C1, C0, C1, C1, C0, C1, C0, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C1, C1, C0, C0, C0, C1, C1, C0, C1, C1, C0, C0, C0, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
+            MockDisplay::from_pattern(&[
+                "                ",
+                "                ",
+                "##   ##         ",
+                "### ###         ",
+                "#######         ",
+                "####### ### ##  ",
+                "## # ## ####### ",
+                "##   ## ## # ## ",
+                "##   ## ## # ## ",
+                "##   ## ## # ## ",
+                "##   ## ## # ## ",
+                "##   ## ##   ## ",
+                "                ",
+                "                ",
+                "                ",
+                "                ",
             ])
         );
     }
 
     #[test]
     fn correct_ascii_borders() {
-        let mut display = MockDisplay::default();
-        display.draw(Font8x16::render_str(" ~").stroke(Some(C1)));
+        let mut display = MockDisplay::new();
+        display.draw(Font8x16::render_str(" ~").stroke(Some(BinaryColor::On)));
 
-        #[cfg_attr(rustfmt, rustfmt_skip)]
         assert_eq!(
             display,
-            MockDisplay::new([
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C1, C1, C1, C0, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C1, C1, C0, C1, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
+            MockDisplay::from_pattern(&[
+                "                ",
+                "         ### ## ",
+                "        ## ###  ",
+                "                ",
+                "                ",
+                "                ",
+                "                ",
+                "                ",
+                "                ",
+                "                ",
+                "                ",
+                "                ",
+                "                ",
+                "                ",
+                "                ",
+                "                ",
             ])
         );
     }
 
     #[test]
     fn correct_dollar_y() {
-        let mut display = MockDisplay::default();
-        display.draw(Font8x16::render_str("$y").stroke(Some(C1)));
+        let mut display = MockDisplay::new();
+        display.draw(Font8x16::render_str("$y").stroke(Some(BinaryColor::On)));
 
-        #[cfg_attr(rustfmt, rustfmt_skip)]
         assert_eq!(
             display,
-            MockDisplay::new([
-                [C0, C0, C0, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C1, C1, C1, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C1, C1, C0, C0, C0, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C1, C1, C0, C0, C0, C0, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C1, C1, C0, C0, C0, C0, C0, C0, C1, C1, C0, C0, C0, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C1, C1, C1, C1, C1, C0, C0, C1, C1, C0, C0, C0, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C1, C1, C0, C1, C1, C0, C0, C0, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C1, C1, C0, C1, C1, C0, C0, C0, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C1, C0, C0, C0, C0, C1, C1, C0, C1, C1, C0, C0, C0, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C1, C1, C0, C0, C0, C1, C1, C0, C1, C1, C0, C0, C0, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C1, C1, C1, C1, C1, C0, C0, C0, C1, C1, C1, C1, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C1, C1, C0, C0, C0, C0, C0, C0, C0, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C1, C1, C1, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
+            MockDisplay::from_pattern(&[
+                "   ##                   ",
+                "   ##                   ",
+                " #####                  ",
+                "##   ##                 ",
+                "##    #                 ",
+                "##      ##   ##         ",
+                " #####  ##   ##         ",
+                "     ## ##   ##         ",
+                "     ## ##   ##         ",
+                "#    ## ##   ##         ",
+                "##   ## ##   ##         ",
+                " #####   ######         ",
+                "   ##        ##         ",
+                "   ##       ##          ",
+                "        #####           ",
+                "                        ",
             ])
         );
     }
 
     #[test]
     fn correct_latin1() {
-        let mut display = MockDisplay::default();
-        display.draw(Font8x16::render_str("¡ÿ").stroke(Some(C1)));
+        let mut display = MockDisplay::new();
+        display.draw(Font8x16::render_str("¡ÿ").stroke(Some(BinaryColor::On)));
 
-        #[cfg_attr(rustfmt, rustfmt_skip)]
         assert_eq!(
             display,
-            MockDisplay::new([
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C1, C1, C0, C0, C0, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C1, C1, C0, C0, C0, C1, C1, C0, C0, C0, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C1, C1, C0, C0, C0, C1, C1, C0, C0, C0, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C1, C1, C0, C0, C0, C1, C1, C0, C0, C0, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C1, C1, C0, C0, C0, C1, C1, C0, C0, C0, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C1, C1, C1, C1, C0, C0, C1, C1, C0, C0, C0, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C1, C1, C1, C1, C0, C0, C1, C1, C0, C0, C0, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C1, C1, C1, C1, C0, C0, C1, C1, C0, C0, C0, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C1, C1, C0, C0, C0, C0, C1, C1, C1, C1, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C1, C1, C1, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
+            MockDisplay::from_pattern(&[
+                "                        ",
+                "        ##   ##         ",
+                "   ##   ##   ##         ",
+                "   ##                   ",
+                "                        ",
+                "   ##   ##   ##         ",
+                "   ##   ##   ##         ",
+                "   ##   ##   ##         ",
+                "  ####  ##   ##         ",
+                "  ####  ##   ##         ",
+                "  ####  ##   ##         ",
+                "   ##    ######         ",
+                "             ##         ",
+                "            ##          ",
+                "        #####           ",
+                "                        ",
             ])
         );
     }
 
     #[test]
     fn dont_panic() {
-        #[cfg_attr(rustfmt, rustfmt_skip)]
-        let two_question_marks = MockDisplay::new(
-            [
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C1, C1, C1, C1, C1, C0, C0, C0, C1, C1, C1, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C1, C1, C0, C0, C0, C1, C1, C0, C1, C1, C0, C0, C0, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C1, C1, C0, C0, C0, C1, C1, C0, C1, C1, C0, C0, C0, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C1, C1, C0, C0, C0, C0, C0, C0, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C1, C1, C0, C0, C0, C0, C0, C0, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C1, C1, C0, C0, C0, C0, C0, C0, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C1, C1, C0, C0, C0, C0, C0, C0, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C1, C1, C0, C0, C0, C0, C0, C0, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C1, C1, C0, C0, C0, C0, C0, C0, C1, C1, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-                [C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0, C0],
-            ]
-        );
+        let two_question_marks = MockDisplay::from_pattern(&[
+            "                        ",
+            "                        ",
+            " #####   #####          ",
+            "##   ## ##   ##         ",
+            "##   ## ##   ##         ",
+            "    ##      ##          ",
+            "   ##      ##           ",
+            "   ##      ##           ",
+            "   ##      ##           ",
+            "                        ",
+            "   ##      ##           ",
+            "   ##      ##           ",
+            "                        ",
+            "                        ",
+            "                        ",
+            "                        ",
+        ]);
 
-        let mut display = MockDisplay::default();
-        display.draw(Font8x16::render_str("\0\n").stroke(Some(C1)));
+        let mut display = MockDisplay::new();
+        display.draw(Font8x16::render_str("\0\n").stroke(Some(BinaryColor::On)));
         assert_eq!(display, two_question_marks);
 
-        let mut display = MockDisplay::default();
-        display.draw(Font8x16::render_str("\x7F\u{A0}").stroke(Some(C1)));
+        let mut display = MockDisplay::new();
+        display.draw(Font8x16::render_str("\x7F\u{A0}").stroke(Some(BinaryColor::On)));
         assert_eq!(display, two_question_marks);
 
-        let mut display = MockDisplay::default();
-        display.draw(Font8x16::render_str("Ā💣").stroke(Some(C1)));
+        let mut display = MockDisplay::new();
+        display.draw(Font8x16::render_str("Ā💣").stroke(Some(BinaryColor::On)));
         assert_eq!(display, two_question_marks);
     }
 }

--- a/embedded-graphics/src/mock_display.rs
+++ b/embedded-graphics/src/mock_display.rs
@@ -1,3 +1,24 @@
+//! Mock display for use in tests.
+//!
+//! [`MockDisplay`] can be used to replace a real display in tests. The internal
+//! framebuffer wraps the color values in `Option` to be able to test which
+//! pixels were modified by drawing operations.
+//!
+//! The [`from_pattern`] method provides a convenient way of creating expected
+//! test results. The same patterns are used by the implementation of `Debug`
+//! and will be shown in failing tests.
+//!
+//! [`MockDisplay`]: struct.MockDisplay.html
+//! [`from_pattern`]: struct.MockDisplay.html#method.from_pattern
+//!
+//! # Characters used in `BinaryColor` patterns
+//!
+//! | Character | Color                    | Description                             |
+//! |-----------|--------------------------|-----------------------------------------|
+//! | `' '`     | `None`                   | No drawing operation changed the pixel  |
+//! | `'.'`     | `Some(BinaryColor::Off)` | Pixel was changed to `BinaryColor::Off` |
+//! | `'#'`     | `Some(BinaryColor::On)`  | Pixel was changed to `BinaryColor::On`  |
+
 use crate::drawable::Pixel;
 use crate::pixelcolor::BinaryColor;
 use crate::prelude::*;
@@ -58,12 +79,15 @@ where
 {
     /// Creates a new mock display from a character pattern.
     ///
-    /// The color pattern is specified by a slice of string slices. Each string slice represents
-    /// a row of pixels and every character a single pixel.
+    /// The color pattern is specified by a slice of string slices. Each string
+    /// slice represents a row of pixels and every character a single pixel.
     ///
-    /// A space character in the pattern represents a pixel which wasn't modified by any
-    /// drawing routine and is left in the default state. All other characters are converted
-    /// by implementations of the `ColorMapping` trait.
+    /// A space character in the pattern represents a pixel which wasn't
+    /// modified by any drawing routine and is left in the default state.
+    /// All other characters are converted by implementations of the
+    /// [`ColorMapping`] trait.
+    ///
+    /// [`ColorMapping`]: trait.ColorMapping.html
     pub fn from_pattern(pattern: &[&str]) -> MockDisplay<C> {
         // Check pattern dimensions.
         let pattern_width = pattern.first().map_or(0, |row| row.len());
@@ -167,6 +191,10 @@ where
 }
 
 /// Mapping between `char`s and colors.
+///
+/// See the [module-level documentation] for a table of implemented mappings.
+///
+/// [module-level documentation]: index.html
 pub trait ColorMapping<C> {
     /// Converts a char into a color of type `C`.
     fn char_to_color(c: char) -> C;

--- a/embedded-graphics/src/mock_display.rs
+++ b/embedded-graphics/src/mock_display.rs
@@ -25,9 +25,30 @@ where
         Self::default()
     }
 
-    /// Returns a iterator over all pixels on the display.
-    pub fn pixels<'a>(&'a self) -> impl Iterator<Item = Option<C>> + 'a {
-        self.0.into_iter().copied()
+    /// Returns the width of the display.
+    pub fn width(&self) -> usize {
+        SIZE
+    }
+
+    /// Returns the height of the display.
+    pub fn height(&self) -> usize {
+        SIZE
+    }
+
+    /// Returns the color of a pixel.
+    pub fn get_pixel(&self, p: UnsignedCoord) -> Option<C> {
+        let x = p[0] as usize;
+        let y = p[1] as usize;
+
+        self.0[x + y * SIZE]
+    }
+
+    /// Changes the color of a pixel.
+    pub fn set_pixel(&mut self, p: UnsignedCoord, color: Option<C>) {
+        let x = p[0] as usize;
+        let y = p[1] as usize;
+
+        self.0[x + y * SIZE] = color;
     }
 }
 
@@ -132,14 +153,14 @@ where
         T: IntoIterator<Item = Pixel<C>>,
     {
         for Pixel(c, color) in item_pixels {
-            let x = c[0];
-            let y = c[1];
+            let x = c[0] as usize;
+            let y = c[1] as usize;
 
-            if x >= SIZE as u32 || y >= SIZE as u32 {
+            if x >= SIZE || y >= SIZE {
                 continue;
             }
 
-            let i = x as usize + y as usize * SIZE;
+            let i = x + y * SIZE;
             self.0[i] = Some(color);
         }
     }

--- a/embedded-graphics/src/mock_display.rs
+++ b/embedded-graphics/src/mock_display.rs
@@ -131,7 +131,10 @@ where
     where
         T: IntoIterator<Item = Pixel<C>>,
     {
-        for Pixel(UnsignedCoord(x, y), color) in item_pixels {
+        for Pixel(c, color) in item_pixels {
+            let x = c[0];
+            let y = c[1];
+
             if x >= SIZE as u32 || y >= SIZE as u32 {
                 continue;
             }

--- a/embedded-graphics/src/mock_display.rs
+++ b/embedded-graphics/src/mock_display.rs
@@ -1,24 +1,125 @@
-use crate::drawable::{Dimensions, Pixel};
+use crate::drawable::Pixel;
 use crate::pixelcolor::BinaryColor;
 use crate::prelude::*;
-use crate::{Drawing, SizedDrawing};
+use crate::Drawing;
+use core::{
+    cmp::PartialEq,
+    fmt::{self, Write},
+    iter,
+};
+
+const SIZE: usize = 64;
 
 /// Mock display for use in tests and some doc examples. Do not use directly!
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Copy, Clone)]
-pub struct MockDisplay<C>(pub [[C; 24]; 16]);
+#[derive(Clone)]
+pub struct MockDisplay<C>([Option<C>; SIZE * SIZE])
+where
+    C: PixelColor;
 
-impl<C> MockDisplay<C> {
-    pub fn new(bytes: [[C; 24]; 16]) -> Self {
-        Self(bytes)
+impl<C> MockDisplay<C>
+where
+    C: PixelColor,
+{
+    /// Creates a new empty mock display.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Returns a iterator over all pixels on the display.
+    pub fn pixels<'a>(&'a self) -> impl Iterator<Item = Option<C>> + 'a {
+        self.0.into_iter().copied()
+    }
+}
+
+impl<C> MockDisplay<C>
+where
+    C: PixelColor + ColorMapping<C>,
+{
+    /// Creates a new mock display from a character pattern.
+    ///
+    /// The color pattern is specified by a slice of string slices. Each string slice represents
+    /// a row of pixels and every character a single pixel.
+    ///
+    /// A space character in the pattern represents a pixel which wasn't modified by any
+    /// drawing routine and is left in the default state. All other characters are converted
+    /// by implementations of the `ColorMapping` trait.
+    pub fn from_pattern(pattern: &[&str]) -> MockDisplay<C> {
+        // Check pattern dimensions.
+        let pattern_width = pattern.first().map_or(0, |row| row.len());
+        let pattern_height = pattern.len();
+        assert!(pattern_width <= SIZE);
+        assert!(pattern_height <= SIZE);
+        for row in pattern {
+            assert_eq!(row.len(), pattern_width);
+        }
+
+        // Convert pattern to colors and pad pattern with None.
+        let pattern_colors = pattern
+            .into_iter()
+            .flat_map(|row| {
+                row.chars()
+                    .map(|c| match c {
+                        ' ' => None,
+                        _ => Some(C::char_to_color(c)),
+                    })
+                    .chain(iter::repeat(None))
+                    .take(SIZE)
+            })
+            .chain(iter::repeat(None))
+            .take(SIZE * SIZE);
+
+        // Copy pattern to display.
+        let mut display = MockDisplay::new();
+        for (i, color) in pattern_colors.enumerate() {
+            display.0[i] = color;
+        }
+
+        display
     }
 }
 
 impl<C> Default for MockDisplay<C>
 where
-    C: PixelColor + From<BinaryColor>,
+    C: PixelColor,
 {
     fn default() -> Self {
-        MockDisplay::new([[BinaryColor::Off.into(); 24]; 16])
+        Self([None; SIZE * SIZE])
+    }
+}
+
+impl<C> fmt::Debug for MockDisplay<C>
+where
+    C: PixelColor + ColorMapping<C>,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let empty_rows = self
+            .0
+            .rchunks(SIZE)
+            .take_while(|row| row.into_iter().all(Option::is_none))
+            .count();
+
+        writeln!(f, "MockDisplay[")?;
+        for row in self.0.chunks(SIZE).take(SIZE - empty_rows) {
+            for color in row {
+                f.write_char(color.map_or(' ', C::color_to_char))?;
+            }
+            writeln!(f)?;
+        }
+        if empty_rows > 0 {
+            writeln!(f, "({} empty rows skipped)", empty_rows)?;
+        }
+        writeln!(f, "]")?;
+
+        Ok(())
+    }
+}
+
+impl<C> PartialEq for MockDisplay<C>
+where
+    C: PixelColor,
+{
+    fn eq(&self, other: &MockDisplay<C>) -> bool {
+        self.0.into_iter().eq(other.0.into_iter())
     }
 }
 
@@ -30,32 +131,39 @@ where
     where
         T: IntoIterator<Item = Pixel<C>>,
     {
-        for Pixel(coord, color) in item_pixels {
-            if coord[0] >= 24 || coord[1] >= 16 {
+        for Pixel(UnsignedCoord(x, y), color) in item_pixels {
+            if x >= SIZE as u32 || y >= SIZE as u32 {
                 continue;
             }
-            self.0[coord[1] as usize][coord[0] as usize] = color;
+
+            let i = x as usize + y as usize * SIZE;
+            self.0[i] = Some(color);
         }
     }
 }
 
-impl<C> SizedDrawing<C> for MockDisplay<C>
-where
-    C: PixelColor,
-{
-    fn draw_sized<T>(&mut self, item: T)
-    where
-        T: IntoIterator<Item = Pixel<C>> + Dimensions,
-    {
-        // Use `top_left()`, `size()`, etc methods defined on Dimensions to set draw area here
+/// Mapping between `char`s and colors.
+pub trait ColorMapping<C> {
+    /// Converts a char into a color of type `C`.
+    fn char_to_color(c: char) -> C;
 
-        let offs = item.top_left().to_unsigned();
+    /// Converts a color of type `C` into a char.
+    fn color_to_char(color: C) -> char;
+}
 
-        for Pixel(coord, color) in item {
-            // Undo any translations applied to this object
-            let coord_untransformed = coord - offs;
+impl ColorMapping<BinaryColor> for BinaryColor {
+    fn char_to_color(c: char) -> Self {
+        match c {
+            '.' => BinaryColor::Off,
+            '#' => BinaryColor::On,
+            _ => panic!("Invalid char in pattern: '{}'", c),
+        }
+    }
 
-            self.0[coord_untransformed[1] as usize][coord_untransformed[0] as usize] = color;
+    fn color_to_char(color: BinaryColor) -> char {
+        match color {
+            BinaryColor::Off => '.',
+            BinaryColor::On => '#',
         }
     }
 }


### PR DESCRIPTION
The PR simplifies testing of drawing routines by using character patterns to specify the expected output.

Apart from being easier to read and write, the previous tests couldn't distinguish if a pixel wasn't drawn at all or was drawn with `BinaryColor::Off`. This is now possible by using `Option<C>` for storing pixels. See `font6x8::tests::correct_inverse_coloured_m` for an example which expects `BinaryColor::Off` and all other font tests which expect a transparent background.

`fmt::Debug` for `MockDisplay` now outputs the same ASCII art representation of the display which is useful to debug failing tests.

Currently char patterns are only supported for `BinaryColor`, but this could easily be extended to other color types for more complex tests which might for example use different colors for stroke and fill.