### PR TITLE
Clean docs dist folder before build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+cargo clean --doc
+
 cargo fmt --all -- --check
 cargo test --release
 cargo test --release --all-features


### PR DESCRIPTION
Hi! Thank you for helping out with Embedded Graphics development! Please:

- [ ] ~Check that you've added passing tests and documentation~
- [ ] ~Add a simulator example(s) where applicable~
- [ ] ~Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc)~
- [ ] ~Run `rustfmt` on the project~
- [x] Run `./build.sh` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

Closes #219

I opted for `cargo clean --doc` as I'd like to keep the build cache
around for faster builds. I don't think there any issues with stale
build cache at the moment (only docs) so I think adding `--doc` is fine.

Not entirely sure how to test this as I've never seen it fail...
