### PR TITLE
Upgrade tinybmp to Nom 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,7 +71,7 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 
 - **(breaking)** Text rendering is now implemented using `Text`, `TextStyle` and `Font` objects instead of using `Font::render_str`.
 
-- tinybmp: Upgraded to Nom 5 internally. No user-facing changes.
+- tinybmp: Upgraded to nom 5 internally. No user-facing changes.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,8 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 
 - **(breaking)** Text rendering is now implemented using `Text`, `TextStyle` and `Font` objects instead of using `Font::render_str`.
 
+- tinybmp: Upgraded to Nom 5 internally. No user-facing changes.
+
 ### Removed
 
 - **(breaking)** The `SizedDrawing` trait is removed.

--- a/tinybmp/Cargo.toml
+++ b/tinybmp/Cargo.toml
@@ -19,5 +19,5 @@ exclude = [
 circle-ci = { repository = "jamwaffles/embedded-graphics", branch = "master" }
 
 [dependencies.nom]
-version = "4.2.3"
+version = "5.0.1"
 default-features = false

--- a/tinybmp/src/header.rs
+++ b/tinybmp/src/header.rs
@@ -53,12 +53,12 @@ pub fn parse_header(input: &[u8]) -> IResult<&[u8], Header> {
     let (input, reserved_1) = le_u16(input)?;
     let (input, reserved_2) = le_u16(input)?;
     let (input, image_data_start) = le_u32(input)?;
-    let (input, _) = le_u32(input)?;
+    let (input, _header_size) = le_u32(input)?;
     let (input, image_width) = le_u32(input)?;
     let (input, image_height) = le_u32(input)?;
-    let (input, _) = le_u16(input)?;
+    let (input, _color_planes) = le_u16(input)?;
     let (input, bpp) = le_u16(input)?;
-    let (input, _) = le_u32(input)?;
+    let (input, _compression_method) = le_u32(input)?;
     let (input, image_data_len) = le_u32(input)?;
 
     Ok((


### PR DESCRIPTION
Hi! Thank you for helping out with Embedded Graphics development! Please:

- [x] Check that you've added passing tests and documentation
- [x] Add a simulator example(s) where applicable
- [x] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc)
- [x] Run `rustfmt` on the project
- [x] Run `./build.sh` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

Like tinytga, upgrades tinybmp internally to Nom 5. No user-facing changes so this can be released as a patch release.
