### PR TITLE
List ST7920 driver in docs

### DIFF
--- a/embedded-graphics/README.md
+++ b/embedded-graphics/README.md
@@ -118,6 +118,7 @@ fn main() {
 - [ssd1351](https://crates.io/crates/ssd1351): SSD1351 driver
 - [ssd1675](https://crates.io/crates/ssd1675): Rust driver for the Solomon Systech SSD1675 e-Paper display (EPD) controller
 - [st7735-lcd](https://crates.io/crates/st7735-lcd): Rust library for displays using the ST7735 driver
+- [st7920](https://crates.io/crates/st7920): ST7920 LCD driver in Rust
 
 There may be other drivers out there we don't know about yet. If you know of a driver to add to this list, please open [an issue](https://github.com/jamwaffles/embedded-graphics/issues/new)!
 

--- a/embedded-graphics/src/lib.rs
+++ b/embedded-graphics/src/lib.rs
@@ -41,6 +41,7 @@
 //! * [ssd1351](https://crates.io/crates/ssd1351): SSD1351 driver
 //! * [ssd1675](https://crates.io/crates/ssd1675): Rust driver for the Solomon Systech SSD1675 e-Paper display (EPD) controller
 //! * [st7735-lcd](https://crates.io/crates/st7735-lcd): Rust library for displays using the ST7735 driver
+//! * [st7920](https://crates.io/crates/st7920): ST7920 LCD driver in Rust
 //!
 //! # Simulator
 //!


### PR DESCRIPTION
Added a mention of a new driver for ST7920-based LCD displays.

Closes #199 