### PR TITLE
Remove SizedDrawing trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
   );
   ```
 
+### Removed
+
+- **(breaking)** The `SizedDrawing` trait is removed.
+
 ## 0.6.0-alpha.2
 
 ### Changed

--- a/embedded-graphics/src/prelude.rs
+++ b/embedded-graphics/src/prelude.rs
@@ -7,4 +7,4 @@ pub use super::image::ImageFile;
 pub use super::pixelcolor::{raw::RawData, GrayColor, PixelColor, RgbColor};
 pub use super::style::{Style, WithStyle};
 pub use super::transform::Transform;
-pub use super::{Drawing, SizedDrawing};
+pub use super::Drawing;


### PR DESCRIPTION
This closes #123 by removing the `SizedDrawing` trait.

@jamwaffles: Could you open a new issue to discuss how this might be implemented in a better way?