### PR TITLE
Change type of Style::stroke_width to u32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 
 - **(breaking)** The simulator API changed.
 
+- **(breaking)** The type of `Style::stroke_width` changed from `u8` to `u32`.
+
 ### Removed
 
 - **(breaking)** The `SizedDrawing` trait is removed.

--- a/embedded-graphics/src/fonts/font_builder.rs
+++ b/embedded-graphics/src/fonts/font_builder.rs
@@ -113,7 +113,7 @@ where
         self
     }
 
-    fn stroke_width(self, _width: u8) -> Self {
+    fn stroke_width(self, _width: u32) -> Self {
         // Noop
 
         self

--- a/embedded-graphics/src/primitives/circle.rs
+++ b/embedded-graphics/src/primitives/circle.rs
@@ -104,7 +104,7 @@ where
         self
     }
 
-    fn stroke_width(mut self, width: u8) -> Self {
+    fn stroke_width(mut self, width: u32) -> Self {
         self.style.stroke_width = width;
 
         self
@@ -168,7 +168,7 @@ where
             return None;
         }
 
-        let radius = self.radius as i32 - i32::from(self.style.stroke_width) + 1;
+        let radius = self.radius as i32 - self.style.stroke_width_i32() + 1;
         let outer_radius = self.radius as i32;
 
         let radius_sq = radius * radius;

--- a/embedded-graphics/src/primitives/line.rs
+++ b/embedded-graphics/src/primitives/line.rs
@@ -98,7 +98,7 @@ where
         self
     }
 
-    fn stroke_width(mut self, width: u8) -> Self {
+    fn stroke_width(mut self, width: u32) -> Self {
         self.style.stroke_width = width;
 
         self

--- a/embedded-graphics/src/primitives/rectangle.rs
+++ b/embedded-graphics/src/primitives/rectangle.rs
@@ -100,7 +100,7 @@ where
         self
     }
 
-    fn stroke_width(mut self, width: u8) -> Self {
+    fn stroke_width(mut self, width: u32) -> Self {
         self.style.stroke_width = width;
 
         self
@@ -174,7 +174,7 @@ where
                 break None;
             }
 
-            let border_width = i32::from(self.style.stroke_width);
+            let border_width = self.style.stroke_width_i32();
             let tl = self.top_left;
             let br = self.bottom_right;
 

--- a/embedded-graphics/src/primitives/triangle.rs
+++ b/embedded-graphics/src/primitives/triangle.rs
@@ -110,7 +110,7 @@ where
         self
     }
 
-    fn stroke_width(mut self, width: u8) -> Self {
+    fn stroke_width(mut self, width: u32) -> Self {
         self.style.stroke_width = width;
 
         self

--- a/embedded-graphics/src/style.rs
+++ b/embedded-graphics/src/style.rs
@@ -1,6 +1,7 @@
 //! Styling struct to customise the look of objects.
 
 use crate::pixelcolor::PixelColor;
+use core::convert::TryFrom;
 
 /// Style properties for an object
 #[derive(Debug, Copy, Clone)]
@@ -18,7 +19,7 @@ pub struct Style<P: PixelColor> {
     /// Stroke width
     ///
     /// Set the stroke width for an object. Has no effect on fonts.
-    pub stroke_width: u8,
+    pub stroke_width: u32,
 }
 
 impl<P> Style<P>
@@ -31,6 +32,14 @@ where
             stroke_color: Some(stroke_color),
             ..Style::default()
         }
+    }
+
+    /// Returns the stroke width as an `i32`.
+    ///
+    /// If the stroke width is too large to fit into an `i32` the maximum value
+    /// for an `i32` is returned instead.
+    pub(crate) fn stroke_width_i32(&self) -> i32 {
+        i32::try_from(self.stroke_width).unwrap_or(i32::max_value())
     }
 }
 
@@ -63,10 +72,32 @@ where
     /// Set the stroke width for the object
     ///
     /// A stroke with a width of zero will not be rendered
-    fn stroke_width(self, width: u8) -> Self;
+    fn stroke_width(self, width: u32) -> Self;
 
     /// Set the fill property of the object's style
     ///
     /// This can be a noop
     fn fill_color(self, color: Option<C>) -> Self;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pixelcolor::BinaryColor;
+
+    #[test]
+    fn stroke_width_i32() {
+        let mut style: Style<BinaryColor> = Style::default();
+        style.stroke_width = 1;
+        assert_eq!(style.stroke_width_i32(), 1);
+
+        style.stroke_width = 0x7FFFFFFF;
+        assert_eq!(style.stroke_width_i32(), 0x7FFFFFFF);
+
+        style.stroke_width = 0x80000000;
+        assert_eq!(style.stroke_width_i32(), 0x7FFFFFFF);
+
+        style.stroke_width = 0xFFFFFFFF;
+        assert_eq!(style.stroke_width_i32(), 0x7FFFFFFF);
+    }
 }


### PR DESCRIPTION
Hi! Thank you for helping out with Embedded Graphics development! Please:

- [x] Check that you've added passing tests and documentation
- [x] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc)
- [x] Run `rustfmt` on the project
- [x] Run `./build.sh` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

This PR changes the type of `Style::stroke_width` to `u32`.
Stroke widths that can't be represented as an `i32` are clipped to `i32::max_value()` in some drawing functions. This should cause less problems than wrapping to negative values.

Closes #195