### PR TITLE
Test other crate readmes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 
 - #216 tinytga: Fixed integer overflow for some RLE compressed TGA files.
 
+- #218 simulator/tinybmp/tinytga: Test README examples in CI and update them to work with latest crate versions.
+
 ### Changed
 
 - **(breaking)** The `Drawable` trait now has a required trait method `draw()`, which describes how the object will be drawn on the screen. See the docs for more details.

--- a/simulator/README.md
+++ b/simulator/README.md
@@ -12,33 +12,41 @@ The simulator can be used to test and debug [embedded-graphics](https://crates.i
 
 ## Simulate a 128x64 SSD1306 OLED
 
-```rust
-use embedded_graphics::{icoord, circle, line, text_6x8};
-use embedded_graphics_simulator::{DisplayBuilder, DisplayTheme};
-use std::thread;
-use std::time::Duration;
+```rust,no_run
+use embedded_graphics::{
+    fonts::{Font6x8, Text},
+    pixelcolor::BinaryColor,
+    prelude::*,
+    primitives::{Circle, Line},
+    style::{PrimitiveStyle, TextStyle},
+};
+use embedded_graphics_simulator::{BinaryColorTheme, SimulatorDisplay, WindowBuilder};
 
 fn main() {
- let mut display = DisplayBuilder::new()
-     .theme(DisplayTheme::OledBlue)
-     .size(128, 64)
-     .build();
+    let mut display = SimulatorDisplay::new(Size::new(129, 129));
 
- text_6x8!("Hello World!").draw(&mut display);
+    let line_style = PrimitiveStyle::with_stroke(BinaryColor::On, 1);
 
- egcircle!((96, 32), 31, stroke_color = Some(1u8.into())).draw(&mut display);
+    Circle::new(Point::new(64, 64), 64)
+        .into_styled(line_style)
+        .draw(&mut display);
 
- egline!((32, 32), (1, 32), stroke_color = Some(1u8.into())).translate(icoord!(64, 0)).draw(&mut display);
- egline!((32, 32), (40, 40), stroke_color = Some(1u8.into())).translate(icoord!(64, 0)).draw(&mut display);
+    Line::new(Point::new(64, 64), Point::new(0, 64))
+        .into_styled(line_style)
+        .draw(&mut display);
+    Line::new(Point::new(64, 64), Point::new(80, 80))
+        .into_styled(line_style)
+        .draw(&mut display);
 
- loop {
-     let end = display.run_once();
+    Text::new("Hello World!", Point::new(5, 50))
+        .into_styled(TextStyle::new(Font6x8, BinaryColor::On))
+        .draw(&mut display);
 
-     if end {
-         break;
-     }
+    let mut window = WindowBuilder::new(&display)
+        .title("Hello World")
+        .theme(BinaryColorTheme::OledBlue)
+        .build();
 
-     thread::sleep(Duration::from_millis(200));
- }
+    window.show_static(&display);
 }
 ```

--- a/simulator/src/check_readme.rs
+++ b/simulator/src/check_readme.rs
@@ -1,0 +1,11 @@
+//! This file includes the contents of the project's README.md so the code examples in it can be run
+//! as Rust doc tests
+
+macro_rules! doc {
+    ($e:expr) => {
+        #[doc = $e]
+        extern {}
+    };
+}
+
+doc!(include_str!("../README.md"));

--- a/simulator/src/lib.rs
+++ b/simulator/src/lib.rs
@@ -80,6 +80,7 @@
 
 #![deny(missing_docs)]
 
+mod check_readme;
 mod display;
 mod theme;
 mod window;

--- a/tinybmp/README.md
+++ b/tinybmp/README.md
@@ -11,29 +11,31 @@ A small BMP parser designed for embedded, no-std environments but usable anywher
 ## Example
 
 ```rust
-use tinybmp::{Bmp, Header, FileType};
+use tinybmp::{Bmp, FileType, Header};
 
-let bmp =
-    Bmp::from_bytes(include_bytes!("./my_image.bmp")).expect("Failed to parse image");
+fn main() {
+    let bmp =
+        Bmp::from_slice(include_bytes!("../tests/chessboard-8px-24bit.bmp")).expect("Failed to parse");
 
-// Metadata extracted from image. Assumes my_image.bmp is 8x8px, 24BPP
-assert_eq!(
-    bmp.header,
-    Header {
-        file_type: FileType::BM,
-        file_size: 314,
-        reserved_1: 0,
-        reserved_2: 0,
-        image_data_start: 122,
-        bpp: 24,
-        image_width: 8,
-        image_height: 8,
-    }
-);
+    assert_eq!(
+        bmp.header,
+        Header {
+            file_type: FileType::BM,
+            file_size: 314,
+            reserved_1: 0,
+            reserved_2: 0,
+            image_data_start: 122,
+            bpp: 24,
+            image_width: 8,
+            image_height: 8,
+            image_data_len: 192
+        }
+    );
 
-let image_data: &[u8] = bmp.image_data();
+    let image_data: &[u8] = bmp.image_data();
 
-// Render, process or iterate on `image_data` here
+    // Render, process or iterate on `image_data` here
+}
 ```
 
 ## License

--- a/tinybmp/src/check_readme.rs
+++ b/tinybmp/src/check_readme.rs
@@ -1,0 +1,11 @@
+//! This file includes the contents of the project's README.md so the code examples in it can be run
+//! as Rust doc tests
+
+macro_rules! doc {
+    ($e:expr) => {
+        #[doc = $e]
+        extern {}
+    };
+}
+
+doc!(include_str!("../README.md"));

--- a/tinybmp/src/lib.rs
+++ b/tinybmp/src/lib.rs
@@ -5,6 +5,7 @@
 #![deny(missing_docs)]
 #![deny(missing_debug_implementations)]
 
+mod check_readme;
 mod header;
 
 use crate::header::parse_header;

--- a/tinytga/README.md
+++ b/tinytga/README.md
@@ -15,7 +15,8 @@ Call `Tga.into_iter()` to get an iterator over individual pixels in the image.
 ```rust
 use tinytga::{ImageType, Tga, TgaFooter, TgaHeader};
 
-let data = include_bytes!("./image.tga");
+// Include an image from a local path as bytes
+let data = include_bytes!("../tests/chessboard_4px_rle.tga");
 
 // Create a TGA instance from a byte slice
 let img = Tga::from_slice(data).unwrap();
@@ -26,26 +27,26 @@ assert_eq!(
     TgaHeader {
         id_len: 0,
         has_color_map: false,
-        image_type: ImageType::Truecolor,
+        image_type: ImageType::RleTruecolor,
         color_map_start: 0,
         color_map_len: 0,
         color_map_depth: 0,
         x_origin: 0,
-        y_origin: 8,
-        width: 8,
-        height: 8,
+        y_origin: 4,
+        width: 4,
+        height: 4,
         pixel_depth: 24,
-        image_descriptor: 32
+        image_descriptor: 32,
     }
 );
 
 // Take a look at the footer
 assert_eq!(
     img.footer,
-    TgaFooter {
+    Some(TgaFooter {
         extension_area_offset: 0,
         developer_directory_offset: 0
-    }
+    })
 );
 
 // Collect pixels into a `Vec<u32>`
@@ -56,9 +57,9 @@ let pixels = img.into_iter().collect::<Vec<u32>>();
 
 Licensed under either of
 
-- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or
-  http://www.apache.org/licenses/LICENSE-2.0)
-- MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+-   Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or
+    http://www.apache.org/licenses/LICENSE-2.0)
+-   MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
 
 at your option.
 

--- a/tinytga/src/check_readme.rs
+++ b/tinytga/src/check_readme.rs
@@ -1,0 +1,11 @@
+//! This file includes the contents of the project's README.md so the code examples in it can be run
+//! as Rust doc tests
+
+macro_rules! doc {
+    ($e:expr) => {
+        #[doc = $e]
+        extern {}
+    };
+}
+
+doc!(include_str!("../README.md"));

--- a/tinytga/src/lib.rs
+++ b/tinytga/src/lib.rs
@@ -11,6 +11,7 @@
 #![deny(unused_import_braces)]
 #![deny(unused_qualifications)]
 
+mod check_readme;
 mod footer;
 mod header;
 mod packet;


### PR DESCRIPTION
Hi! Thank you for helping out with Embedded Graphics development! Please:

- [x] Check that you've added passing tests and documentation
- [x] Add a simulator example(s) where applicable
- [x] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc)
- [x] Run `rustfmt` on the project
- [x] Run `./build.sh` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

This PR uses the `doc!(include_str!("../README.md"))` trick to include READMEs from `embedded-graphics-simulator`, `tinytga` and `tinybmp` in their respective crate builds. The README examples for these crates are now tested in CI like e-g.

Note that I added `no_run` to the simulator readme example otherwise it opens the sim window during tests (and hangs).
