### PR TITLE
Events as iterator instead of vec, move quit to an event instead of bool

### DIFF
--- a/simulator/examples/analog-clock.rs
+++ b/simulator/examples/analog-clock.rs
@@ -13,7 +13,7 @@ use embedded_graphics::fonts::Font12x16;
 use embedded_graphics::pixelcolor::BinaryColor;
 use embedded_graphics::prelude::*;
 use embedded_graphics::primitives::{Circle, Line, Rectangle};
-use embedded_graphics_simulator::{SimulatorDisplay, WindowBuilder};
+use embedded_graphics_simulator::{SimulatorDisplay, SimulatorEvent, WindowBuilder};
 use std::thread;
 use std::time::Duration;
 
@@ -164,13 +164,13 @@ fn main() {
             .fill_color(Some(BinaryColor::On))
             .draw(&mut display);
 
-        window.update(&display);
+        'running: loop {
+            window.update(&display);
 
-        let end = window.handle_events();
-        if end {
-            break;
+            if window.events().any(|e| e == SimulatorEvent::Quit) {
+                break 'running;
+            }
+            thread::sleep(Duration::from_millis(50));
         }
-
-        thread::sleep(Duration::from_millis(50));
     }
 }

--- a/simulator/examples/input-handling.rs
+++ b/simulator/examples/input-handling.rs
@@ -39,16 +39,12 @@ fn main() {
         .fill_color(FOREGROUND_COLOR)
         .draw(&mut display);
 
-    loop {
+    'running: loop {
         window.update(&display);
 
-        let end = window.handle_events();
-        if end {
-            break;
-        }
-
-        for event in window.get_input_events() {
+        for event in window.events() {
             match event {
+                SimulatorEvent::Quit => break 'running,
                 SimulatorEvent::KeyDown { keycode, .. } => {
                     let delta = match keycode {
                         Keycode::Left => Point::new(-KEYBOARD_DELTA, 0),

--- a/simulator/src/lib.rs
+++ b/simulator/src/lib.rs
@@ -33,42 +33,48 @@
 //! ## Simulate a 128x64 SSD1306 OLED
 //!
 //! ```rust,no_run
-//! use embedded_graphics::prelude::*;
-//! use embedded_graphics::{egcircle, egline, text_6x8};
-//! use embedded_graphics::pixelcolor::BinaryColor;
-//! use embedded_graphics_simulator::{SimulatorDisplay, BinaryColorTheme, SimulatorEvent, WindowBuilder};
-//! use std::thread;
-//! use std::time::Duration;
+//!use embedded_graphics::pixelcolor::BinaryColor;
+//!use embedded_graphics::prelude::*;
+//!use embedded_graphics::{egcircle, egline, text_6x8};
+//!use embedded_graphics_simulator::{
+//!    BinaryColorTheme, SimulatorDisplay, SimulatorEvent, WindowBuilder,
+//!};
+//!use std::thread;
+//!use std::time::Duration;
 //!
-//! fn main() {
-//!     let mut display = SimulatorDisplay::new(Size::new(128, 64));
-//!     let mut window = WindowBuilder::new(&display)
-//!         .theme(BinaryColorTheme::OledBlue)
-//!         .build();
+//!fn main() {
+//!    let mut display = SimulatorDisplay::new(Size::new(128, 64));
+//!    let mut window = WindowBuilder::new(&display)
+//!        .theme(BinaryColorTheme::OledBlue)
+//!        .build();
 //!
-//!     text_6x8!("Hello World!").draw(&mut display);
+//!    text_6x8!("Hello World!").draw(&mut display);
 //!
-//!     egcircle!((96, 32), 31, stroke_color = Some(BinaryColor::On)).draw(&mut display);
+//!    egcircle!((96, 32), 31, stroke_color = Some(BinaryColor::On)).draw(&mut display);
 //!
-//!     egline!((32, 32), (1, 32), stroke_color = Some(BinaryColor::On)).translate(Point::new(64, 0)).draw(&mut display);
-//!     egline!((32, 32), (40, 40), stroke_color = Some(BinaryColor::On)) .translate(Point::new(64, 0)).draw(&mut display);
+//!    egline!((32, 32), (1, 32), stroke_color = Some(BinaryColor::On))
+//!        .translate(Point::new(64, 0))
+//!        .draw(&mut display);
+//!    egline!((32, 32), (40, 40), stroke_color = Some(BinaryColor::On))
+//!        .translate(Point::new(64, 0))
+//!        .draw(&mut display);
 //!
-//!     loop {
-//!         window.update(&display);
+//!    'running: loop {
+//!        window.update(&display);
 //!
-//!         let end = window.handle_events();
-//!         if end {
-//!             break;
-//!         }
+//!        for event in window.events() {
+//!            match event {
+//!                SimulatorEvent::MouseButtonUp { point, .. } => {
+//!                    println!("Click event at ({}, {})", point.x, point.y);
+//!                }
+//!                SimulatorEvent::Quit => break 'running,
+//!                _ => {}
+//!            }
 //!
-//!         for event in window.get_input_events() {
-//!             if let SimulatorEvent::MouseButtonUp { point, ..} = event {
-//!                 println!("Click event at ({}, {})", point.x, point.y);
-//!             }
-//!         }
-//!         thread::sleep(Duration::from_millis(200));
-//!     }
-//! }
+//!            thread::sleep(Duration::from_millis(200));
+//!        }
+//!    }
+//!}
 //! ```
 
 #![deny(missing_docs)]

--- a/simulator/src/lib.rs
+++ b/simulator/src/lib.rs
@@ -33,48 +33,48 @@
 //! ## Simulate a 128x64 SSD1306 OLED
 //!
 //! ```rust,no_run
-//!use embedded_graphics::pixelcolor::BinaryColor;
-//!use embedded_graphics::prelude::*;
-//!use embedded_graphics::{egcircle, egline, text_6x8};
-//!use embedded_graphics_simulator::{
-//!    BinaryColorTheme, SimulatorDisplay, SimulatorEvent, WindowBuilder,
-//!};
-//!use std::thread;
-//!use std::time::Duration;
+//! use embedded_graphics::pixelcolor::BinaryColor;
+//! use embedded_graphics::prelude::*;
+//! use embedded_graphics::{egcircle, egline, text_6x8};
+//! use embedded_graphics_simulator::{
+//!     BinaryColorTheme, SimulatorDisplay, SimulatorEvent, WindowBuilder,
+//! };
+//! use std::thread;
+//! use std::time::Duration;
 //!
-//!fn main() {
-//!    let mut display = SimulatorDisplay::new(Size::new(128, 64));
-//!    let mut window = WindowBuilder::new(&display)
-//!        .theme(BinaryColorTheme::OledBlue)
-//!        .build();
+//! fn main() {
+//!     let mut display = SimulatorDisplay::new(Size::new(128, 64));
+//!     let mut window = WindowBuilder::new(&display)
+//!         .theme(BinaryColorTheme::OledBlue)
+//!         .build();
 //!
-//!    text_6x8!("Hello World!").draw(&mut display);
+//!     text_6x8!("Hello World!").draw(&mut display);
 //!
-//!    egcircle!((96, 32), 31, stroke_color = Some(BinaryColor::On)).draw(&mut display);
+//!     egcircle!((96, 32), 31, stroke_color = Some(BinaryColor::On)).draw(&mut display);
 //!
-//!    egline!((32, 32), (1, 32), stroke_color = Some(BinaryColor::On))
-//!        .translate(Point::new(64, 0))
-//!        .draw(&mut display);
-//!    egline!((32, 32), (40, 40), stroke_color = Some(BinaryColor::On))
-//!        .translate(Point::new(64, 0))
-//!        .draw(&mut display);
+//!     egline!((32, 32), (1, 32), stroke_color = Some(BinaryColor::On))
+//!         .translate(Point::new(64, 0))
+//!         .draw(&mut display);
+//!     egline!((32, 32), (40, 40), stroke_color = Some(BinaryColor::On))
+//!         .translate(Point::new(64, 0))
+//!         .draw(&mut display);
 //!
-//!    'running: loop {
-//!        window.update(&display);
+//!     'running: loop {
+//!         window.update(&display);
 //!
-//!        for event in window.events() {
-//!            match event {
-//!                SimulatorEvent::MouseButtonUp { point, .. } => {
-//!                    println!("Click event at ({}, {})", point.x, point.y);
-//!                }
-//!                SimulatorEvent::Quit => break 'running,
-//!                _ => {}
-//!            }
+//!         for event in window.events() {
+//!             match event {
+//!                 SimulatorEvent::MouseButtonUp { point, .. } => {
+//!                     println!("Click event at ({}, {})", point.x, point.y);
+//!                 }
+//!                 SimulatorEvent::Quit => break 'running,
+//!                 _ => {}
+//!             }
 //!
-//!            thread::sleep(Duration::from_millis(200));
-//!        }
-//!    }
-//!}
+//!             thread::sleep(Duration::from_millis(200));
+//!         }
+//!     }
+//! }
 //! ```
 
 #![deny(missing_docs)]

--- a/simulator/src/window.rs
+++ b/simulator/src/window.rs
@@ -60,6 +60,7 @@ pub struct Window {
     scale: usize,
     pixel_spacing: usize,
     theme: BinaryColorTheme,
+
     canvas: render::Canvas<sdl2::video::Window>,
     event_pump: sdl2::EventPump,
 }

--- a/simulator/src/window.rs
+++ b/simulator/src/window.rs
@@ -51,6 +51,8 @@ pub enum SimulatorEvent {
         /// The directionality of the scroll (normal or flipped)
         direction: MouseWheelDirection,
     },
+    /// An exit event
+    Quit,
 }
 
 /// Simulator window
@@ -58,10 +60,8 @@ pub struct Window {
     scale: usize,
     pixel_spacing: usize,
     theme: BinaryColorTheme,
-
     canvas: render::Canvas<sdl2::video::Window>,
     event_pump: sdl2::EventPump,
-    input_events: Vec<SimulatorEvent>,
 }
 
 impl Window {
@@ -96,7 +96,6 @@ impl Window {
             theme,
             canvas,
             event_pump,
-            input_events: vec![],
         }
     }
 
@@ -154,27 +153,27 @@ impl Window {
     {
         self.update(&display);
 
-        loop {
-            let end = self.handle_events();
-            if end {
-                break;
+        'running: loop {
+            if self.events().any(|e| e == SimulatorEvent::Quit) {
+                break 'running;
             }
-
             thread::sleep(Duration::from_millis(20));
         }
     }
 
     /// Handle events
-    pub fn handle_events(&mut self) -> bool {
-        for event in self.event_pump.poll_iter() {
-            match event {
+    /// Return an iterator of all captured SimulatorEvent
+    pub fn events(&mut self) -> impl Iterator<Item = SimulatorEvent> + '_ {
+        let scale = self.scale;
+        let pixel_spacing = self.pixel_spacing;
+        self.event_pump
+            .poll_iter()
+            .filter_map(move |event| match event {
                 Event::Quit { .. }
                 | Event::KeyDown {
                     keycode: Some(Keycode::Escape),
                     ..
-                } => {
-                    return true;
-                }
+                } => Some(SimulatorEvent::Quit),
                 Event::KeyDown {
                     keycode,
                     keymod,
@@ -182,11 +181,13 @@ impl Window {
                     ..
                 } => {
                     if let Some(valid_keycode) = keycode {
-                        self.input_events.push(SimulatorEvent::KeyDown {
+                        Some(SimulatorEvent::KeyDown {
                             keycode: valid_keycode,
                             keymod,
                             repeat,
-                        });
+                        })
+                    } else {
+                        None
                     }
                 }
                 Event::KeyUp {
@@ -196,47 +197,35 @@ impl Window {
                     ..
                 } => {
                     if let Some(valid_keycode) = keycode {
-                        self.input_events.push(SimulatorEvent::KeyUp {
+                        Some(SimulatorEvent::KeyUp {
                             keycode: valid_keycode,
                             keymod,
                             repeat,
-                        });
+                        })
+                    } else {
+                        None
                     }
                 }
                 Event::MouseButtonUp {
                     x, y, mouse_btn, ..
                 } => {
-                    let point = map_input_to_point((x, y), self.scale, self.pixel_spacing);
-                    self.input_events
-                        .push(SimulatorEvent::MouseButtonUp { point, mouse_btn });
+                    let point = map_input_to_point((x, y), scale, pixel_spacing);
+                    Some(SimulatorEvent::MouseButtonUp { point, mouse_btn })
                 }
                 Event::MouseButtonDown {
                     x, y, mouse_btn, ..
                 } => {
-                    let point = map_input_to_point((x, y), self.scale, self.pixel_spacing);
-                    self.input_events
-                        .push(SimulatorEvent::MouseButtonDown { point, mouse_btn });
+                    let point = map_input_to_point((x, y), scale, pixel_spacing);
+                    Some(SimulatorEvent::MouseButtonDown { point, mouse_btn })
                 }
                 Event::MouseWheel {
                     x, y, direction, ..
-                } => {
-                    self.input_events.push(SimulatorEvent::MouseWheel {
-                        scroll_delta: Point::new(x, y),
-                        direction,
-                    });
-                }
-                _ => {}
-            }
-        }
-
-        false
-    }
-
-    /// Return all captured input events
-    pub fn get_input_events(&mut self) -> Vec<SimulatorEvent> {
-        let input_events = self.input_events.clone();
-        self.input_events.clear();
-        input_events
+                } => Some(SimulatorEvent::MouseWheel {
+                    scroll_delta: Point::new(x, y),
+                    direction,
+                }),
+                _ => None,
+            })
     }
 }
 


### PR DESCRIPTION
Perhaps moving the quit bool into an event survives from #190?

## checklist
- [x] Check that you've added passing tests and documentation
- [x] Add a simulator example(s) where applicable *Not applicable* 
- [x] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) *Not applicable* 
- [x] Run `rustfmt` on the project
- [x] Run `./build.sh` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

