### PR TITLE
Fix circle rendering (again :()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 
 ### Fixed
 
-- #143 Circles with no stroke are now drawn correctly
+- #143, #209 Circles with no stroke are now drawn correctly
 
 - #192 Performance of drawing in the simulator is increased.
 

--- a/embedded-graphics/src/primitives/circle.rs
+++ b/embedded-graphics/src/primitives/circle.rs
@@ -137,7 +137,8 @@ where
     // https://stackoverflow.com/a/1237519/383609
     // https://stackoverflow.com/questions/1201200/fast-algorithm-for-drawing-filled-circles#comment80182898_1237519
     fn next(&mut self) -> Option<Self::Item> {
-        // If border or stroke colour is `None`, treat entire object as transparent and exit early
+        // If the fill and stroke colors are `None`, treat entire object as transparent and exit
+        // early.
         if self.style.stroke_color.is_none() && self.style.fill_color.is_none() {
             return None;
         }
@@ -151,15 +152,9 @@ where
             let is_fill = len <= self.outer_threshold;
 
             let item = if is_stroke && self.style.stroke_color.is_some() {
-                Some(Pixel(
-                    self.center + t,
-                    self.style.stroke_color.expect("Border color not defined"),
-                ))
+                Some(Pixel(self.center + t, self.style.stroke_color.unwrap()))
             } else if is_fill && self.style.fill_color.is_some() {
-                Some(Pixel(
-                    self.center + t,
-                    self.style.fill_color.expect("Fill color not defined"),
-                ))
+                Some(Pixel(self.center + t, self.style.fill_color.unwrap()))
             } else {
                 None
             };

--- a/embedded-graphics/src/primitives/circle.rs
+++ b/embedded-graphics/src/primitives/circle.rs
@@ -223,20 +223,31 @@ mod tests {
     /// Test for issue #143
     #[test]
     fn issue_143_stroke_and_fill() {
-        let circle_no_stroke: Styled<Circle, PrimitiveStyle<BinaryColor>> =
-            Circle::new(Point::new(10, 16), 3)
-                .into_styled(PrimitiveStyle::with_fill(BinaryColor::On));
+        for size in 0..10 {
+            let circle_no_stroke: Styled<Circle, PrimitiveStyle<BinaryColor>> =
+                Circle::new(Point::new(10, 16), size)
+                    .into_styled(PrimitiveStyle::with_fill(BinaryColor::On));
 
-        let style = PrimitiveStyle {
-            fill_color: Some(BinaryColor::On),
-            stroke_color: Some(BinaryColor::On),
-            stroke_width: 1,
-        };
-        let circle_stroke: Styled<Circle, PrimitiveStyle<BinaryColor>> =
-            Circle::new(Point::new(10, 16), 3).into_styled(style);
+            let style = PrimitiveStyle {
+                fill_color: Some(BinaryColor::On),
+                stroke_color: Some(BinaryColor::On),
+                stroke_width: 1,
+            };
+            let circle_stroke: Styled<Circle, PrimitiveStyle<BinaryColor>> =
+                Circle::new(Point::new(10, 16), size).into_styled(style);
 
-        assert_eq!(circle_stroke.size(), circle_no_stroke.size());
-        assert!(circle_no_stroke.into_iter().eq(circle_stroke.into_iter()));
+            assert_eq!(
+                circle_stroke.size(),
+                circle_no_stroke.size(),
+                "Filled and unfilled circle iters are unequal for radius {}",
+                size
+            );
+            assert!(
+                circle_no_stroke.into_iter().eq(circle_stroke.into_iter()),
+                "Filled and unfilled circle iters are unequal for radius {}",
+                size
+            );
+        }
     }
 
     #[test]

--- a/embedded-graphics/src/primitives/circle.rs
+++ b/embedded-graphics/src/primitives/circle.rs
@@ -146,9 +146,9 @@ where
             let t = self.p;
             let len = t.x.pow(2) + t.y.pow(2);
 
-            let is_stroke = len > self.inner_threshold && len < self.outer_threshold;
+            let is_stroke = len > self.inner_threshold && len <= self.outer_threshold;
 
-            let is_fill = len < self.outer_threshold;
+            let is_fill = len <= self.outer_threshold;
 
             let item = if is_stroke && self.style.stroke_color.is_some() {
                 Some(Pixel(

--- a/embedded-graphics/src/primitives/circle.rs
+++ b/embedded-graphics/src/primitives/circle.rs
@@ -147,9 +147,8 @@ where
             let t = self.p;
             let len = t.x.pow(2) + t.y.pow(2);
 
-            let is_stroke = len > self.inner_threshold && len <= self.outer_threshold;
-
-            let is_fill = len <= self.outer_threshold;
+            let is_fill = len <= self.inner_threshold;
+            let is_stroke = len <= self.outer_threshold && !is_fill;
 
             let item = if is_stroke && self.style.stroke_color.is_some() {
                 Some(Pixel(self.center + t, self.style.stroke_color.unwrap()))
@@ -203,12 +202,13 @@ where
         let inner_radius = self.primitive.radius as i32 - self.style.stroke_width_i32() + 1;
         let outer_radius = self.primitive.radius as i32;
 
-        let inner_threshold = inner_radius.pow(2) - inner_radius;
+        let mut inner_threshold = inner_radius.pow(2) - inner_radius;
         let mut outer_threshold = outer_radius.pow(2) + outer_radius;
 
         // Special case for small circles. This kludge removes the top-left pixel and leaves the
         // circle as a `+` shape.
         if self.primitive.radius == 1 {
+            inner_threshold -= 1;
             outer_threshold -= 1;
         }
 

--- a/embedded-graphics/src/primitives/circle.rs
+++ b/embedded-graphics/src/primitives/circle.rs
@@ -147,8 +147,9 @@ where
             let t = self.p;
             let len = t.x.pow(2) + t.y.pow(2);
 
-            let is_fill = len <= self.inner_threshold;
-            let is_stroke = len <= self.outer_threshold && !is_fill;
+            let is_stroke = len > self.inner_threshold && len <= self.outer_threshold;
+
+            let is_fill = len <= self.outer_threshold;
 
             let item = if is_stroke && self.style.stroke_color.is_some() {
                 Some(Pixel(self.center + t, self.style.stroke_color.unwrap()))
@@ -202,13 +203,12 @@ where
         let inner_radius = self.primitive.radius as i32 - self.style.stroke_width_i32() + 1;
         let outer_radius = self.primitive.radius as i32;
 
-        let mut inner_threshold = inner_radius.pow(2) - inner_radius;
+        let inner_threshold = inner_radius.pow(2) - inner_radius;
         let mut outer_threshold = outer_radius.pow(2) + outer_radius;
 
         // Special case for small circles. This kludge removes the top-left pixel and leaves the
         // circle as a `+` shape.
         if self.primitive.radius == 1 {
-            inner_threshold -= 1;
             outer_threshold -= 1;
         }
 

--- a/embedded-graphics/src/primitives/circle.rs
+++ b/embedded-graphics/src/primitives/circle.rs
@@ -146,11 +146,11 @@ where
             let t = self.p;
             let len = t.x.pow(2) + t.y.pow(2);
 
-            let is_border = len > self.inner_threshold && len < self.outer_threshold;
+            let is_stroke = len > self.inner_threshold && len < self.outer_threshold;
 
             let is_fill = len < self.outer_threshold;
 
-            let item = if is_border && self.style.stroke_color.is_some() {
+            let item = if is_stroke && self.style.stroke_color.is_some() {
                 Some(Pixel(
                     self.center + t,
                     self.style.stroke_color.expect("Border color not defined"),
@@ -204,7 +204,7 @@ where
             -(self.primitive.radius as i32),
         );
 
-        // A stroke width of zero renders a 1px border, so add 1 to inner radius to compensate
+        // A stroke width of zero renders a 1px stroke, so add 1 to inner radius to compensate
         let inner_radius = self.primitive.radius as i32 - self.style.stroke_width_i32() + 1;
         let outer_radius = self.primitive.radius as i32;
 

--- a/embedded-graphics/src/primitives/circle.rs
+++ b/embedded-graphics/src/primitives/circle.rs
@@ -132,14 +132,16 @@ where
 {
     type Item = Pixel<C>;
 
-    // https://stackoverflow.com/questions/1201200/fast-algorithm-for-drawing-filled-circles
+    // https://stackoverflow.com/a/1237519/383609
+    // https://stackoverflow.com/questions/1201200/fast-algorithm-for-drawing-filled-circles#comment80182898_1237519
     fn next(&mut self) -> Option<Self::Item> {
         // If border or stroke colour is `None`, treat entire object as transparent and exit early
         if self.style.stroke_color.is_none() && self.style.fill_color.is_none() {
             return None;
         }
 
-        let inner_radius = self.radius as i32 - self.style.stroke_width_i32();
+        // A stroke width of zero renders a 1px border, so add 1 to inner radius to compensate
+        let inner_radius = self.radius as i32 - self.style.stroke_width_i32() + 1;
         let outer_radius = self.radius as i32;
 
         let inner_radius_sq = inner_radius * inner_radius;
@@ -149,9 +151,10 @@ where
             let t = self.p;
             let len = t.x * t.x + t.y * t.y;
 
-            let is_border = len >= inner_radius_sq && len <= outer_radius_sq;
+            let is_border =
+                len > inner_radius_sq - inner_radius && len < outer_radius_sq + outer_radius;
 
-            let is_fill = len <= outer_radius_sq;
+            let is_fill = len < outer_radius_sq + outer_radius;
 
             let item = if is_border && self.style.stroke_color.is_some() {
                 Some(Pixel(

--- a/embedded-graphics/src/primitives/circle.rs
+++ b/embedded-graphics/src/primitives/circle.rs
@@ -233,6 +233,51 @@ mod tests {
     use super::*;
     use crate::pixelcolor::BinaryColor;
 
+    fn test_expected_circle(
+        circle: Styled<Circle, PrimitiveStyle<BinaryColor>>,
+        expected: &[(i32, i32)],
+    ) {
+        let mut expected_iter = expected.iter();
+
+        for (idx, Pixel(coord, _)) in circle.into_iter().enumerate() {
+            match expected_iter.next() {
+                Some(point) => assert_eq!(
+                    coord,
+                    Point::from(*point),
+                    "Coordinate at index {} does not match expected value",
+                    idx
+                ),
+
+                // expected runs out of points before circle does
+                None => unreachable!(),
+            }
+        }
+        // check that expected has no points left
+        assert!(expected_iter.next().is_none())
+    }
+
+    // Check that tiny circles render as a "+" shape with a hole in the center
+    #[test]
+    fn tiny_circle() {
+        let circle = Circle::new(Point::new(10, 10), 1)
+            .into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 1));
+
+        let expected = [(10, 9), (9, 10), (11, 10), (10, 11)];
+
+        test_expected_circle(circle, &expected);
+    }
+
+    // Check that tiny filled circle render as a "+" shape with NO hole in the center
+    #[test]
+    fn tiny_circle_filled() {
+        let circle = Circle::new(Point::new(10, 10), 1)
+            .into_styled(PrimitiveStyle::with_fill(BinaryColor::On));
+
+        let expected = [(10, 9), (9, 10), (10, 10), (11, 10), (10, 11)];
+
+        test_expected_circle(circle, &expected);
+    }
+
     /// Test for issue #143
     #[test]
     fn issue_143_stroke_and_fill() {

--- a/embedded-graphics/src/primitives/circle.rs
+++ b/embedded-graphics/src/primitives/circle.rs
@@ -139,19 +139,19 @@ where
             return None;
         }
 
-        let radius = self.radius as i32 - self.style.stroke_width_i32() + 1;
+        let inner_radius = self.radius as i32 - self.style.stroke_width_i32();
         let outer_radius = self.radius as i32;
 
-        let radius_sq = radius * radius;
+        let inner_radius_sq = inner_radius * inner_radius;
         let outer_radius_sq = outer_radius * outer_radius;
 
         loop {
             let t = self.p;
             let len = t.x * t.x + t.y * t.y;
 
-            let is_border = len > radius_sq - radius && len < outer_radius_sq + radius;
+            let is_border = len >= inner_radius_sq && len <= outer_radius_sq;
 
-            let is_fill = len <= outer_radius_sq + 1;
+            let is_fill = len <= outer_radius_sq;
 
             let item = if is_border && self.style.stroke_color.is_some() {
                 Some(Pixel(

--- a/embedded-graphics/src/primitives/circle.rs
+++ b/embedded-graphics/src/primitives/circle.rs
@@ -209,7 +209,13 @@ where
         let outer_radius = self.primitive.radius as i32;
 
         let inner_threshold = inner_radius.pow(2) - inner_radius;
-        let outer_threshold = outer_radius.pow(2) + outer_radius;
+        let mut outer_threshold = outer_radius.pow(2) + outer_radius;
+
+        // Special case for small circles. This kludge removes the top-left pixel and leaves the
+        // circle as a `+` shape.
+        if self.primitive.radius == 1 {
+            outer_threshold -= 1;
+        }
 
         StyledCircleIterator {
             center: self.primitive.center,

--- a/embedded-graphics/src/primitives/circle.rs
+++ b/embedded-graphics/src/primitives/circle.rs
@@ -231,51 +231,47 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::mock_display::MockDisplay;
     use crate::pixelcolor::BinaryColor;
-
-    fn test_expected_circle(
-        circle: Styled<Circle, PrimitiveStyle<BinaryColor>>,
-        expected: &[(i32, i32)],
-    ) {
-        let mut expected_iter = expected.iter();
-
-        for (idx, Pixel(coord, _)) in circle.into_iter().enumerate() {
-            match expected_iter.next() {
-                Some(point) => assert_eq!(
-                    coord,
-                    Point::from(*point),
-                    "Coordinate at index {} does not match expected value",
-                    idx
-                ),
-
-                // expected runs out of points before circle does
-                None => unreachable!(),
-            }
-        }
-        // check that expected has no points left
-        assert!(expected_iter.next().is_none())
-    }
 
     // Check that tiny circles render as a "+" shape with a hole in the center
     #[test]
     fn tiny_circle() {
-        let circle = Circle::new(Point::new(10, 10), 1)
-            .into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 1));
+        let mut display = MockDisplay::new();
 
-        let expected = [(10, 9), (9, 10), (11, 10), (10, 11)];
+        Circle::new(Point::new(1, 1), 1)
+            .into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 1))
+            .draw(&mut display);
 
-        test_expected_circle(circle, &expected);
+        #[rustfmt::skip]
+        assert_eq!(
+            display,
+            MockDisplay::from_pattern(&[
+                " # ",
+                "# #",
+                " # "
+            ])
+        );
     }
 
     // Check that tiny filled circle render as a "+" shape with NO hole in the center
     #[test]
     fn tiny_circle_filled() {
-        let circle = Circle::new(Point::new(10, 10), 1)
-            .into_styled(PrimitiveStyle::with_fill(BinaryColor::On));
+        let mut display = MockDisplay::new();
 
-        let expected = [(10, 9), (9, 10), (10, 10), (11, 10), (10, 11)];
+        Circle::new(Point::new(1, 1), 1)
+            .into_styled(PrimitiveStyle::with_fill(BinaryColor::On))
+            .draw(&mut display);
 
-        test_expected_circle(circle, &expected);
+        #[rustfmt::skip]
+        assert_eq!(
+            display,
+            MockDisplay::from_pattern(&[
+                " # ",
+                "###",
+                " # "
+            ])
+        );
     }
 
     /// Test for issue #143

--- a/simulator/examples/debug-circle.rs
+++ b/simulator/examples/debug-circle.rs
@@ -17,7 +17,7 @@ use embedded_graphics_simulator::{SimulatorDisplay, SimulatorEvent, WindowBuilde
 use sdl2::keyboard::Keycode;
 
 fn main() {
-    let mut display = SimulatorDisplay::new(Size::new(200, 100));
+    let mut display = SimulatorDisplay::new(Size::new(300, 100));
     let mut window = WindowBuilder::new(&display)
         .scale(3)
         .title("Debug circle")
@@ -47,7 +47,7 @@ fn main() {
         // Bounding lines to check size
         Line::new(
             Point::new(0, 50 - size as i32),
-            Point::new(200, 50 - size as i32),
+            Point::new(300, 50 - size as i32),
         )
         .into_styled(PrimitiveStyle::with_stroke(Rgb888::BLUE, 1))
         .draw(&mut display);
@@ -61,6 +61,14 @@ fn main() {
                 // fill_color: Some(Rgb888::GREEN),
                 fill_color: None,
                 stroke_color: Some(Rgb888::GREEN),
+                stroke_width,
+            })
+            .draw(&mut display);
+
+        Circle::new(Point::new(250, 50), size)
+            .into_styled(PrimitiveStyle {
+                fill_color: Some(Rgb888::MAGENTA),
+                stroke_color: Some(Rgb888::CYAN),
                 stroke_width,
             })
             .draw(&mut display);

--- a/simulator/examples/debug-circle.rs
+++ b/simulator/examples/debug-circle.rs
@@ -2,6 +2,9 @@
 //!
 //! Use <kbd>Up</kb>/<kbd>Down</kbd> to change circle size. Circle's edge should lie on horizontal
 //! line for correct size. The red/green circles should look identicle (aside from colour).
+//!
+//! Use <kbd>Left</kb>/<kbd>Right</kbd> to change circle stroke width.
+
 extern crate embedded_graphics;
 extern crate embedded_graphics_simulator;
 
@@ -21,15 +24,24 @@ fn main() {
         .build();
 
     let mut size: u32 = 4;
+    let mut stroke_width: u32 = 1;
 
     'running: loop {
         display.clear(Rgb888::BLACK);
 
         text_6x8!(
-            &format!("Sz: {}", size),
+            &format!("Size: {}", size),
             text_color = Some(Rgb888::WHITE),
             background_color = Some(Rgb888::BLACK),
         )
+        .draw(&mut display);
+
+        text_6x8!(
+            &format!("Stroke: {}", stroke_width),
+            text_color = Some(Rgb888::WHITE),
+            background_color = Some(Rgb888::BLACK),
+        )
+        .translate(Point::new(0, 8))
         .draw(&mut display);
 
         // Bounding lines to check size
@@ -49,7 +61,7 @@ fn main() {
                 // fill_color: Some(Rgb888::GREEN),
                 fill_color: None,
                 stroke_color: Some(Rgb888::GREEN),
-                stroke_width: 1,
+                stroke_width,
             })
             .draw(&mut display);
 
@@ -62,6 +74,14 @@ fn main() {
                     match keycode {
                         Keycode::Up => size += 1,
                         Keycode::Down => size = if size > 0 { size - 1 } else { 0 },
+                        Keycode::Right => stroke_width += 1,
+                        Keycode::Left => {
+                            stroke_width = if stroke_width > 0 {
+                                stroke_width - 1
+                            } else {
+                                0
+                            }
+                        }
                         _ => (),
                     };
                 }

--- a/simulator/examples/debug-circle.rs
+++ b/simulator/examples/debug-circle.rs
@@ -1,0 +1,73 @@
+//! # Example: Circle Debugging
+//!
+//! Use <kbd>Up</kb>/<kbd>Down</kbd> to change circle size. Circle's edge should lie on horizontal
+//! line for correct size. The red/green circles should look identicle (aside from colour).
+extern crate embedded_graphics;
+extern crate embedded_graphics_simulator;
+
+use embedded_graphics::pixelcolor::Rgb888;
+use embedded_graphics::prelude::*;
+use embedded_graphics::primitives::{Circle, Line};
+use embedded_graphics::style::PrimitiveStyle;
+use embedded_graphics::text_6x8;
+use embedded_graphics_simulator::{SimulatorDisplay, SimulatorEvent, WindowBuilder};
+use sdl2::keyboard::Keycode;
+
+fn main() {
+    let mut display = SimulatorDisplay::new(Size::new(200, 100));
+    let mut window = WindowBuilder::new(&display)
+        .scale(3)
+        .title("Debug circle")
+        .build();
+
+    let mut size: u32 = 4;
+
+    'running: loop {
+        display.clear(Rgb888::BLACK);
+
+        text_6x8!(
+            &format!("Sz: {}", size),
+            text_color = Some(Rgb888::WHITE),
+            background_color = Some(Rgb888::BLACK),
+        )
+        .draw(&mut display);
+
+        // Bounding lines to check size
+        Line::new(
+            Point::new(0, 50 - size as i32),
+            Point::new(200, 50 - size as i32),
+        )
+        .into_styled(PrimitiveStyle::with_stroke(Rgb888::BLUE, 1))
+        .draw(&mut display);
+
+        Circle::new(Point::new(50, 50), size)
+            .into_styled(PrimitiveStyle::with_fill(Rgb888::RED))
+            .draw(&mut display);
+
+        Circle::new(Point::new(150, 50), size)
+            .into_styled(PrimitiveStyle {
+                // fill_color: Some(Rgb888::GREEN),
+                fill_color: None,
+                stroke_color: Some(Rgb888::GREEN),
+                stroke_width: 1,
+            })
+            .draw(&mut display);
+
+        window.update(&display);
+
+        for event in window.events() {
+            match event {
+                SimulatorEvent::Quit => break 'running,
+                SimulatorEvent::KeyDown { keycode, .. } => {
+                    match keycode {
+                        Keycode::Up => size += 1,
+                        Keycode::Down => size = if size > 0 { size - 1 } else { 0 },
+                        _ => (),
+                    };
+                }
+
+                _ => {}
+            }
+        }
+    }
+}


### PR DESCRIPTION
Hi! Thank you for helping out with Embedded Graphics development! Please:

- [x] Check that you've added passing tests and documentation
- [x] Add a simulator example(s) where applicable
- [x] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc)
- [x] Run `rustfmt` on the project
- [x] Run `./build.sh` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

Closes #143 again. Not sure if this is a regression or the test never caught it in the first place.

The test for #143 now loops from sizes `0..10` which does a slightly better job of ensuring filled/stroked circles are the same.

TODO:

* [x] Fix drawing behaviour to be in line with master (stroked and filled or just filled, pick one). Compare:

  Master:

  ![master](https://user-images.githubusercontent.com/800791/69718825-26b41200-1107-11ea-9e76-2786a2c247ba.png)

  This branch:
  
  ![fix](https://user-images.githubusercontent.com/800791/69718836-2c115c80-1107-11ea-8ab7-89f61b156181.png)


