### PR TITLE
Test and fix README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ fn main() {
 ## Cargo Features
 
 * `nalgebra_support` - use the [Nalgebra](https://crates.io/crates/nalgebra) crate with `no_std`
-support to enable conversions from `nalgebra::Vector2` to [`Coord`] and [`UnsignedCoord`].
+support to enable conversions from `nalgebra::Vector2` to `Coord` and `UnsignedCoord`.
 * `bmp` - use the [TinyBMP](https://crates.io/crates/tinybmp) crate for BMP image support.
 * `tga` - use the [TinyTGA](https://crates.io/crates/tinytga) crate for TGA image support.
 

--- a/README.md
+++ b/README.md
@@ -38,19 +38,23 @@ use embedded_graphics::coord::Coord;
 use embedded_graphics::fonts::Font6x8;
 use embedded_graphics::prelude::*;
 use embedded_graphics::primitives::{Circle, Line};
+use embedded_graphics::pixelcolor::BinaryColor::On as C1;
+
+// Only used for examples - this would be replaced by the driver for your chosen display
+use embedded_graphics::mock_display::MockDisplay as Display;
 
 fn main() {
     // Create a display object to draw into
     // This will be whichever display driver you decide to use, like the SSD1306, SSD1351, etc
     let mut display = Display::new();
 
-    display.draw(Circle::new(Coord::new(64, 64), 64).with_stroke(Some(1u8)));
-    display.draw(Line::new(Coord::new(64, 64), Coord::new(0, 64)).with_stroke(Some(1u8)));
-    display.draw(Line::new(Coord::new(64, 64), Coord::new(80, 80)).with_stroke(Some(1u8)));
+    display.draw(Circle::new(Coord::new(64, 64), 64).stroke(Some(C1)));
+    display.draw(Line::new(Coord::new(64, 64), Coord::new(0, 64)).stroke(Some(C1)));
+    display.draw(Line::new(Coord::new(64, 64), Coord::new(80, 80)).stroke(Some(C1)));
 
     display.draw(
         Font6x8::render_str("Hello World!")
-            .with_stroke(Some(1u8))
+            .stroke(Some(C1))
             .translate(Coord::new(5, 50)),
     );
 }
@@ -60,18 +64,23 @@ Macros are also supported for text and primitives:
 
 ```rust
 use embedded_graphics::prelude::*;
-use embedded_graphics::{circle, icoord, line, rect, text_6x8, triangle};
+use embedded_graphics::{egcircle, icoord, egline, egrectangle, text_6x8, egtriangle};
+use embedded_graphics::pixelcolor::BinaryColor::On as C1;
+use embedded_graphics::pixelcolor::BinaryColor::Off as C0;
+
+// Only used for examples - this would be replaced by the driver for your chosen display
+use embedded_graphics::mock_display::MockDisplay as Display;
 
 fn main() {
     // Create a display object to draw into
     // This will be whichever display driver you decide to use, like the SSD1306, SSD1351, etc
     let mut display = Display::new();
 
-    display.draw(egcircle!((64, 64), 64, stroke = Some(1u8)));
-    display.draw(egline!((64, 64), (0, 64), stroke = Some(1u8)));
-    display.draw(egline!((64, 64), (80, 80), stroke = Some(1u8)));
-    display.draw(egrectangle!((64, 64), (80, 80), stroke = None, fill = Some(2u8)));
-    display.draw(text_6x8!("Hello world!", stroke = Some(1u8)).translate(icoord!(5, 50)));
+    display.draw(egcircle!((64, 64), 64, stroke = Some(C1)));
+    display.draw(egline!((64, 64), (0, 64), stroke = Some(C1)));
+    display.draw(egline!((64, 64), (80, 80), stroke = Some(C1)));
+    display.draw(egrectangle!((64, 64), (80, 80), stroke = None, fill = Some(C0)));
+    display.draw(text_6x8!("Hello world!", stroke = Some(C1)).translate(icoord!(5, 50)));
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ fn main() {
 
 ## Cargo Features
 
-* `nalgebra_support` - use the [Nalgebra](https://crates.io/crates/nalgebra) crate with `no_std` support to use as the `Coord` type. This should allow you to use most Nalgebra methods on objects rendered by embedded_graphics.
+* `nalgebra_support` - use the [Nalgebra](https://crates.io/crates/nalgebra) crate with `no_std`
+support to enable conversions from `nalgebra::Vector2` to [`Coord`] and [`UnsignedCoord`].
 * `bmp` - use the [TinyBMP](https://crates.io/crates/tinybmp) crate for BMP image support.
 * `tga` - use the [TinyTGA](https://crates.io/crates/tinytga) crate for TGA image support.
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ support to enable conversions from `nalgebra::Vector2` to `Coord` and `UnsignedC
 * [ssd1675](https://crates.io/crates/ssd1675): Rust driver for the Solomon Systech SSD1675 e-Paper display (EPD) controller
 * [st7735-lcd](https://crates.io/crates/st7735-lcd): Rust library for displays using the ST7735 driver
 
+There may be other drivers out there we don't know about yet. If you know of a driver to add to this list, please open [an issue](https://github.com/jamwaffles/embedded-graphics/issues/new)!
+
 ## Attribution
 
 All source font PNGs are taken from the excellent [Uzebox Wiki page](http://uzebox.org/wiki/Font_Bitmaps).

--- a/embedded-graphics/src/lib.rs
+++ b/embedded-graphics/src/lib.rs
@@ -174,6 +174,7 @@ pub mod mock_display;
 pub mod pixelcolor;
 pub mod prelude;
 pub mod primitives;
+mod readme;
 pub mod style;
 pub mod transform;
 pub mod unsignedcoord;

--- a/embedded-graphics/src/readme.rs
+++ b/embedded-graphics/src/readme.rs
@@ -1,0 +1,8 @@
+macro_rules! doc {
+    ($e:expr) => {
+        #[doc = $e]
+        extern {}
+    };
+}
+
+doc!(include_str!("../../README.md"));


### PR DESCRIPTION
This PR includes the contents of `README.md` as a doc comment, meaning the examples in the readme are tested in CI. It also fixes the woefully outdated and broken examples. Nalgebra description also updated.

Closes #159 

May thanks to @jonas-schievink for pointing out [this trick](https://github.com/jonas-schievink/crate-template/blob/134c43fff451b6e30ddccae43f20de4dc6256893/template/src/readme.rs).