### PR TITLE
Refactor Nalgebra integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Embedded Graphics is a `no_std` library for adding graphics features to display drivers. It aims to use the minimum amount of memory for builtin graphics objects by leveraging Rust's iterators to avoid large allocations. It targets embedded environments, but can run anywhere like a Raspberry Pi up to full desktop machines.
 
+## Unreleased
+
+- **(breaking)** Integration with Nalgebra through the `nalgebra_support` feature is now achieved by converting Nalgebra types into `Coord` or `UnsignedCoord` instead of Embedded Graphics aliasing `Coord` and `UnsignedCoord` to `nalgebra::Vector2<i32>` and `nalgebra::Vector2<u32>` respectively. Integration now requires calling `Coord::from(my_nalgebra_var)` or `my_nalgebra_var.into()`.
+
+  The benefit of this change is to allow more integer primitive types in `Vector2`. Embedded Graphics should now support `u8`, `u16` and `u32` conversions to `UnsignedCoord`, and `u8`, `u16`, `i8`, `i16` and `i32` conversions to `Coord`. It also reduces coupling between Nalgebra and Embedded Graphics.
+
 ## 0.6.0-alpha.1
 
 Major breaking changes ahead! @rfuest has been hard at work making the colours story in Embedded Graphics much richer and easier to use.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 
   The benefit of this change is to allow more integer primitive types in `Vector2`. Embedded Graphics should now support `u8`, `u16` and `u32` conversions to `UnsignedCoord`, and `u8`, `u16`, `i8`, `i16` and `i32` conversions to `Coord`. It also reduces coupling between Nalgebra and Embedded Graphics.
 
+- **(breaking)** `Coord`s can no longer be created from `(u32, u32)`, `[u32; 2]` or `&[u32; 2]`; these conversions are dangerous as the full range of `u32` values cannot be represented by the `i32` used for storage inside `Coord`.
+
 ## 0.6.0-alpha.1
 
 Major breaking changes ahead! @rfuest has been hard at work making the colours story in Embedded Graphics much richer and easier to use.

--- a/embedded-graphics/src/coord.rs
+++ b/embedded-graphics/src/coord.rs
@@ -156,24 +156,6 @@ impl Neg for Coord {
     }
 }
 
-impl From<(u32, u32)> for Coord {
-    fn from(other: (u32, u32)) -> Self {
-        Self(other.0 as i32, other.1 as i32)
-    }
-}
-
-impl From<[u32; 2]> for Coord {
-    fn from(other: [u32; 2]) -> Self {
-        Self(other[0] as i32, other[1] as i32)
-    }
-}
-
-impl From<&[u32; 2]> for Coord {
-    fn from(other: &[u32; 2]) -> Self {
-        Self(other[0] as i32, other[1] as i32)
-    }
-}
-
 impl From<(i32, i32)> for Coord {
     fn from(other: (i32, i32)) -> Self {
         Self(other.0, other.1)
@@ -295,19 +277,19 @@ mod tests {
 
     #[test]
     fn from_tuple() {
-        assert_eq!(Coord::from((20u32, 30u32)), Coord::new(20, 30));
+        assert_eq!(Coord::from((20i32, 30i32)), Coord::new(20, 30));
         assert_eq!(Coord::from((20i32, 30i32)), Coord::new(20, 30));
     }
 
     #[test]
     fn from_array() {
-        assert_eq!(Coord::from([20u32, 30u32]), Coord::new(20, 30));
+        assert_eq!(Coord::from([20i32, 30i32]), Coord::new(20, 30));
         assert_eq!(Coord::from([20i32, 30i32]), Coord::new(20, 30));
     }
 
     #[test]
     fn from_array_ref() {
-        assert_eq!(Coord::from(&[20u32, 30u32]), Coord::new(20, 30));
+        assert_eq!(Coord::from(&[20i32, 30i32]), Coord::new(20, 30));
         assert_eq!(Coord::from(&[20i32, 30i32]), Coord::new(20, 30));
     }
 

--- a/embedded-graphics/src/coord.rs
+++ b/embedded-graphics/src/coord.rs
@@ -13,6 +13,15 @@ type CoordPart = i32;
 /// [`Rect`] may be defined that has its top left at `(-1,-2)`. To specify positive-only screen
 /// coordinates and the like, see [`UnsignedCoord`].
 ///
+/// [Nalgebra] support can be enabled with the `nalgebra_support` feature. This implements
+/// `From<Vector2<N>>` and `From<&Vector2<N>>` where `N` is `Scalar + Into<i32>`. This allows use
+/// of Nalgebra's [`Vector2`] with embedded-graphics where `i8`, `i16`, `i32`, `u16` or `u8` is used
+/// for value storage.
+///
+/// # Examples
+///
+/// ## Create a `Coord` from two integers
+///
 /// ```rust
 /// use embedded_graphics::{coord::Coord, icoord};
 ///
@@ -25,12 +34,43 @@ type CoordPart = i32;
 /// assert_eq!(c1, c2);
 /// ```
 ///
-/// Note that enabling the `nalgebra` feature will alias Nalgebra's [`Vector2<i32>`] type to
-/// `Coord` instead of this builtin implementation.
+/// ## Create a `Coord` from a Nalgebra `Vector2`
+///
+/// _Be sure to enable the `nalgebra_support` feature to get [Nalgebra] integration._
+///
+/// ```rust
+/// # #[cfg(feature = "nalgebra_support")] {
+/// use embedded_graphics::{coord::Coord, icoord};
+/// use nalgebra::Vector2;
+///
+/// let n_coord = Vector2::new(10i32, 20);
+///
+/// assert_eq!(Coord::from(n_coord), Coord::new(10, 20));
+/// # }
+/// ```
+///
+/// ## Convert a `Vector2<u8>` into a `Coord`
+///
+/// _Be sure to enable the `nalgebra_support` feature to get [Nalgebra] integration._
+///
+/// Smaller unsigned types that can be converted to `i32` are also supported in conversions.
+///
+/// ```rust
+/// # #[cfg(feature = "nalgebra_support")] {
+/// use embedded_graphics::{coord::Coord, icoord};
+/// use nalgebra::Vector2;
+
+/// let n_coord = Vector2::new(10u8, 20);
+///
+/// assert_eq!(Coord::from(n_coord), Coord::new(10, 20));
+/// # }
+/// ```
 ///
 /// [`UnsignedCoord`]: ../unsignedcoord/struct.UnsignedCoord.html
 /// [`Rect`]: ../primitives/rectangle/struct.Rectangle.html
-/// [`Vector2<i32>`]: https://docs.rs/nalgebra/0.18.0/nalgebra/base/type.Vector2.html
+/// [`Vector2<N>`]: https://docs.rs/nalgebra/0.18.0/nalgebra/base/type.Vector2.html
+/// [`Vector2`]: https://docs.rs/nalgebra/0.18.0/nalgebra/base/type.Vector2.html
+/// [Nalgebra]: https://docs.rs/nalgebra
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub struct Coord(pub CoordPart, pub CoordPart);
 

--- a/embedded-graphics/src/coord.rs
+++ b/embedded-graphics/src/coord.rs
@@ -8,7 +8,7 @@ use core::ops::{Add, AddAssign, Index, Neg, Sub, SubAssign};
 /// 2D signed integer coordinate type
 ///
 /// This coordinate should be used to define graphics object coordinates. For example, a
-/// [`Rect`] may be defined that has its top left at `(-1,-2)`. To specify positive-only screen
+/// [`Rectangle`] may be defined that has its top left at `(-1,-2)`. To specify positive-only screen
 /// coordinates and the like, see [`UnsignedCoord`].
 ///
 /// [Nalgebra] support can be enabled with the `nalgebra_support` feature. This implements
@@ -65,7 +65,7 @@ use core::ops::{Add, AddAssign, Index, Neg, Sub, SubAssign};
 /// ```
 ///
 /// [`UnsignedCoord`]: ../unsignedcoord/struct.UnsignedCoord.html
-/// [`Rect`]: ../primitives/rectangle/struct.Rectangle.html
+/// [`Rectangle`]: ../primitives/rectangle/struct.Rectangle.html
 /// [`Vector2<N>`]: https://docs.rs/nalgebra/0.18.0/nalgebra/base/type.Vector2.html
 /// [`Vector2`]: https://docs.rs/nalgebra/0.18.0/nalgebra/base/type.Vector2.html
 /// [Nalgebra]: https://docs.rs/nalgebra
@@ -74,7 +74,7 @@ pub struct Coord(pub i32, pub i32);
 
 impl Coord {
     /// Create a new coordinate with X and Y values
-    pub fn new(x: i32, y: i32) -> Self {
+    pub const fn new(x: i32, y: i32) -> Self {
         Coord(x, y)
     }
 
@@ -143,7 +143,7 @@ impl Index<usize> for Coord {
         match idx {
             0 => &self.0,
             1 => &self.1,
-            _ => panic!("Unreachable index {}", idx),
+            _ => panic!("index out of bounds: the len is 2 but the index is {}", idx),
         }
     }
 }

--- a/embedded-graphics/src/coord.rs
+++ b/embedded-graphics/src/coord.rs
@@ -2,184 +2,192 @@
 //!
 //! To output (non-negative) pixel coordinates, use [`UnsignedCoord`](../unsignedcoord/index.html).
 
-use super::unsignedcoord::UnsignedCoord;
+use crate::unsignedcoord::UnsignedCoord;
+use core::ops::{Add, AddAssign, Index, Neg, Sub, SubAssign};
 
 type CoordPart = i32;
 
-#[cfg(not(feature = "nalgebra_support"))]
-mod internal_coord {
-    use super::*;
-    use core::ops::{Add, AddAssign, Index, Neg, Sub, SubAssign};
+/// 2D signed integer coordinate type
+///
+/// This coordinate should be used to define graphics object coordinates. For example, a
+/// [`Rect`] may be defined that has its top left at `(-1,-2)`. To specify positive-only screen
+/// coordinates and the like, see [`UnsignedCoord`].
+///
+/// ```rust
+/// use embedded_graphics::{coord::Coord, icoord};
+///
+/// // Create a coord using the `new` constructor method
+/// let c1 = Coord::new(10, 20);
+///
+/// // Create a coord using the handy `icoord` macro
+/// let c2 = icoord!(10, 20);
+///
+/// assert_eq!(c1, c2);
+/// ```
+///
+/// Note that enabling the `nalgebra` feature will alias Nalgebra's [`Vector2<i32>`] type to
+/// `Coord` instead of this builtin implementation.
+///
+/// [`UnsignedCoord`]: ../unsignedcoord/struct.UnsignedCoord.html
+/// [`Rect`]: ../primitives/rectangle/struct.Rectangle.html
+/// [`Vector2<i32>`]: https://docs.rs/nalgebra/0.18.0/nalgebra/base/type.Vector2.html
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub struct Coord(pub CoordPart, pub CoordPart);
 
-    /// 2D signed integer coordinate type
+impl Coord {
+    /// Create a new coordinate with X and Y values
+    pub fn new(x: CoordPart, y: CoordPart) -> Self {
+        Coord(x, y)
+    }
+
+    /// Clamp coordinate components to positive integer range
     ///
-    /// This coordinate should be used to define graphics object coordinates. For example, a
-    /// [`Rect`] may be defined that has its top left at `(-1,-2)`. To specify positive-only screen
-    /// coordinates and the like, see [`UnsignedCoord`].
-    ///
-    /// ```rust
-    /// use embedded_graphics::{coord::Coord, icoord};
-    ///
-    /// // Create a coord using the `new` constructor method
-    /// let c1 = Coord::new(10, 20);
-    ///
-    /// // Create a coord using the handy `icoord` macro
-    /// let c2 = icoord!(10, 20);
-    ///
-    /// assert_eq!(c1, c2);
     /// ```
+    /// # use embedded_graphics::coord::Coord;
+    /// #
+    /// let coord = Coord::new(-5, 10);
     ///
-    /// Note that enabling the `nalgebra` feature will alias Nalgebra's [`Vector2<i32>`] type to
-    /// `Coord` instead of this builtin implementation.
+    /// assert_eq!(coord.clamp_positive(), Coord::new(0, 10));
+    /// ```
+    pub fn clamp_positive(&self) -> Self {
+        Coord::new(self.0.max(0), self.1.max(0))
+    }
+
+    /// Remove the sign from a coordinate
     ///
-    /// [`UnsignedCoord`]: ../unsignedcoord/struct.UnsignedCoord.html
-    /// [`Rect`]: ../primitives/rectangle/struct.Rectangle.html
-    /// [`Vector2<i32>`]: https://docs.rs/nalgebra/0.18.0/nalgebra/base/type.Vector2.html
-    #[derive(Debug, Copy, Clone, Eq, PartialEq)]
-    pub struct Coord(pub CoordPart, pub CoordPart);
-
-    impl Coord {
-        /// Create a new coordinate with X and Y values
-        pub fn new(x: CoordPart, y: CoordPart) -> Self {
-            Coord(x, y)
-        }
-
-        /// Clamp coordinate components to positive integer range
-        ///
-        /// ```
-        /// # use embedded_graphics::coord::Coord;
-        /// #
-        /// let coord = Coord::new(-5, 10);
-        ///
-        /// assert_eq!(coord.clamp_positive(), Coord::new(0, 10));
-        /// ```
-        pub fn clamp_positive(&self) -> Self {
-            Coord::new(self.0.max(0), self.1.max(0))
-        }
-
-        /// Remove the sign from a coordinate
-        ///
-        ///
-        /// ```
-        /// # use embedded_graphics::coord::Coord;
-        /// #
-        /// let coord = Coord::new(-5, -10);
-        ///
-        /// assert_eq!(coord.abs(), Coord::new(5, 10));
-        /// ```
-        pub fn abs(&self) -> Self {
-            Coord::new(self.0.abs(), self.1.abs())
-        }
+    ///
+    /// ```
+    /// # use embedded_graphics::coord::Coord;
+    /// #
+    /// let coord = Coord::new(-5, -10);
+    ///
+    /// assert_eq!(coord.abs(), Coord::new(5, 10));
+    /// ```
+    pub fn abs(&self) -> Self {
+        Coord::new(self.0.abs(), self.1.abs())
     }
+}
 
-    impl Add for Coord {
-        type Output = Coord;
+impl Add for Coord {
+    type Output = Coord;
 
-        fn add(self, other: Coord) -> Coord {
-            Coord::new(self.0 + other.0, self.1 + other.1)
-        }
+    fn add(self, other: Coord) -> Coord {
+        Coord::new(self.0 + other.0, self.1 + other.1)
     }
+}
 
-    impl AddAssign for Coord {
-        fn add_assign(&mut self, other: Coord) {
-            self.0 += other.0;
-            self.1 += other.1;
-        }
+impl AddAssign for Coord {
+    fn add_assign(&mut self, other: Coord) {
+        self.0 += other.0;
+        self.1 += other.1;
     }
+}
 
-    impl Sub for Coord {
-        type Output = Coord;
+impl Sub for Coord {
+    type Output = Coord;
 
-        fn sub(self, other: Coord) -> Coord {
-            Coord::new(self.0 - other.0, self.1 - other.1)
-        }
+    fn sub(self, other: Coord) -> Coord {
+        Coord::new(self.0 - other.0, self.1 - other.1)
     }
+}
 
-    impl SubAssign for Coord {
-        fn sub_assign(&mut self, other: Coord) {
-            self.0 -= other.0;
-            self.1 -= other.1;
-        }
+impl SubAssign for Coord {
+    fn sub_assign(&mut self, other: Coord) {
+        self.0 -= other.0;
+        self.1 -= other.1;
     }
+}
 
-    impl Index<usize> for Coord {
-        type Output = CoordPart;
+impl Index<usize> for Coord {
+    type Output = CoordPart;
 
-        fn index(&self, idx: usize) -> &CoordPart {
-            match idx {
-                0 => &self.0,
-                1 => &self.1,
-                _ => panic!("Unreachable index {}", idx),
-            }
-        }
-    }
-
-    impl Neg for Coord {
-        type Output = Coord;
-
-        fn neg(self) -> Self::Output {
-            Coord::new(-self.0, -self.1)
-        }
-    }
-
-    impl From<(u32, u32)> for Coord {
-        fn from(other: (u32, u32)) -> Self {
-            Self(other.0 as i32, other.1 as i32)
-        }
-    }
-
-    impl From<[u32; 2]> for Coord {
-        fn from(other: [u32; 2]) -> Self {
-            Self(other[0] as i32, other[1] as i32)
-        }
-    }
-
-    impl From<&[u32; 2]> for Coord {
-        fn from(other: &[u32; 2]) -> Self {
-            Self(other[0] as i32, other[1] as i32)
-        }
-    }
-
-    impl From<(i32, i32)> for Coord {
-        fn from(other: (i32, i32)) -> Self {
-            Self(other.0, other.1)
-        }
-    }
-
-    impl From<[i32; 2]> for Coord {
-        fn from(other: [i32; 2]) -> Self {
-            Self(other[0], other[1])
-        }
-    }
-
-    impl From<&[i32; 2]> for Coord {
-        fn from(other: &[i32; 2]) -> Self {
-            Self(other[0], other[1])
-        }
-    }
-
-    impl From<Coord> for (i32, i32) {
-        fn from(other: Coord) -> (i32, i32) {
-            (other.0, other.1)
-        }
-    }
-
-    impl From<&Coord> for (i32, i32) {
-        fn from(other: &Coord) -> (i32, i32) {
-            (other.0, other.1)
+    fn index(&self, idx: usize) -> &CoordPart {
+        match idx {
+            0 => &self.0,
+            1 => &self.1,
+            _ => panic!("Unreachable index {}", idx),
         }
     }
 }
 
-#[cfg(not(feature = "nalgebra_support"))]
-pub use self::internal_coord::Coord;
+impl Neg for Coord {
+    type Output = Coord;
+
+    fn neg(self) -> Self::Output {
+        Coord::new(-self.0, -self.1)
+    }
+}
+
+impl From<(u32, u32)> for Coord {
+    fn from(other: (u32, u32)) -> Self {
+        Self(other.0 as i32, other.1 as i32)
+    }
+}
+
+impl From<[u32; 2]> for Coord {
+    fn from(other: [u32; 2]) -> Self {
+        Self(other[0] as i32, other[1] as i32)
+    }
+}
+
+impl From<&[u32; 2]> for Coord {
+    fn from(other: &[u32; 2]) -> Self {
+        Self(other[0] as i32, other[1] as i32)
+    }
+}
+
+impl From<(i32, i32)> for Coord {
+    fn from(other: (i32, i32)) -> Self {
+        Self(other.0, other.1)
+    }
+}
+
+impl From<[i32; 2]> for Coord {
+    fn from(other: [i32; 2]) -> Self {
+        Self(other[0], other[1])
+    }
+}
+
+impl From<&[i32; 2]> for Coord {
+    fn from(other: &[i32; 2]) -> Self {
+        Self(other[0], other[1])
+    }
+}
+
+impl From<Coord> for (i32, i32) {
+    fn from(other: Coord) -> (i32, i32) {
+        (other.0, other.1)
+    }
+}
+
+impl From<&Coord> for (i32, i32) {
+    fn from(other: &Coord) -> (i32, i32) {
+        (other.0, other.1)
+    }
+}
 
 #[cfg(feature = "nalgebra_support")]
-use nalgebra;
+use nalgebra::{base::Scalar, Vector2};
 
-/// 2D coordinate type with Nalgebra support
 #[cfg(feature = "nalgebra_support")]
-pub type Coord = nalgebra::Vector2<CoordPart>;
+impl<N> From<Vector2<N>> for Coord
+where
+    N: Into<CoordPart> + Scalar,
+{
+    fn from(other: Vector2<N>) -> Self {
+        Self::new(other[0].into(), other[1].into())
+    }
+}
+
+#[cfg(feature = "nalgebra_support")]
+impl<N> From<&Vector2<N>> for Coord
+where
+    N: Into<CoordPart> + Scalar,
+{
+    fn from(other: &Vector2<N>) -> Self {
+        Self::new(other[0].into(), other[1].into())
+    }
+}
 
 /// Convert a value to an unsigned coordinate
 pub trait ToUnsigned {
@@ -248,27 +256,18 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(feature = "nalgebra_support"))]
     fn from_tuple() {
         assert_eq!(Coord::from((20u32, 30u32)), Coord::new(20, 30));
         assert_eq!(Coord::from((20i32, 30i32)), Coord::new(20, 30));
     }
 
     #[test]
-    #[cfg(not(feature = "nalgebra_support"))]
     fn from_array() {
         assert_eq!(Coord::from([20u32, 30u32]), Coord::new(20, 30));
         assert_eq!(Coord::from([20i32, 30i32]), Coord::new(20, 30));
     }
 
     #[test]
-    #[cfg(feature = "nalgebra_support")]
-    fn from_array() {
-        assert_eq!(Coord::from([20i32, 30i32]), Coord::new(20, 30));
-    }
-
-    #[test]
-    #[cfg(not(feature = "nalgebra_support"))]
     fn from_array_ref() {
         assert_eq!(Coord::from(&[20u32, 30u32]), Coord::new(20, 30));
         assert_eq!(Coord::from(&[20i32, 30i32]), Coord::new(20, 30));
@@ -280,7 +279,18 @@ mod tests {
         let left = nalgebra::Vector2::new(30, 40);
         let right = nalgebra::Vector2::new(10, 20);
 
-        assert_eq!(left - right, Coord::new(20, 20));
+        assert_eq!(Coord::from(left - right), Coord::new(20, 20));
+    }
+
+    #[test]
+    #[cfg(feature = "nalgebra_support")]
+    fn convert_ref() {
+        let left = nalgebra::Vector2::new(30, 40);
+        let right = nalgebra::Vector2::new(10, 20);
+
+        let c = left - right;
+
+        assert_eq!(Coord::from(&c), Coord::new(20, 20));
     }
 
     #[test]

--- a/embedded-graphics/src/coord.rs
+++ b/embedded-graphics/src/coord.rs
@@ -5,8 +5,6 @@
 use crate::unsignedcoord::UnsignedCoord;
 use core::ops::{Add, AddAssign, Index, Neg, Sub, SubAssign};
 
-type CoordPart = i32;
-
 /// 2D signed integer coordinate type
 ///
 /// This coordinate should be used to define graphics object coordinates. For example, a
@@ -72,11 +70,11 @@ type CoordPart = i32;
 /// [`Vector2`]: https://docs.rs/nalgebra/0.18.0/nalgebra/base/type.Vector2.html
 /// [Nalgebra]: https://docs.rs/nalgebra
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
-pub struct Coord(pub CoordPart, pub CoordPart);
+pub struct Coord(pub i32, pub i32);
 
 impl Coord {
     /// Create a new coordinate with X and Y values
-    pub fn new(x: CoordPart, y: CoordPart) -> Self {
+    pub fn new(x: i32, y: i32) -> Self {
         Coord(x, y)
     }
 
@@ -139,9 +137,9 @@ impl SubAssign for Coord {
 }
 
 impl Index<usize> for Coord {
-    type Output = CoordPart;
+    type Output = i32;
 
-    fn index(&self, idx: usize) -> &CoordPart {
+    fn index(&self, idx: usize) -> &i32 {
         match idx {
             0 => &self.0,
             1 => &self.1,
@@ -212,7 +210,7 @@ use nalgebra::{base::Scalar, Vector2};
 #[cfg(feature = "nalgebra_support")]
 impl<N> From<Vector2<N>> for Coord
 where
-    N: Into<CoordPart> + Scalar,
+    N: Into<i32> + Scalar,
 {
     fn from(other: Vector2<N>) -> Self {
         Self::new(other[0].into(), other[1].into())
@@ -222,7 +220,7 @@ where
 #[cfg(feature = "nalgebra_support")]
 impl<N> From<&Vector2<N>> for Coord
 where
-    N: Into<CoordPart> + Scalar,
+    N: Into<i32> + Scalar,
 {
     fn from(other: &Vector2<N>) -> Self {
         Self::new(other[0].into(), other[1].into())

--- a/embedded-graphics/src/lib.rs
+++ b/embedded-graphics/src/lib.rs
@@ -68,8 +68,7 @@
 //! Add these to your `Cargo.toml` to turn on extra bits of functionality.
 //!
 //! * `nalgebra_support` - use the [Nalgebra](https://crates.io/crates/nalgebra) crate with `no_std`
-//! support to use as the `Coord` type. This should allow you to use most Nalgebra methods on
-//! objects rendered by embedded_graphics.
+//! support to enable conversions from `nalgebra::Vector2` to [`Coord`] and [`UnsignedCoord`].
 //! * `bmp` - use the [TinyBMP](https://crates.io/crates/tinybmp) crate for BMP image support.
 //! * `tga` - use the [TinyTGA](https://crates.io/crates/tinytga) crate for TGA image support.
 //!
@@ -143,6 +142,8 @@
 //! implementation details.
 //!
 //! [`Circle`]: ./primitives/circle/struct.Circle.html
+//! [`Coord`]: ./coord/struct.Coord.html
+//! [`UnsignedCoord`]: ./unsignedcoord/struct.UnsignedCoord.html
 //! [`Font6x8`]: ./fonts/type.Font6x8.html
 //! [`Drawing`]: ./trait.Drawing.html
 //! [`SizedDrawing`]: ./trait.SizedDrawing.html

--- a/embedded-graphics/src/unsignedcoord.rs
+++ b/embedded-graphics/src/unsignedcoord.rs
@@ -4,122 +4,117 @@ use crate::coord::Coord;
 
 type UnsignedCoordPart = u32;
 
-#[cfg(not(feature = "nalgebra_support"))]
-mod internal_unsigned_coord {
-    use super::UnsignedCoordPart;
-    use crate::coord::Coord;
-    use core::ops::{Add, AddAssign, Index, Neg, Sub, SubAssign};
+use core::ops::{Add, AddAssign, Index, Neg, Sub, SubAssign};
 
-    /// 2D unsigned coordinate in screen space
-    ///
-    /// As opposed to [`Coord`](../coord/index.html), this coordinate is unsigned. It is intended for
-    /// use with [`Drawable`](../drawable/trait.Drawable.html) iterators to output valid _display pixel_
-    /// coordinates, i.e. coordinates that are always positive.
-    ///
-    /// ```rust
-    /// use embedded_graphics::{unsignedcoord::UnsignedCoord, ucoord};
-    ///
-    /// // Create a coord using the `new` constructor method
-    /// let c1 = UnsignedCoord::new(10, 20);
-    ///
-    /// // Create a coord using the handy `ucoord` macro
-    /// let c2 = ucoord!(10, 20);
-    ///
-    /// assert_eq!(c1, c2);
-    /// ```
-    ///
-    /// Note that enabling the `nalgebra` feature will alias Nalgebra's [`Vector2<u32>`] type to
-    /// `UnsignedCoord` instead of this builtin implementation.
-    ///
-    /// [`Vector2<u32>`]: https://docs.rs/nalgebra/0.18.0/nalgebra/base/type.Vector2.html
-    #[derive(Debug, Copy, Clone, Eq, PartialEq)]
-    pub struct UnsignedCoord(pub UnsignedCoordPart, pub UnsignedCoordPart);
+/// 2D unsigned coordinate in screen space
+///
+/// As opposed to [`Coord`](../coord/index.html), this coordinate is unsigned. It is intended for
+/// use with [`Drawable`](../drawable/trait.Drawable.html) iterators to output valid _display pixel_
+/// coordinates, i.e. coordinates that are always positive.
+///
+/// ```rust
+/// use embedded_graphics::{unsignedcoord::UnsignedCoord, ucoord};
+///
+/// // Create a coord using the `new` constructor method
+/// let c1 = UnsignedCoord::new(10, 20);
+///
+/// // Create a coord using the handy `ucoord` macro
+/// let c2 = ucoord!(10, 20);
+///
+/// assert_eq!(c1, c2);
+/// ```
+///
+/// Note that enabling the `nalgebra` feature will alias Nalgebra's [`Vector2<u32>`] type to
+/// `UnsignedCoord` instead of this builtin implementation.
+///
+/// [`Vector2<u32>`]: https://docs.rs/nalgebra/0.18.0/nalgebra/base/type.Vector2.html
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub struct UnsignedCoord(pub UnsignedCoordPart, pub UnsignedCoordPart);
 
-    impl UnsignedCoord {
-        /// Create a new coordinate with X and Y values
-        pub fn new(x: UnsignedCoordPart, y: UnsignedCoordPart) -> Self {
-            UnsignedCoord(x, y)
+impl UnsignedCoord {
+    /// Create a new coordinate with X and Y values
+    pub fn new(x: UnsignedCoordPart, y: UnsignedCoordPart) -> Self {
+        UnsignedCoord(x, y)
+    }
+}
+
+impl Add for UnsignedCoord {
+    type Output = UnsignedCoord;
+
+    fn add(self, other: UnsignedCoord) -> UnsignedCoord {
+        UnsignedCoord(self.0 + other.0, self.1 + other.1)
+    }
+}
+
+impl AddAssign for UnsignedCoord {
+    fn add_assign(&mut self, other: UnsignedCoord) {
+        self.0 += other.0;
+        self.1 += other.1;
+    }
+}
+
+impl Sub for UnsignedCoord {
+    type Output = UnsignedCoord;
+
+    fn sub(self, other: UnsignedCoord) -> UnsignedCoord {
+        UnsignedCoord(self.0 - other.0, self.1 - other.1)
+    }
+}
+
+impl SubAssign for UnsignedCoord {
+    fn sub_assign(&mut self, other: UnsignedCoord) {
+        self.0 -= other.0;
+        self.1 -= other.1;
+    }
+}
+
+impl Index<usize> for UnsignedCoord {
+    type Output = UnsignedCoordPart;
+
+    fn index(&self, idx: usize) -> &UnsignedCoordPart {
+        match idx {
+            0 => &self.0,
+            1 => &self.1,
+            _ => panic!("Unreachable index {}", idx),
         }
     }
+}
 
-    impl Add for UnsignedCoord {
-        type Output = UnsignedCoord;
+impl Neg for UnsignedCoord {
+    type Output = Coord;
 
-        fn add(self, other: UnsignedCoord) -> UnsignedCoord {
-            UnsignedCoord(self.0 + other.0, self.1 + other.1)
-        }
+    fn neg(self) -> Self::Output {
+        Coord::new(-(self.0 as i32), -(self.1 as i32))
     }
+}
 
-    impl AddAssign for UnsignedCoord {
-        fn add_assign(&mut self, other: UnsignedCoord) {
-            self.0 += other.0;
-            self.1 += other.1;
-        }
+impl From<(u32, u32)> for UnsignedCoord {
+    fn from(other: (u32, u32)) -> Self {
+        Self(other.0, other.1)
     }
+}
 
-    impl Sub for UnsignedCoord {
-        type Output = UnsignedCoord;
-
-        fn sub(self, other: UnsignedCoord) -> UnsignedCoord {
-            UnsignedCoord(self.0 - other.0, self.1 - other.1)
-        }
+impl From<[u32; 2]> for UnsignedCoord {
+    fn from(other: [u32; 2]) -> Self {
+        Self(other[0], other[1])
     }
+}
 
-    impl SubAssign for UnsignedCoord {
-        fn sub_assign(&mut self, other: UnsignedCoord) {
-            self.0 -= other.0;
-            self.1 -= other.1;
-        }
+impl From<&[u32; 2]> for UnsignedCoord {
+    fn from(other: &[u32; 2]) -> Self {
+        Self(other[0], other[1])
     }
+}
 
-    impl Index<usize> for UnsignedCoord {
-        type Output = UnsignedCoordPart;
-
-        fn index(&self, idx: usize) -> &UnsignedCoordPart {
-            match idx {
-                0 => &self.0,
-                1 => &self.1,
-                _ => panic!("Unreachable index {}", idx),
-            }
-        }
+impl From<UnsignedCoord> for (u32, u32) {
+    fn from(other: UnsignedCoord) -> (u32, u32) {
+        (other.0, other.1)
     }
+}
 
-    impl Neg for UnsignedCoord {
-        type Output = Coord;
-
-        fn neg(self) -> Self::Output {
-            Coord::new(-(self.0 as i32), -(self.1 as i32))
-        }
-    }
-
-    impl From<(u32, u32)> for UnsignedCoord {
-        fn from(other: (u32, u32)) -> Self {
-            Self(other.0, other.1)
-        }
-    }
-
-    impl From<[u32; 2]> for UnsignedCoord {
-        fn from(other: [u32; 2]) -> Self {
-            Self(other[0], other[1])
-        }
-    }
-
-    impl From<&[u32; 2]> for UnsignedCoord {
-        fn from(other: &[u32; 2]) -> Self {
-            Self(other[0], other[1])
-        }
-    }
-
-    impl From<UnsignedCoord> for (u32, u32) {
-        fn from(other: UnsignedCoord) -> (u32, u32) {
-            (other.0, other.1)
-        }
-    }
-
-    impl From<&UnsignedCoord> for (u32, u32) {
-        fn from(other: &UnsignedCoord) -> (u32, u32) {
-            (other.0, other.1)
-        }
+impl From<&UnsignedCoord> for (u32, u32) {
+    fn from(other: &UnsignedCoord) -> (u32, u32) {
+        (other.0, other.1)
     }
 }
 
@@ -139,15 +134,28 @@ macro_rules! ucoord {
     };
 }
 
-#[cfg(not(feature = "nalgebra_support"))]
-pub use self::internal_unsigned_coord::UnsignedCoord;
+#[cfg(feature = "nalgebra_support")]
+use nalgebra::{base::Scalar, Vector2};
 
 #[cfg(feature = "nalgebra_support")]
-use nalgebra;
+impl<N> From<Vector2<N>> for UnsignedCoord
+where
+    N: Into<UnsignedCoordPart> + Scalar,
+{
+    fn from(other: Vector2<N>) -> Self {
+        Self::new(other[0].into(), other[1].into())
+    }
+}
 
 #[cfg(feature = "nalgebra_support")]
-/// 2D coordinate type with Nalgebra support
-pub type UnsignedCoord = nalgebra::Vector2<UnsignedCoordPart>;
+impl<N> From<&Vector2<N>> for UnsignedCoord
+where
+    N: Into<UnsignedCoordPart> + Scalar,
+{
+    fn from(other: &Vector2<N>) -> Self {
+        Self::new(other[0].into(), other[1].into())
+    }
+}
 
 /// Convert an unsigned coordinate to a signed representation
 ///
@@ -185,7 +193,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(feature = "nalgebra_support"))]
     fn from_tuple() {
         assert_eq!(UnsignedCoord::from((20, 30)), UnsignedCoord::new(20, 30));
     }
@@ -196,7 +203,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(feature = "nalgebra_support"))]
     fn from_array_ref() {
         assert_eq!(UnsignedCoord::from(&[20, 30]), UnsignedCoord::new(20, 30));
     }
@@ -204,14 +210,16 @@ mod tests {
     #[test]
     #[cfg(feature = "nalgebra_support")]
     fn nalgebra_support() {
-        let left = nalgebra::Vector2::new(30, 40);
+        let left = nalgebra::Vector2::new(30u32, 40);
         let right = nalgebra::Vector2::new(10, 20);
 
-        assert_eq!(left - right, UnsignedCoord::new(20, 20));
+        assert_eq!(
+            UnsignedCoord::from(left - right),
+            UnsignedCoord::new(20, 20)
+        );
     }
 
     #[test]
-    #[cfg(not(feature = "nalgebra_support"))]
     fn neg() {
         assert_eq!(-UnsignedCoord::new(10, 20), Coord::new(-10, -20));
     }

--- a/embedded-graphics/src/unsignedcoord.rs
+++ b/embedded-graphics/src/unsignedcoord.rs
@@ -8,9 +8,19 @@ use core::ops::{Add, AddAssign, Index, Neg, Sub, SubAssign};
 
 /// 2D unsigned coordinate in screen space
 ///
-/// As opposed to [`Coord`](../coord/index.html), this coordinate is unsigned. It is intended for
+/// Unlike [`Coord`](../coord/index.html), this coordinate is unsigned. It is intended for
 /// use with [`Drawable`](../drawable/trait.Drawable.html) iterators to output valid _display pixel_
 /// coordinates, i.e. coordinates that are always positive.
+///
+/// [Nalgebra] support can be enabled with the `nalgebra_support` feature. This implements
+/// `From<Vector2<N>>` and `From<&Vector2<N>>` where `N` is `Scalar + Into<u32>`. This allows use
+/// of Nalgebra's [`Vector2`] with embedded-graphics where `u32`, `u16` or `u8` is used for value
+/// storage.
+///
+/// # Examples
+///
+/// ## Create an `UnsignedCoord` from two integers
+///
 ///
 /// ```rust
 /// use embedded_graphics::{unsignedcoord::UnsignedCoord, ucoord};
@@ -24,10 +34,39 @@ use core::ops::{Add, AddAssign, Index, Neg, Sub, SubAssign};
 /// assert_eq!(c1, c2);
 /// ```
 ///
-/// Note that enabling the `nalgebra` feature will alias Nalgebra's [`Vector2<u32>`] type to
-/// `UnsignedCoord` instead of this builtin implementation.
+/// ## Create an `UnsignedCoord` from a Nalgebra `Vector2`
 ///
-/// [`Vector2<u32>`]: https://docs.rs/nalgebra/0.18.0/nalgebra/base/type.Vector2.html
+/// _Be sure to enable the `nalgebra_support` feature to get [Nalgebra] integration._
+///
+/// Any `Vector2<N>` can be used where `N: Into<u32> + nalgebra::Scalar`. This includes the primitive types `u32`, `u16` and `u8`.
+///
+/// ```rust
+/// # #[cfg(feature = "nalgebra_support")] {
+/// use nalgebra::Vector2;
+/// use embedded_graphics::unsignedcoord::UnsignedCoord;
+///
+/// assert_eq!(UnsignedCoord::from(Vector2::new(10u32, 20)), UnsignedCoord::new(10u32, 20));
+/// assert_eq!(UnsignedCoord::from(Vector2::new(10u16, 20)), UnsignedCoord::new(10u32, 20));
+/// assert_eq!(UnsignedCoord::from(Vector2::new(10u8, 20)), UnsignedCoord::new(10u32, 20));
+/// # }
+/// ```
+///
+/// `.into()` can also be used, but may require more type annotations:
+///
+/// ```rust
+/// # #[cfg(feature = "nalgebra_support")] {
+/// use nalgebra::Vector2;
+/// use embedded_graphics::unsignedcoord::UnsignedCoord;
+///
+/// let c: UnsignedCoord = Vector2::new(10u32, 20).into();
+///
+/// assert_eq!(c, UnsignedCoord::new(10u32, 20));
+/// # }
+/// ```
+///
+/// [`Vector2<N>`]: https://docs.rs/nalgebra/0.18.0/nalgebra/base/type.Vector2.html
+/// [`Vector2`]: https://docs.rs/nalgebra/0.18.0/nalgebra/base/type.Vector2.html
+/// [Nalgebra]: https://docs.rs/nalgebra
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub struct UnsignedCoord(pub UnsignedCoordPart, pub UnsignedCoordPart);
 

--- a/embedded-graphics/src/unsignedcoord.rs
+++ b/embedded-graphics/src/unsignedcoord.rs
@@ -2,8 +2,6 @@
 
 use crate::coord::Coord;
 
-type UnsignedCoordPart = u32;
-
 use core::ops::{Add, AddAssign, Index, Neg, Sub, SubAssign};
 
 /// 2D unsigned coordinate in screen space
@@ -68,11 +66,11 @@ use core::ops::{Add, AddAssign, Index, Neg, Sub, SubAssign};
 /// [`Vector2`]: https://docs.rs/nalgebra/0.18.0/nalgebra/base/type.Vector2.html
 /// [Nalgebra]: https://docs.rs/nalgebra
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
-pub struct UnsignedCoord(pub UnsignedCoordPart, pub UnsignedCoordPart);
+pub struct UnsignedCoord(pub u32, pub u32);
 
 impl UnsignedCoord {
     /// Create a new coordinate with X and Y values
-    pub fn new(x: UnsignedCoordPart, y: UnsignedCoordPart) -> Self {
+    pub fn new(x: u32, y: u32) -> Self {
         UnsignedCoord(x, y)
     }
 }
@@ -108,9 +106,9 @@ impl SubAssign for UnsignedCoord {
 }
 
 impl Index<usize> for UnsignedCoord {
-    type Output = UnsignedCoordPart;
+    type Output = u32;
 
-    fn index(&self, idx: usize) -> &UnsignedCoordPart {
+    fn index(&self, idx: usize) -> &u32 {
         match idx {
             0 => &self.0,
             1 => &self.1,
@@ -179,7 +177,7 @@ use nalgebra::{base::Scalar, Vector2};
 #[cfg(feature = "nalgebra_support")]
 impl<N> From<Vector2<N>> for UnsignedCoord
 where
-    N: Into<UnsignedCoordPart> + Scalar,
+    N: Into<u32> + Scalar,
 {
     fn from(other: Vector2<N>) -> Self {
         Self::new(other[0].into(), other[1].into())
@@ -189,7 +187,7 @@ where
 #[cfg(feature = "nalgebra_support")]
 impl<N> From<&Vector2<N>> for UnsignedCoord
 where
-    N: Into<UnsignedCoordPart> + Scalar,
+    N: Into<u32> + Scalar,
 {
     fn from(other: &Vector2<N>) -> Self {
         Self::new(other[0].into(), other[1].into())

--- a/embedded-graphics/src/unsignedcoord.rs
+++ b/embedded-graphics/src/unsignedcoord.rs
@@ -70,7 +70,7 @@ pub struct UnsignedCoord(pub u32, pub u32);
 
 impl UnsignedCoord {
     /// Create a new coordinate with X and Y values
-    pub fn new(x: u32, y: u32) -> Self {
+    pub const fn new(x: u32, y: u32) -> Self {
         UnsignedCoord(x, y)
     }
 }
@@ -112,7 +112,7 @@ impl Index<usize> for UnsignedCoord {
         match idx {
             0 => &self.0,
             1 => &self.1,
-            _ => panic!("Unreachable index {}", idx),
+            _ => panic!("index out of bounds: the len is 2 but the index is {}", idx),
         }
     }
 }


### PR DESCRIPTION
* Drastically improves docs for `Coord` and `UnsignedCoord` (even if they're changed a bunch later)
* Changes Nalgebra integration from a type alias (`type Coord = nalgebra::Vector2<i32>` to implementing `From<Vector2<N>>` for `Coord` and `UnsignedCoord`. This allows for less breakage between non-`nalgebra_support` and `nalgebra_support` modes but introduces a breaking change when converting between Nalgebra-using code and e-g
* Closes #153 