### PR TITLE
Build docs in project root

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -4,10 +4,12 @@ set -e
 
 cargo fmt --all -- --check
 cargo test --release
+
 pushd embedded-graphics
 cargo test --release --all-features
-cargo doc --all-features
 popd
+
+cargo doc --all-features
 cargo bench --no-run
 
 linkchecker target/doc/embedded_graphics/index.html

--- a/build.sh
+++ b/build.sh
@@ -4,14 +4,10 @@ set -e
 
 cargo fmt --all -- --check
 cargo test --release
-
-pushd embedded-graphics
 cargo test --release --all-features
-popd
-
-cargo doc --all-features
 cargo bench --no-run
 
+cargo doc --all-features
 linkchecker target/doc/embedded_graphics/index.html
 linkchecker target/doc/tinybmp/index.html
 linkchecker target/doc/tinytga/index.html


### PR DESCRIPTION
Hi! Thank you for helping out with Embedded Graphics development! Please:

- [x] Check that you've added passing tests and documentation (N/A)
- [x] Add a simulator example(s) where applicable (N/A)
- [x] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) (N/A)
- [x] Run `rustfmt` on the project (N/A)
- [x] Run `./build.sh` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

A small change introduced in #187 meant that only docs in the e-g project were built, breaking the linkchecker. Not sure why we've only seen it now but it might be a caching thing. This PR builds docs in the workspace root, making `linkchecker` work again.
