### PR TITLE
simulator: add game of life adapted from https://github.com/rustwasm/wasm_game_of_life

### DIFF
--- a/simulator/Cargo.toml
+++ b/simulator/Cargo.toml
@@ -33,6 +33,7 @@ required-features = ["bmp"]
 
 [dependencies]
 sdl2 = "0.32.2"
+heapless = "0.5.1"
 
 [dependencies.embedded-graphics]
 version = "0.6.0-alpha.2"

--- a/simulator/examples/game-of-life/life.rs
+++ b/simulator/examples/game-of-life/life.rs
@@ -1,0 +1,114 @@
+//! https://github.com/rustwasm/wasm_game_of_life
+
+use heapless::consts::*;
+
+#[derive(Copy, Clone, PartialEq)]
+pub enum Cell {
+    Dead = 0,
+    Alive = 1,
+}
+
+pub struct Universe {
+    width: u32,
+    height: u32,
+    cells: heapless::Vec<Cell, U32768>,
+    next_cells: heapless::Vec<Cell, U32768>,
+}
+
+impl Universe {
+    pub fn new(
+        width: u32,
+        height: u32,
+        mut cells: heapless::Vec<Cell, U32768>,
+        mut next_cells: heapless::Vec<Cell, U32768>,
+    ) -> Universe {
+        cells.clear();
+        next_cells.clear();
+
+        for i in 0..width * height {
+            let cell = if i % 2 == 0 || i % 7 == 0 {
+                Cell::Alive
+            } else {
+                Cell::Dead
+            };
+            cells.push(cell).ok();
+            next_cells.push(Cell::Dead).ok();
+        }
+
+        Universe {
+            width,
+            height,
+            cells,
+            next_cells,
+        }
+    }
+
+    // min 0,0 = 0, max 127,159 = 127 * 160 + 159 = 20479
+    fn get_index(&self, row: u32, column: u32) -> usize {
+        (row * self.width + column) as usize
+    }
+
+    fn live_neighbor_count(&self, row: u32, column: u32) -> u8 {
+        let mut count = 0;
+        for delta_row in [self.height - 1, 0, 1].iter().cloned() {
+            for delta_col in [self.width - 1, 0, 1].iter().cloned() {
+                if delta_row == 0 && delta_col == 0 {
+                    continue;
+                }
+
+                let neighbor_row = (row + delta_row) % self.height;
+                let neighbor_col = (column + delta_col) % self.width;
+                let idx = self.get_index(neighbor_row, neighbor_col);
+                count += self.cells[idx] as u8;
+            }
+        }
+        count
+    }
+
+    pub fn tick(&mut self) {
+        for row in 0..self.height {
+            for col in 0..self.width {
+                let idx = self.get_index(row, col);
+                let cell = self.cells[idx];
+                let live_neighbors = self.live_neighbor_count(row, col);
+
+                let next_cell = match (cell, live_neighbors) {
+                    // Rule 1: Any live cell with fewer than two live neighbours
+                    // dies, as if caused by underpopulation.
+                    (Cell::Alive, x) if x < 2 => Cell::Dead,
+                    // Rule 2: Any live cell with two or three live neighbours
+                    // lives on to the next generation.
+                    (Cell::Alive, 2) | (Cell::Alive, 3) => Cell::Alive,
+                    // Rule 3: Any live cell with more than three live
+                    // neighbours dies, as if by overpopulation.
+                    (Cell::Alive, x) if x > 3 => Cell::Dead,
+                    // Rule 4: Any dead cell with exactly three live neighbours
+                    // becomes a live cell, as if by reproduction.
+                    (Cell::Dead, 3) => Cell::Alive,
+                    // All other cells remain in the same state.
+                    (otherwise, _) => otherwise,
+                };
+
+                self.next_cells[idx] = next_cell;
+            }
+        }
+
+        //swap the working copy
+        core::mem::swap(&mut self.next_cells, &mut self.cells);
+    }
+
+    //todo lifetime ok?
+    pub fn iter(&mut self) -> impl Iterator<Item = (u32, u32, Cell)> + '_ {
+        let width = self.width;
+        let size = (self.width * self.height) as usize;
+        self.cells[..size]
+            .iter()
+            .enumerate()
+            .map(move |(idx, cell)| {
+                let index = idx as u32;
+                let row = index / width;
+                let column = index % width;
+                (row, column, *cell)
+            })
+    }
+}

--- a/simulator/examples/game-of-life/main.rs
+++ b/simulator/examples/game-of-life/main.rs
@@ -1,0 +1,63 @@
+//! # Example: Game of Life
+//!
+//! A zero player cellular automaton 'game' https://en.wikipedia.org/wiki/Conway%27s_Game_of_Life
+//! Code slightly adapted from the wasm example for no_std use cases where Vec is not available
+//! https://github.com/rustwasm/wasm_game_of_life
+
+use embedded_graphics::pixelcolor::BinaryColor;
+use embedded_graphics::prelude::*;
+
+use embedded_graphics_simulator::{SimulatorDisplay, SimulatorEvent, WindowBuilder};
+
+use heapless::consts::*;
+use heapless::Vec;
+
+use std::thread;
+use std::time::Duration;
+
+mod life;
+use life::{Cell, Universe};
+
+/// The width and height of the display
+const DISP_SIZE_X: u32 = 160;
+const DISP_SIZE_Y: u32 = 128;
+
+fn main() {
+    let mut display = SimulatorDisplay::<BinaryColor>::new(Size::new(DISP_SIZE_X, DISP_SIZE_Y));
+    let mut window = WindowBuilder::new(&display)
+        .title("Game Of Life")
+        .scale(2)
+        .build();
+
+    //wasted space, but there is no U20480
+    let cells = Vec::<Cell, U32768>::new();
+    //more wasted space, a copy to edit while we keep last values
+    let next = Vec::<Cell, U32768>::new();
+
+    let mut universe = Universe::new(DISP_SIZE_X as u32, DISP_SIZE_Y as u32, cells, next);
+
+    'running: loop {
+        window.update(&display);
+
+        for event in window.events() {
+            if let SimulatorEvent::Quit = event {
+                break 'running;
+            }
+        }
+        universe.tick();
+
+        universe
+            .iter()
+            .map(|(row, col, cell)| {
+                let color = if cell == Cell::Alive {
+                    BinaryColor::On
+                } else {
+                    BinaryColor::Off
+                };
+                Pixel(Point::new(col as i32, row as i32), color)
+            })
+            .draw(&mut display);
+
+        thread::sleep(Duration::from_millis(50));
+    }
+}


### PR DESCRIPTION

- [x] Check that you've added passing tests and documentation
- [x] Add a simulator example(s) where applicable
- [ ] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc)
- [x] Run `rustfmt` on the project
- [x] Run `./build.sh` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

Not sure where to showcase. I still havent quite figured if maybe it can fit in its original repo without complicating the original example and show how you can have both wasm and no_std embedded code work.. But for now here it is.

The big changes from the upstream codebase were to 
* use two heapless vec for game state, and then `core::mem::swap` between them, instead of using Vec and `clone`. 
* impl `iter` so I didnt have to leak so much internal state, and also because then embedded graphics could consume game state easily.

