### PR TITLE
Trial ~Discord~ Matrix

### DIFF
--- a/embedded-graphics/README.md
+++ b/embedded-graphics/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://circleci.com/gh/jamwaffles/embedded-graphics/tree/master.svg?style=shield)](https://circleci.com/gh/jamwaffles/embedded-graphics/tree/master)
 [![Crates.io](https://img.shields.io/crates/v/embedded-graphics.svg)](https://crates.io/crates/embedded-graphics)
 [![Docs.rs](https://docs.rs/embedded-graphics/badge.svg)](https://docs.rs/embedded-graphics)
-[![embedded-graphics on Discord](https://img.shields.io/discord/659506039401742346)](https://discord.gg/JK7Dpbs)
+[![embedded-graphics on Discord](https://img.shields.io/matrix/rust-embedded-graphics:matrix.org)](https://matrix.to/#/#rust-embedded-graphics:matrix.org)
 
 ![Embedded Graphics Simulator example screenshots](https://raw.githubusercontent.com/jamwaffles/embedded-graphics/master/assets/simulator-demo.png)
 
@@ -11,7 +11,7 @@
 
 If you think you've found a bug, or would like to suggest a new feature to add to embedded-graphics, please [open an issue](https://github.com/jamwaffles/embedded-graphics/issues/new).
 
-If you need more deeper/more personalised help, please check out the [embedded-graphics channel on Discord](https://discord.gg/JK7Dpbs).
+If you need more deeper/more personalised help, please check out the [embedded-graphics Matrix channel](https://matrix.to/#/#rust-embedded-graphics:matrix.org).
 
 ## [Documentation](https://docs.rs/embedded-graphics)
 

--- a/embedded-graphics/README.md
+++ b/embedded-graphics/README.md
@@ -3,8 +3,15 @@
 [![Build Status](https://circleci.com/gh/jamwaffles/embedded-graphics/tree/master.svg?style=shield)](https://circleci.com/gh/jamwaffles/embedded-graphics/tree/master)
 [![Crates.io](https://img.shields.io/crates/v/embedded-graphics.svg)](https://crates.io/crates/embedded-graphics)
 [![Docs.rs](https://docs.rs/embedded-graphics/badge.svg)](https://docs.rs/embedded-graphics)
+[![embedded-graphics on Discord](https://img.shields.io/discord/659506039401742346)](https://discord.gg/JK7Dpbs)
 
 ![Embedded Graphics Simulator example screenshots](https://raw.githubusercontent.com/jamwaffles/embedded-graphics/master/assets/simulator-demo.png)
+
+## Getting help/reporting an issue
+
+If you think you've found a bug, or would like to suggest a new feature to add to embedded-graphics, please [open an issue](https://github.com/jamwaffles/embedded-graphics/issues/new).
+
+If you need more deeper/more personalised help, please check out the [embedded-graphics channel on Discord](https://discord.gg/JK7Dpbs).
 
 ## [Documentation](https://docs.rs/embedded-graphics)
 


### PR DESCRIPTION
This adds a badge and links to [this Matrix channel](https://matrix.to/#/#rust-embedded-graphics:matrix.org) I don't know if this is the best solution, but let's start somewhere and see if Matrix is right for this project. If not, we can always switch.

This used to be Discord, but switched to Matrix. Thanks to @jacobrosenthal for pointing out that Rust is moving to Matrix.

Cc https://github.com/jamwaffles/embedded-graphics/issues/156#issuecomment-568593897