### PR TITLE
simulator speedup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,6 @@ members = [
 [patch.crates-io]
 embedded-graphics = { path = "embedded-graphics" }
 embedded-graphics-simulator = { path = "simulator" }
+
+[profile.release]
+debug = true

--- a/simulator/Cargo.toml
+++ b/simulator/Cargo.toml
@@ -21,7 +21,7 @@ exclude = [
 circle-ci = { repository = "jamwaffles/embedded-graphics", branch = "master" }
 
 [dependencies]
-sdl2 = "0.32.2"
+sdl2 = { version = "0.32.2", features = ["gfx"]}
 
 [dependencies.embedded-graphics]
 version = "0.6.0-alpha.2"
@@ -29,3 +29,13 @@ features = [ "bmp", "tga" ]
 
 [dev-dependencies]
 chrono = "0.4.9"
+
+
+[features]
+default = []
+gfx = ["sdl2/gfx"]
+
+#todo cant get this to work
+# [[example]]
+# required-features = ["gfx"]
+# name = "input-handling"

--- a/simulator/examples/input-handling.rs
+++ b/simulator/examples/input-handling.rs
@@ -62,5 +62,7 @@ fn main() {
                 _ => {}
             }
         }
+
+        display.flush();
     }
 }

--- a/simulator/examples/input-handling.rs
+++ b/simulator/examples/input-handling.rs
@@ -39,15 +39,10 @@ fn main() {
         .fill_color(FOREGROUND_COLOR)
         .draw(&mut display);
 
-    loop {
-        let end = display.run_once();
-
-        if end {
-            break;
-        }
-
+    'running: loop {
         for event in display.get_input_events() {
             match event {
+                SimulatorEvent::Quit => break 'running,
                 SimulatorEvent::KeyDown { keycode, .. } => {
                     let delta = match keycode {
                         Keycode::Left => Point::new(-KEYBOARD_DELTA, 0),

--- a/simulator/examples/input-handling.rs
+++ b/simulator/examples/input-handling.rs
@@ -46,7 +46,9 @@ fn main() {
         .draw(&mut display);
 
     'running: loop {
-        for event in display.get_input_events() {
+        //hrm not much better, todo, be good at lifetimes.
+        let events: Vec<SimulatorEvent> = display.get_input_events().collect();
+        for event in events {
             match event {
                 SimulatorEvent::Quit => break 'running,
                 SimulatorEvent::KeyDown { keycode, .. } => {

--- a/simulator/examples/input-handling.rs
+++ b/simulator/examples/input-handling.rs
@@ -9,7 +9,7 @@ extern crate embedded_graphics_simulator;
 
 use embedded_graphics::pixelcolor::Rgb888;
 use embedded_graphics::prelude::*;
-use embedded_graphics::primitives::Circle;
+use embedded_graphics::primitives::{Circle, Rectangle};
 use embedded_graphics_simulator::{DisplayBuilder, RgbDisplay, SimulatorEvent};
 use sdl2::keyboard::Keycode;
 
@@ -33,6 +33,12 @@ fn main() {
         .title("Click to move circle")
         .size(800, 480)
         .build_rgb();
+
+    let position2 = Point::new(1, 1);
+    let position3 = Point::new(100, 100);
+    Rectangle::new(position2, position3)
+        .fill_color(FOREGROUND_COLOR)
+        .draw(&mut display);
 
     let mut position = Point::new(200, 200);
     Circle::new(position, 100)

--- a/simulator/src/display_builder.rs
+++ b/simulator/src/display_builder.rs
@@ -87,7 +87,10 @@ impl DisplayBuilder {
     /// Finish building the simulated binary display and open an SDL window to render it into
     pub fn build_binary(&self) -> BinaryDisplay {
         let window = self.build_window();
-        let pixels = PixelData::new(self.width, self.height);
+        let pixels = PixelData {
+            width: self.width,
+            height: self.height,
+        };
 
         BinaryDisplay {
             theme: self.theme.clone(),
@@ -99,7 +102,10 @@ impl DisplayBuilder {
     /// Finish building the simulated RGB display and open an SDL window to render it into
     pub fn build_rgb(&self) -> RgbDisplay {
         let window = self.build_window();
-        let pixels = PixelData::new(self.width, self.height);
+        let pixels = PixelData {
+            width: self.width,
+            height: self.height,
+        };
 
         RgbDisplay { pixels, window }
     }

--- a/simulator/src/lib.rs
+++ b/simulator/src/lib.rs
@@ -143,18 +143,8 @@ where
 
         let Point { x, y } = center;
 
-        let fill_color: Option<Rgb888> = if let Some(color) = style.fill_color {
-            let color: Rgb888 = self.theme.convert(color.into());
-            Some(color)
-        } else {
-            None
-        };
-        let stroke_color: Option<Rgb888> = if let Some(color) = style.stroke_color {
-            let color: Rgb888 = self.theme.convert(color.into());
-            Some(color)
-        } else {
-            None
-        };
+        let fill_color = style.fill_color.map(|c| self.theme.convert(c.into()));
+        let stroke_color = style.stroke_color.map(|c| self.theme.convert(c.into()));
 
         self.window
             .draw_circle(*x, *y, *radius, fill_color, stroke_color);
@@ -166,18 +156,8 @@ where
         let Point { x: x1, y: y1 } = start;
         let Point { x: x2, y: y2 } = end;
 
-        let fill_color: Option<Rgb888> = if let Some(color) = style.fill_color {
-            let color: Rgb888 = self.theme.convert(color.into());
-            Some(color)
-        } else {
-            None
-        };
-        let stroke_color: Option<Rgb888> = if let Some(color) = style.stroke_color {
-            let color: Rgb888 = self.theme.convert(color.into());
-            Some(color)
-        } else {
-            None
-        };
+        let fill_color = style.fill_color.map(|c| self.theme.convert(c.into()));
+        let stroke_color = style.stroke_color.map(|c| self.theme.convert(c.into()));
 
         self.window
             .draw_line(*x1, *y1, *x2, *y2, fill_color, stroke_color);
@@ -197,18 +177,8 @@ where
         let Point { x: x1, y: y1 } = top_left;
         let Point { x: x2, y: y2 } = bottom_right;
 
-        let fill_color: Option<Rgb888> = if let Some(color) = style.fill_color {
-            let color: Rgb888 = self.theme.convert(color.into());
-            Some(color)
-        } else {
-            None
-        };
-        let stroke_color: Option<Rgb888> = if let Some(color) = style.stroke_color {
-            let color: Rgb888 = self.theme.convert(color.into());
-            Some(color)
-        } else {
-            None
-        };
+        let fill_color = style.fill_color.map(|c| self.theme.convert(c.into()));
+        let stroke_color = style.stroke_color.map(|c| self.theme.convert(c.into()));
 
         self.window
             .draw_rectangle(*x1, *y1, *x2, *y2, fill_color, stroke_color);
@@ -266,17 +236,8 @@ where
 
         let Point { x, y } = center;
 
-        //really?
-        let fill_color: Option<Rgb888> = if let Some(color) = style.fill_color {
-            Some(color.into())
-        } else {
-            None
-        };
-        let stroke_color: Option<Rgb888> = if let Some(color) = style.stroke_color {
-            Some(color.into())
-        } else {
-            None
-        };
+        let fill_color = style.fill_color.map(|c| c.into());
+        let stroke_color = style.stroke_color.map(|c| c.into());
 
         self.window
             .draw_circle(*x, *y, *radius, fill_color, stroke_color);
@@ -288,17 +249,8 @@ where
         let Point { x: x1, y: y1 } = start;
         let Point { x: x2, y: y2 } = end;
 
-        //really?
-        let fill_color: Option<Rgb888> = if let Some(color) = style.fill_color {
-            Some(color.into())
-        } else {
-            None
-        };
-        let stroke_color: Option<Rgb888> = if let Some(color) = style.stroke_color {
-            Some(color.into())
-        } else {
-            None
-        };
+        let fill_color = style.fill_color.map(|c| c.into());
+        let stroke_color = style.stroke_color.map(|c| c.into());
 
         self.window
             .draw_line(*x1, *y1, *x2, *y2, fill_color, stroke_color);
@@ -318,17 +270,8 @@ where
         let Point { x: x1, y: y1 } = top_left;
         let Point { x: x2, y: y2 } = bottom_right;
 
-        //really?
-        let fill_color: Option<Rgb888> = if let Some(color) = style.fill_color {
-            Some(color.into())
-        } else {
-            None
-        };
-        let stroke_color: Option<Rgb888> = if let Some(color) = style.stroke_color {
-            Some(color.into())
-        } else {
-            None
-        };
+        let fill_color = style.fill_color.map(|c| c.into());
+        let stroke_color = style.stroke_color.map(|c| c.into());
 
         self.window
             .draw_rectangle(*x1, *y1, *x2, *y2, fill_color, stroke_color);

--- a/simulator/src/lib.rs
+++ b/simulator/src/lib.rs
@@ -83,7 +83,7 @@ use crate::window::Window;
 use embedded_graphics::drawable::Pixel;
 use embedded_graphics::geometry::Size;
 use embedded_graphics::pixelcolor::{BinaryColor, Rgb888, RgbColor};
-use embedded_graphics::primitives::circle::Circle;
+use embedded_graphics::primitives::{Circle, Line, Rectangle, Triangle};
 use embedded_graphics::DrawTarget;
 
 struct PixelData {
@@ -169,6 +169,18 @@ where
     fn draw_circle(&mut self, item: &Circle<C>) {
         // todo, theme?
         self.window.draw_circle(item);
+    }
+
+    fn draw_line(&mut self, _item: &Line<C>) {
+        unimplemented!();
+    }
+
+    fn draw_triangle(&mut self, _item: &Triangle<C>) {
+        unimplemented!();
+    }
+
+    fn draw_rectangle(&mut self, item: &Rectangle<C>) {
+        self.window.draw_rectangle(item);
     }
 
     fn size(&self) -> Size {

--- a/simulator/src/lib.rs
+++ b/simulator/src/lib.rs
@@ -148,6 +148,11 @@ impl RgbDisplay {
     pub fn get_input_events(&mut self) -> Vec<SimulatorEvent> {
         self.window.get_input_events()
     }
+
+    /// Update the display
+    pub fn flush(&mut self) {
+        self.window.present();
+    }
 }
 
 impl<C> DrawTarget<C> for RgbDisplay
@@ -159,16 +164,14 @@ where
         let x = coord[0] as usize;
         let y = coord[1] as usize;
         self.window.draw_pixel(x, y, color.into());
-        self.window.present();
-    }
-
-    fn size(&self) -> Size {
-        Size::new(self.pixels.width as u32, self.pixels.height as u32)
     }
 
     fn draw_circle(&mut self, item: &Circle<C>) {
         // todo, theme?
         self.window.draw_circle(item);
-        self.window.present();
+    }
+
+    fn size(&self) -> Size {
+        Size::new(self.pixels.width as u32, self.pixels.height as u32)
     }
 }

--- a/simulator/src/lib.rs
+++ b/simulator/src/lib.rs
@@ -109,7 +109,7 @@ impl BinaryDisplay {
     }
 
     /// Get a vector of detected input events
-    pub fn get_input_events(&mut self) -> Vec<SimulatorEvent> {
+    pub fn get_input_events(&mut self) -> impl Iterator<Item = SimulatorEvent> + '_ {
         self.window.get_input_events()
     }
 }
@@ -145,7 +145,7 @@ impl RgbDisplay {
     }
 
     /// Get a vector of detected input events
-    pub fn get_input_events(&mut self) -> Vec<SimulatorEvent> {
+    pub fn get_input_events(&mut self) -> impl Iterator<Item = SimulatorEvent> + '_ {
         self.window.get_input_events()
     }
 

--- a/simulator/src/window.rs
+++ b/simulator/src/window.rs
@@ -214,8 +214,8 @@ impl Window {
 
     /// Return an iterator of all captured SimulatorEvent
     pub fn get_input_events(&mut self) -> impl Iterator<Item = SimulatorEvent> + '_ {
-        let scale = self.scale.clone();
-        let pixel_spacing = self.pixel_spacing.clone();
+        let scale = self.scale;
+        let pixel_spacing = self.pixel_spacing;
         self.event_pump
             .poll_iter()
             .filter_map(move |event| match event {

--- a/simulator/src/window.rs
+++ b/simulator/src/window.rs
@@ -84,11 +84,10 @@ impl Window {
         let window = video_subsystem
             .window(title, window_width as u32, window_height as u32)
             .position_centered()
-            .opengl()
             .build()
             .unwrap();
 
-        let canvas = window.into_canvas().build().unwrap();
+        let canvas = window.into_canvas().software().build().unwrap();
         let event_pump = sdl_context.event_pump().unwrap();
 
         Self {

--- a/simulator/src/window.rs
+++ b/simulator/src/window.rs
@@ -1,7 +1,6 @@
 use embedded_graphics::geometry::Point;
-
 use embedded_graphics::pixelcolor::{Rgb888, RgbColor};
-use embedded_graphics::primitives::Circle;
+use embedded_graphics::primitives::{Circle, Line, Rectangle, Triangle};
 
 use sdl2::event::Event;
 //todo any reason to feature gate gfx?
@@ -140,7 +139,7 @@ impl Window {
     //     unimplemented!();
     // }
 
-    pub fn draw_circle<C>(&mut self, circle: &Circle<C>)
+    pub fn draw_circle<C>(&mut self, item: &Circle<C>)
     where
         C: RgbColor + Into<Rgb888>,
     {
@@ -148,7 +147,7 @@ impl Window {
             center,
             radius,
             style,
-        } = circle;
+        } = item;
 
         let Point { x, y } = center;
 
@@ -167,6 +166,45 @@ impl Window {
             let _ = self
                 .canvas
                 .circle(*x as i16, *y as i16, *radius as i16, color);
+        }
+    }
+
+    pub fn draw_line<C>(&mut self, _item: &Line<C>)
+    where
+        C: RgbColor + Into<Rgb888>,
+    {
+        unimplemented!();
+    }
+
+    pub fn draw_triangle<C>(&mut self, _item: &Triangle<C>)
+    where
+        C: RgbColor + Into<Rgb888>,
+    {
+        unimplemented!();
+    }
+
+    pub fn draw_rectangle<C>(&mut self, item: &Rectangle<C>)
+    where
+        C: RgbColor + Into<Rgb888>,
+    {
+        let Rectangle {
+            top_left,
+            bottom_right,
+            style,
+        } = item;
+
+        let Point { x: x1, y: y1 } = top_left;
+        let Point { x: x2, y: y2 } = bottom_right;
+
+        //todo, fill or stroke?
+        //todo, i16 from i32...
+        if let Some(fill) = style.fill_color {
+            //neccesary?
+            let color = Color::RGB(fill.r(), fill.g(), fill.b());
+
+            let _ = self
+                .canvas
+                .rectangle(*x1 as i16, *y1 as i16, *x2 as i16, *y2 as i16, color);
         }
     }
 

--- a/simulator/src/window.rs
+++ b/simulator/src/window.rs
@@ -1,6 +1,6 @@
 use embedded_graphics::geometry::Point;
 use embedded_graphics::pixelcolor::{Rgb888, RgbColor};
-use embedded_graphics::primitives::{Circle, Line, Rectangle, Triangle};
+use embedded_graphics::primitives::Triangle;
 
 use sdl2::event::Event;
 //todo any reason to feature gate gfx?
@@ -136,41 +136,52 @@ impl Window {
     //     unimplemented!();
     // }
 
-    pub fn draw_circle<C>(&mut self, item: &Circle<C>)
-    where
-        C: RgbColor + Into<Rgb888>,
-    {
-        let Circle {
-            center,
-            radius,
-            style,
-        } = item;
-
-        let Point { x, y } = center;
-
-        //todo, i16 from i32...
-        if let Some(fill) = style.fill_color {
-            //neccesary?
-            let color = Color::RGB(fill.r(), fill.g(), fill.b());
+    pub fn draw_circle(
+        &mut self,
+        x: i32,
+        y: i32,
+        radius: u32,
+        fill_color: Option<Rgb888>,
+        stroke_color: Option<Rgb888>,
+    ) {
+        // todo, i16 from i32...
+        if let Some(color) = fill_color {
+            let color = Color::RGB(color.r(), color.g(), color.b());
 
             let _ = self
                 .canvas
-                .filled_circle(*x as i16, *y as i16, *radius as i16, color);
-        } else if let Some(stroke) = style.stroke_color {
-            //how to stroke? style.stroke_width
-            let color = Color::RGB(stroke.r(), stroke.g(), stroke.b());
+                .filled_circle(x as i16, y as i16, radius as i16, color);
+        } else if let Some(color) = stroke_color {
+            // how to stroke? style.stroke_width
+            let color = Color::RGB(color.r(), color.g(), color.b());
 
-            let _ = self
-                .canvas
-                .circle(*x as i16, *y as i16, *radius as i16, color);
+            let _ = self.canvas.circle(x as i16, y as i16, radius as i16, color);
         }
     }
 
-    pub fn draw_line<C>(&mut self, _item: &Line<C>)
-    where
-        C: RgbColor + Into<Rgb888>,
-    {
-        unimplemented!();
+    pub fn draw_line(
+        &mut self,
+        x1: i32,
+        y1: i32,
+        x2: i32,
+        y2: i32,
+        fill_color: Option<Rgb888>,
+        _stroke_color: Option<Rgb888>,
+    ) {
+        if let Some(color) = fill_color {
+            let color = Color::RGB(color.r(), color.g(), color.b());
+
+            //any performance reason to use vline and hline?
+            if x1 == x2 {
+                let _ = self.canvas.vline(x1 as i16, y1 as i16, y2 as i16, color);
+            } else if y1 == y2 {
+                let _ = self.canvas.hline(x1 as i16, x2 as i16, y1 as i16, color);
+            } else {
+                let _ = self
+                    .canvas
+                    .rectangle(x1 as i16, y1 as i16, x2 as i16, y2 as i16, color);
+            }
+        }
     }
 
     pub fn draw_triangle<C>(&mut self, _item: &Triangle<C>)
@@ -180,28 +191,24 @@ impl Window {
         unimplemented!();
     }
 
-    pub fn draw_rectangle<C>(&mut self, item: &Rectangle<C>)
-    where
-        C: RgbColor + Into<Rgb888>,
-    {
-        let Rectangle {
-            top_left,
-            bottom_right,
-            style,
-        } = item;
-
-        let Point { x: x1, y: y1 } = top_left;
-        let Point { x: x2, y: y2 } = bottom_right;
-
+    pub fn draw_rectangle(
+        &mut self,
+        x1: i32,
+        y1: i32,
+        x2: i32,
+        y2: i32,
+        fill_color: Option<Rgb888>,
+        _stroke_color: Option<Rgb888>,
+    ) {
         //todo, fill or stroke?
         //todo, i16 from i32...
-        if let Some(fill) = style.fill_color {
-            //neccesary?
-            let color = Color::RGB(fill.r(), fill.g(), fill.b());
+
+        if let Some(color) = fill_color {
+            let color = Color::RGB(color.r(), color.g(), color.b());
 
             let _ = self
                 .canvas
-                .rectangle(*x1 as i16, *y1 as i16, *x2 as i16, *y2 as i16, color);
+                .rectangle(x1 as i16, y1 as i16, x2 as i16, y2 as i16, color);
         }
     }
 


### PR DESCRIPTION
Ive been meaning to dig into why the simulator is really slow, and in the process realized presumably this is probably what that extended graphics pr was partially addressing. Hope Im not stepping on anyones toes.

'works' and fast! But doesn't properly clean the screen--After a few moves there a multiple circles hanging around.
Lots of todos, too

Any pointers appreciated.


- [ ] Check that you've added passing tests and documentation
- [ ] Add a simulator example(s) where applicable
- [ ] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc)
- [ ] Run `rustfmt` on the project
- [ ] Run `./build.sh` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.