### PR TITLE
All the derives, add fallible point conversions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 - tinbmp: Added `.into_iter()` support to the `Bmp` struct to get an iterator over every pixel in the image.
 - Added as many `#[derive()]`s as possible to all embedded-graphics, tinybmp and tinytga items.
 - Added `From<Point> for [i32; 2]`
+- Added `From<Size> for [u32; 2]`
 - Added the following fallible conversions to/from `Point`
   - `TryFrom<Point> for (u32, u32)`
   - `TryFrom<(u32, u32)> for Point`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 - Added [hub75](https://crates.io/crates/hub75) driver to list of known supported drivers.
 - tinbmp: Added `.into_iter()` support to the `Bmp` struct to get an iterator over every pixel in the image.
 - Added as many `#[derive()]`s as possible to all embedded-graphics, tinybmp and tinytga items.
+- Added `TryFrom<Point> for (u32, u32)` and `TryFrom<(u32, u32)> for Point` fallible conversions for `Point`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,15 +10,15 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 
 - Added [hub75](https://crates.io/crates/hub75) driver to list of known supported drivers.
 - tinbmp: Added `.into_iter()` support to the `Bmp` struct to get an iterator over every pixel in the image.
-- Added as many `#[derive()]`s as possible to all embedded-graphics, tinybmp and tinytga items.
+- Added as many `#[derive()]`s as possible to all embedded-graphics, tinybmp and tinytga types.
 - Added `From<Point> for [i32; 2]`
 - Added `From<Size> for [u32; 2]`
 - Added the following fallible conversions to/from `Point`
-  - `TryFrom<Point> for (u32, u32)`
-  - `TryFrom<(u32, u32)> for Point`
-  - `TryFrom<Point> for [u32; 2]`
-  - `TryFrom<[u32; 2]> for Point`
-  - `TryFrom<&[u32; 2]> for Point`
+  - `TryFrom<Point>` for `(u32, u32)`
+  - `TryFrom<(u32, u32)>` for `Point`
+  - `TryFrom<Point>` for `[u32; 2]`
+  - `TryFrom<[u32; 2]>` for `Point`
+  - `TryFrom<&[u32; 2]>` for `Point`
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 
 - Added [hub75](https://crates.io/crates/hub75) driver to list of known supported drivers.
 - tinbmp: Added `.into_iter()` support to the `Bmp` struct to get an iterator over every pixel in the image.
+- Added as many `#[derive()]`s as possible to all embedded-graphics, tinybmp and tinytga items.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,13 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 - Added [hub75](https://crates.io/crates/hub75) driver to list of known supported drivers.
 - tinbmp: Added `.into_iter()` support to the `Bmp` struct to get an iterator over every pixel in the image.
 - Added as many `#[derive()]`s as possible to all embedded-graphics, tinybmp and tinytga items.
-- Added `TryFrom<Point> for (u32, u32)` and `TryFrom<(u32, u32)> for Point` fallible conversions for `Point`.
+- Added `From<Point> for [i32; 2]`
+- Added the following fallible conversions to/from `Point`
+  - `TryFrom<Point> for (u32, u32)`
+  - `TryFrom<(u32, u32)> for Point`
+  - `TryFrom<Point> for [u32; 2]`
+  - `TryFrom<[u32; 2]> for Point`
+  - `TryFrom<&[u32; 2]> for Point`
 
 ### Changed
 

--- a/embedded-graphics/Cargo.toml
+++ b/embedded-graphics/Cargo.toml
@@ -26,8 +26,8 @@ circle-ci = { repository = "jamwaffles/embedded-graphics", branch = "master" }
 [dependencies]
 byteorder = { version = "1.3.2", default-features = false }
 nalgebra = { version = "0.19.0", optional = true, default-features = false }
-tinybmp = { version = "0.1.1", optional = true }
-tinytga = { version = "0.2.0", optional = true }
+tinybmp = { version = "0.1.2-alpha.0", optional = true }
+tinytga = { version = "0.2.1-alpha.0", optional = true }
 
 [features]
 default = []

--- a/embedded-graphics/Cargo.toml
+++ b/embedded-graphics/Cargo.toml
@@ -26,8 +26,8 @@ circle-ci = { repository = "jamwaffles/embedded-graphics", branch = "master" }
 [dependencies]
 byteorder = { version = "1.3.2", default-features = false }
 nalgebra = { version = "0.19.0", optional = true, default-features = false }
-tinybmp = { version = "0.1.2-alpha.0", optional = true }
-tinytga = { version = "0.2.1-alpha.0", optional = true }
+tinybmp = { version = "0.1.1", optional = true }
+tinytga = { version = "0.2.0", optional = true }
 
 [features]
 default = []

--- a/embedded-graphics/src/draw_target.rs
+++ b/embedded-graphics/src/draw_target.rs
@@ -70,7 +70,7 @@ use crate::{
 ///         let Pixel(coord, color) = pixel;
 ///
 ///         // Place an (x, y) pixel at the right index in the framebuffer. If the pixel coordinates
-///         // are out of bounds (negative or greater than `(63, 63)`), this operation will be a
+///         // are out of bounds (negative or greater than (63, 63)), this operation will be a
 ///         // noop.
 ///         if let Ok((x @ 0..=63, y @ 0..=63)) = coord.try_into() {
 ///             let index: u32 = x + y * 64;
@@ -107,12 +107,18 @@ use crate::{
 ///
 /// In addition to defining [`draw_pixel`], an implementation of [`DrawTarget`] can also provide
 /// alternative implementations for hardware accelerated drawing operations. This example implements
-/// `DrawTarget` for a display without a framebuffer that supports drawing hardware accelerated
-/// styled [`Rectangle`]s. The `draw_rectangle()` method overrides the default implementation.
+/// `DrawTarget` for a display without a framebuffer that supports hardware accelerated drawing of
+/// styled [`Rectangle`]s.
+///
+/// The default implementation of `draw_rectangle()` (as well as `draw_line()`, `draw_circle()` and
+/// `draw_triangle()`) defer to `draw_iter()` internally. In this example, the default
+/// implementation of `draw_rectangle()` is overridden to allow usage of accelerated draw commands
+/// specific to the targeted hardware.
 ///
 /// As this example doesn't use a framebuffer, a `flush()` method is not required. All draw
-/// operations are performed in "immediate mode" directly on the display. As drawing operations are
-/// now fallible due to hardware issues, a custom error type `CommError` is introduced.
+/// operations are performed in "immediate mode" directly on the display. As each drawing operation
+/// requires communication with the display that may fail, a custom error type `CommError` is
+/// introduced.
 ///
 /// ```rust
 /// # use embedded_graphics::prelude::*;
@@ -188,7 +194,7 @@ use crate::{
 ///     top_left = (10, 20),
 ///     bottom_right = (30, 40),
 ///     style = primitive_style!(stroke_color = Gray8::WHITE, stroke_width = 1)
-/// );
+/// ).draw(&mut display)?;
 ///
 /// // Draw a rectangle on the display using accelerated `draw_rectangle()` function
 /// # Ok::<(), CommError>(())

--- a/embedded-graphics/src/draw_target.rs
+++ b/embedded-graphics/src/draw_target.rs
@@ -110,12 +110,12 @@ use crate::{
 /// `DrawTarget` for a display without a framebuffer that supports hardware accelerated drawing of
 /// styled [`Rectangle`]s.
 ///
-/// The default implementation of `draw_rectangle()` (as well as `draw_line()`, `draw_circle()` and
-/// `draw_triangle()`) defer to `draw_iter()` internally. In this example, the default
-/// implementation of `draw_rectangle()` is overridden to allow usage of accelerated draw commands
+/// The default implementations of [`draw_rectangle`] as well as other shape drawing methods
+/// ([`draw_circle`], etc) defer to [`draw_iter`] internally. In this example, the default
+/// implementation of [`draw_rectangle`] is overridden to allow usage of accelerated draw commands
 /// specific to the targeted hardware.
 ///
-/// As this example doesn't use a framebuffer, a `flush()` method is not required. All draw
+/// As this example doesn't use a framebuffer, a "flush" operation is not required. All draw
 /// operations are performed in "immediate mode" directly on the display. As each drawing operation
 /// requires communication with the display that may fail, a custom error type `CommError` is
 /// introduced.
@@ -207,6 +207,9 @@ use crate::{
 /// [`DrawTarget`]: ./trait.DrawTarget.html
 /// [`Rectangle`]: ../primitives/rectangle/struct.Rectangle.html
 /// [`primitive`]: ../primitives/index.html
+/// [`draw_rectangle`]: ./trait.DrawTarget.html#method.draw_rectangle
+/// [`draw_circle`]: ./trait.DrawTarget.html#method.draw_circle
+/// [`draw_iter`]: ./trait.DrawTarget.html#method.draw_iter
 pub trait DrawTarget<C>
 where
     C: PixelColor,

--- a/embedded-graphics/src/drawable.rs
+++ b/embedded-graphics/src/drawable.rs
@@ -101,7 +101,7 @@ where
 ///
 /// [`Drawable`]: trait.Drawable.html
 /// [`DrawTarget`]: ../trait.DrawTarget.html
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 pub struct Pixel<C: PixelColor>(pub Point, pub C);
 
 impl<C> Drawable<C> for Pixel<C>

--- a/embedded-graphics/src/drawable.rs
+++ b/embedded-graphics/src/drawable.rs
@@ -66,7 +66,7 @@ where
     C: PixelColor,
 {
     /// Draw the graphics object using the supplied DrawTarget.
-    fn draw<T: DrawTarget<C>>(self, display: &mut T) -> Result<(), T::Error>;
+    fn draw<D: DrawTarget<C>>(self, display: &mut D) -> Result<(), D::Error>;
 }
 
 /// A single pixel.

--- a/embedded-graphics/src/fonts/font12x16.rs
+++ b/embedded-graphics/src/fonts/font12x16.rs
@@ -7,7 +7,7 @@ use crate::{fonts::Font, geometry::Size};
 /// # Examples
 ///
 /// See the [module-level documentation](./index.html) for examples.
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 pub struct Font12x16;
 
 /// Config for 12x16 font

--- a/embedded-graphics/src/fonts/font24x32.rs
+++ b/embedded-graphics/src/fonts/font24x32.rs
@@ -13,7 +13,7 @@ use crate::{fonts::Font, geometry::Size};
 /// See the [module-level documentation](./index.html) for examples.
 ///
 /// [12x16 font]: struct.Font12x16.html
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 pub struct Font24x32;
 
 impl Font for Font24x32 {

--- a/embedded-graphics/src/fonts/font6x12.rs
+++ b/embedded-graphics/src/fonts/font6x12.rs
@@ -7,7 +7,7 @@ use crate::{fonts::Font, geometry::Size};
 /// # Examples
 ///
 /// See the [module-level documentation](./index.html) for examples.
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 pub struct Font6x12;
 
 impl Font for Font6x12 {

--- a/embedded-graphics/src/fonts/font6x8.rs
+++ b/embedded-graphics/src/fonts/font6x8.rs
@@ -7,7 +7,7 @@ use crate::{fonts::Font, geometry::Size};
 /// # Examples
 ///
 /// See the [module-level documentation](./index.html) for examples.
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 pub struct Font6x8;
 
 impl Font for Font6x8 {

--- a/embedded-graphics/src/fonts/font8x16.rs
+++ b/embedded-graphics/src/fonts/font8x16.rs
@@ -7,7 +7,7 @@ use crate::{fonts::Font, geometry::Size};
 /// # Examples
 ///
 /// See the [module-level documentation](./index.html) for examples.
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 pub struct Font8x16;
 
 impl Font for Font8x16 {

--- a/embedded-graphics/src/fonts/text.rs
+++ b/embedded-graphics/src/fonts/text.rs
@@ -21,7 +21,7 @@ use crate::{
 /// [`into_styled`]: #method.into_styled
 /// [`Styled`]: ../style/struct.Styled.html
 /// [module-level documentation]: index.html
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub struct Text<'a> {
     /// The string.
     pub text: &'a str,

--- a/embedded-graphics/src/fonts/text.rs
+++ b/embedded-graphics/src/fonts/text.rs
@@ -21,7 +21,7 @@ use crate::{
 /// [`into_styled`]: #method.into_styled
 /// [`Styled`]: ../style/struct.Styled.html
 /// [module-level documentation]: index.html
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 pub struct Text<'a> {
     /// The string.
     pub text: &'a str,
@@ -133,7 +133,7 @@ where
 }
 
 /// Pixel iterator for styled text.
-#[derive(Debug, Clone, Copy)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 pub struct StyledTextIterator<'a, C, F>
 where
     C: PixelColor,
@@ -222,7 +222,7 @@ mod tests {
     use super::*;
     use crate::{mock_display::MockDisplay, pixelcolor::BinaryColor};
 
-    #[derive(Debug, Clone, Copy)]
+    #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
     struct SpacedFont;
 
     impl Font for SpacedFont {

--- a/embedded-graphics/src/geometry/point.rs
+++ b/embedded-graphics/src/geometry/point.rs
@@ -60,7 +60,7 @@ use core::ops::{Add, AddAssign, Index, Neg, Sub, SubAssign};
 /// [`Vector2<N>`]: https://docs.rs/nalgebra/0.18.0/nalgebra/base/type.Vector2.html
 /// [`Vector2`]: https://docs.rs/nalgebra/0.18.0/nalgebra/base/type.Vector2.html
 /// [Nalgebra]: https://docs.rs/nalgebra
-#[derive(Debug, Default, Copy, Clone, Eq, PartialEq)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 pub struct Point {
     /// The x coordinate.
     pub x: i32,

--- a/embedded-graphics/src/geometry/point.rs
+++ b/embedded-graphics/src/geometry/point.rs
@@ -300,6 +300,41 @@ mod tests {
     use super::*;
 
     #[test]
+    fn convert_positive_to_u32_tuple() {
+        let p = Point::new(10, 20);
+
+        let tuple: (u32, u32) = p.try_into().unwrap();
+
+        assert_eq!(tuple, (10u32, 20u32));
+    }
+
+    #[test]
+    fn convert_i32_max_to_u32_tuple() {
+        let p = Point::new(i32::max_value(), i32::max_value());
+
+        let tuple: (u32, u32) = p.try_into().unwrap();
+
+        // Literal value taken from [here](https://doc.rust-lang.org/std/primitive.i32.html#method.max_value)
+        assert_eq!(tuple, (2147483647, 2147483647));
+    }
+
+    #[test]
+    #[should_panic]
+    fn negative_u32_tuple() {
+        let p = Point::new(-50, -10);
+
+        let _tuple: (u32, u32) = p.try_into().unwrap();
+    }
+
+    #[test]
+    #[should_panic]
+    fn max_negative_u32_tuple() {
+        let p = Point::new(i32::min_value(), i32::min_value());
+
+        let _tuple: (u32, u32) = p.try_into().unwrap();
+    }
+
+    #[test]
     fn points_can_be_added() {
         let mut left = Point::new(10, 20);
         let right = Point::new(30, 40);

--- a/embedded-graphics/src/geometry/point.rs
+++ b/embedded-graphics/src/geometry/point.rs
@@ -1,4 +1,5 @@
 use crate::geometry::Size;
+use core::convert::{TryFrom, TryInto};
 use core::ops::{Add, AddAssign, Index, Neg, Sub, SubAssign};
 
 /// 2D point.
@@ -249,6 +250,25 @@ impl From<Point> for (i32, i32) {
 impl From<&Point> for (i32, i32) {
     fn from(other: &Point) -> (i32, i32) {
         (other.x, other.y)
+    }
+}
+
+impl TryFrom<Point> for (u32, u32) {
+    type Error = core::num::TryFromIntError;
+
+    fn try_from(point: Point) -> Result<Self, Self::Error> {
+        Ok((point.x.try_into()?, point.y.try_into()?))
+    }
+}
+
+impl TryFrom<(u32, u32)> for Point {
+    type Error = core::num::TryFromIntError;
+
+    fn try_from(point: (u32, u32)) -> Result<Self, Self::Error> {
+        let x = point.0.try_into()?;
+        let y = point.1.try_into()?;
+
+        Ok(Point::new(x, y))
     }
 }
 

--- a/embedded-graphics/src/geometry/point.rs
+++ b/embedded-graphics/src/geometry/point.rs
@@ -247,6 +247,12 @@ impl From<Point> for (i32, i32) {
     }
 }
 
+impl From<Point> for [i32; 2] {
+    fn from(other: Point) -> [i32; 2] {
+        [other.x, other.y]
+    }
+}
+
 impl From<&Point> for (i32, i32) {
     fn from(other: &Point) -> (i32, i32) {
         (other.x, other.y)
@@ -267,6 +273,36 @@ impl TryFrom<(u32, u32)> for Point {
     fn try_from(point: (u32, u32)) -> Result<Self, Self::Error> {
         let x = point.0.try_into()?;
         let y = point.1.try_into()?;
+
+        Ok(Point::new(x, y))
+    }
+}
+
+impl TryFrom<Point> for [u32; 2] {
+    type Error = core::num::TryFromIntError;
+
+    fn try_from(point: Point) -> Result<Self, Self::Error> {
+        Ok([point.x.try_into()?, point.y.try_into()?])
+    }
+}
+
+impl TryFrom<[u32; 2]> for Point {
+    type Error = core::num::TryFromIntError;
+
+    fn try_from(point: [u32; 2]) -> Result<Self, Self::Error> {
+        let x = point[0].try_into()?;
+        let y = point[1].try_into()?;
+
+        Ok(Point::new(x, y))
+    }
+}
+
+impl TryFrom<&[u32; 2]> for Point {
+    type Error = core::num::TryFromIntError;
+
+    fn try_from(point: &[u32; 2]) -> Result<Self, Self::Error> {
+        let x = point[0].try_into()?;
+        let y = point[1].try_into()?;
 
         Ok(Point::new(x, y))
     }
@@ -304,8 +340,10 @@ mod tests {
         let p = Point::new(10, 20);
 
         let tuple: (u32, u32) = p.try_into().unwrap();
+        let array: [u32; 2] = p.try_into().unwrap();
 
         assert_eq!(tuple, (10, 20));
+        assert_eq!(array, [10, 20]);
     }
 
     #[test]
@@ -313,9 +351,11 @@ mod tests {
         let p = Point::new(i32::max_value(), i32::max_value());
 
         let tuple: (u32, u32) = p.try_into().unwrap();
+        let array: [u32; 2] = p.try_into().unwrap();
 
         // Literal value taken from https://doc.rust-lang.org/std/primitive.i32.html#method.max_value
         assert_eq!(tuple, (2147483647, 2147483647));
+        assert_eq!(array, [2147483647, 2147483647]);
     }
 
     #[test]
@@ -323,8 +363,10 @@ mod tests {
         let p = Point::new(-50, -10);
 
         let tuple: Result<(u32, u32), _> = p.try_into();
+        let array: Result<[u32; 2], _> = p.try_into();
 
         assert!(tuple.is_err());
+        assert!(array.is_err());
     }
 
     #[test]
@@ -332,8 +374,10 @@ mod tests {
         let p = Point::new(i32::min_value(), i32::min_value());
 
         let tuple: Result<(u32, u32), _> = p.try_into();
+        let array: Result<[u32; 2], _> = p.try_into();
 
         assert!(tuple.is_err());
+        assert!(array.is_err());
     }
 
     #[test]

--- a/embedded-graphics/src/geometry/point.rs
+++ b/embedded-graphics/src/geometry/point.rs
@@ -359,7 +359,7 @@ mod tests {
     }
 
     #[test]
-    fn negative_u32_tuple() {
+    fn convert_negative_to_u32_tuple() {
         let p = Point::new(-50, -10);
 
         let tuple: Result<(u32, u32), _> = p.try_into();
@@ -370,7 +370,7 @@ mod tests {
     }
 
     #[test]
-    fn max_negative_u32_tuple() {
+    fn convert_i32_min_to_u32_tuple() {
         let p = Point::new(i32::min_value(), i32::min_value());
 
         let tuple: Result<(u32, u32), _> = p.try_into();

--- a/embedded-graphics/src/geometry/point.rs
+++ b/embedded-graphics/src/geometry/point.rs
@@ -305,7 +305,7 @@ mod tests {
 
         let tuple: (u32, u32) = p.try_into().unwrap();
 
-        assert_eq!(tuple, (10u32, 20u32));
+        assert_eq!(tuple, (10, 20));
     }
 
     #[test]
@@ -314,24 +314,26 @@ mod tests {
 
         let tuple: (u32, u32) = p.try_into().unwrap();
 
-        // Literal value taken from [here](https://doc.rust-lang.org/std/primitive.i32.html#method.max_value)
+        // Literal value taken from https://doc.rust-lang.org/std/primitive.i32.html#method.max_value
         assert_eq!(tuple, (2147483647, 2147483647));
     }
 
     #[test]
-    #[should_panic]
     fn negative_u32_tuple() {
         let p = Point::new(-50, -10);
 
-        let _tuple: (u32, u32) = p.try_into().unwrap();
+        let tuple: Result<(u32, u32), _> = p.try_into();
+
+        assert!(tuple.is_err());
     }
 
     #[test]
-    #[should_panic]
     fn max_negative_u32_tuple() {
         let p = Point::new(i32::min_value(), i32::min_value());
 
-        let _tuple: (u32, u32) = p.try_into().unwrap();
+        let tuple: Result<(u32, u32), _> = p.try_into();
+
+        assert!(tuple.is_err());
     }
 
     #[test]

--- a/embedded-graphics/src/geometry/size.rs
+++ b/embedded-graphics/src/geometry/size.rs
@@ -57,7 +57,7 @@ use core::ops::{Add, AddAssign, Index, Sub, SubAssign};
 /// [`Vector2<N>`]: https://docs.rs/nalgebra/0.18.0/nalgebra/base/type.Vector2.html
 /// [`Vector2`]: https://docs.rs/nalgebra/0.18.0/nalgebra/base/type.Vector2.html
 /// [Nalgebra]: https://docs.rs/nalgebra
-#[derive(Debug, Default, Copy, Clone, Eq, PartialEq)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 pub struct Size {
     /// The width.
     pub width: u32,

--- a/embedded-graphics/src/geometry/size.rs
+++ b/embedded-graphics/src/geometry/size.rs
@@ -155,6 +155,12 @@ impl From<Size> for (u32, u32) {
     }
 }
 
+impl From<Size> for [u32; 2] {
+    fn from(other: Size) -> [u32; 2] {
+        [other.width, other.height]
+    }
+}
+
 impl From<&Size> for (u32, u32) {
     fn from(other: &Size) -> (u32, u32) {
         (other.width, other.height)
@@ -212,6 +218,13 @@ mod tests {
     #[test]
     fn from_array() {
         assert_eq!(Size::from([20, 30]), Size::new(20, 30));
+    }
+
+    #[test]
+    fn to_array() {
+        let array: [u32; 2] = Size::new(20, 30).into();
+
+        assert_eq!(array, [20, 30]);
     }
 
     #[test]

--- a/embedded-graphics/src/image/image_bmp.rs
+++ b/embedded-graphics/src/image/image_bmp.rs
@@ -28,7 +28,7 @@ use tinybmp::{Bmp, BmpIterator};
 /// image.draw(&mut display)?;
 /// # Ok::<(), core::convert::Infallible>(())
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub struct ImageBmp<'a, C>
 where
     C: PixelColor + From<<C as PixelColor>::Raw>,
@@ -126,7 +126,7 @@ where
     }
 }
 
-#[derive(Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub struct ImageBmpIterator<'a, C>
 where
     C: PixelColor + From<<C as PixelColor>::Raw>,

--- a/embedded-graphics/src/image/image_raw.rs
+++ b/embedded-graphics/src/image/image_raw.rs
@@ -93,7 +93,7 @@ pub type ImageBE<'a, C> = Image<'a, C, BigEndian>;
 /// [`ImageLE`]: type.ImageLE.html
 /// [`PixelColor`]: ../pixelcolor/trait.PixelColor.html
 /// [`ByteOrder`]: ../pixelcolor/raw/trait.ByteOrder.html
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub struct Image<'a, C, BO = BigEndian>
 where
     C: PixelColor + From<<C as PixelColor>::Raw>,

--- a/embedded-graphics/src/image/image_raw.rs
+++ b/embedded-graphics/src/image/image_raw.rs
@@ -93,7 +93,7 @@ pub type ImageBE<'a, C> = Image<'a, C, BigEndian>;
 /// [`ImageLE`]: type.ImageLE.html
 /// [`PixelColor`]: ../pixelcolor/trait.PixelColor.html
 /// [`ByteOrder`]: ../pixelcolor/raw/trait.ByteOrder.html
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 pub struct Image<'a, C, BO = BigEndian>
 where
     C: PixelColor + From<<C as PixelColor>::Raw>,
@@ -244,7 +244,7 @@ where
     }
 }
 
-#[derive(Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub struct ImageIterator<'a, C, BO>
 where
     C: PixelColor + From<<C as PixelColor>::Raw>,
@@ -296,7 +296,7 @@ mod tests {
         transform::Transform,
     };
 
-    #[derive(Debug, PartialEq, Clone, Copy)]
+    #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
     struct TestColorU32(RawU32);
 
     impl PixelColor for TestColorU32 {

--- a/embedded-graphics/src/image/image_tga.rs
+++ b/embedded-graphics/src/image/image_tga.rs
@@ -29,7 +29,7 @@ use tinytga::{Tga, TgaIterator};
 /// image.draw(&mut display)?;
 /// # Ok::<(), core::convert::Infallible>(())
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub struct ImageTga<'a, C>
 where
     C: PixelColor + From<<C as PixelColor>::Raw>,
@@ -102,7 +102,7 @@ where
     }
 }
 
-#[derive(Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub struct ImageTgaIterator<'a, 'b, C>
 where
     C: PixelColor + From<<C as PixelColor>::Raw>,

--- a/embedded-graphics/src/mock_display.rs
+++ b/embedded-graphics/src/mock_display.rs
@@ -124,7 +124,7 @@ const SIZE: usize = 64;
 /// Mock display struct
 ///
 /// See the [module documentation](./index.html) for usage and examples.
-#[derive(Clone)]
+#[derive(Copy, Clone)]
 pub struct MockDisplay<C>([Option<C>; SIZE * SIZE])
 where
     C: PixelColor;

--- a/embedded-graphics/src/pixelcolor/binary_color.rs
+++ b/embedded-graphics/src/pixelcolor/binary_color.rs
@@ -48,6 +48,12 @@ pub enum BinaryColor {
     On,
 }
 
+impl Default for BinaryColor {
+    fn default() -> Self {
+        Self::Off
+    }
+}
+
 impl BinaryColor {
     /// Inverts the color.
     ///
@@ -143,6 +149,11 @@ impl From<bool> for BinaryColor {
 mod tests {
     use super::*;
     use crate::pixelcolor::{Rgb565, RgbColor};
+
+    #[test]
+    fn default_color_is_off() {
+        assert_eq!(BinaryColor::default(), BinaryColor::Off);
+    }
 
     #[test]
     fn invert_binary_color() {

--- a/embedded-graphics/src/pixelcolor/binary_color.rs
+++ b/embedded-graphics/src/pixelcolor/binary_color.rs
@@ -39,7 +39,7 @@ use crate::pixelcolor::{
 /// };
 /// assert_eq!(color, BinaryColor::On);
 /// ```
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub enum BinaryColor {
     /// Inactive pixel.
     Off,

--- a/embedded-graphics/src/pixelcolor/gray_color.rs
+++ b/embedded-graphics/src/pixelcolor/gray_color.rs
@@ -19,7 +19,7 @@ macro_rules! gray_color {
     ($type:ident, $raw_type:ident, $bpp_str:expr) => {
         #[doc = $bpp_str]
         #[doc = "grayscale color."]
-        #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
         pub struct $type($raw_type);
 
         impl $type {

--- a/embedded-graphics/src/pixelcolor/mod.rs
+++ b/embedded-graphics/src/pixelcolor/mod.rs
@@ -14,7 +14,7 @@
 //! use embedded_graphics::{egrectangle, geometry::Size, prelude::*, primitive_style};
 //!
 //! /// Color with 3 states.
-//! #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+//! #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 //! pub enum EpdColor {
 //!     White,
 //!     Black,

--- a/embedded-graphics/src/pixelcolor/raw/iter.rs
+++ b/embedded-graphics/src/pixelcolor/raw/iter.rs
@@ -5,7 +5,7 @@ use byteorder::{ByteOrder, BE, LE};
 use core::marker::PhantomData;
 
 /// Iterator over a slice of raw pixel data.
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub struct RawDataIter<'a, R, BO> {
     /// Pixel data.
     data: &'a [u8],

--- a/embedded-graphics/src/pixelcolor/raw/iter.rs
+++ b/embedded-graphics/src/pixelcolor/raw/iter.rs
@@ -5,7 +5,7 @@ use byteorder::{ByteOrder, BE, LE};
 use core::marker::PhantomData;
 
 /// Iterator over a slice of raw pixel data.
-#[derive(Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 pub struct RawDataIter<'a, R, BO> {
     /// Pixel data.
     data: &'a [u8],

--- a/embedded-graphics/src/pixelcolor/raw/mod.rs
+++ b/embedded-graphics/src/pixelcolor/raw/mod.rs
@@ -19,7 +19,7 @@
 //! use embedded_graphics::{image::Image, pixelcolor::raw::RawU4, prelude::*};
 //!
 //! /// RGBI color
-//! #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+//! #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 //! pub struct RGBI(RawU4);
 //!
 //! impl RGBI {
@@ -147,7 +147,7 @@ macro_rules! impl_raw_data {
         #[doc = "[module-level documentation]: index.html"]
         #[doc = "[`new`]: #method.new"]
         #[doc = "[`into_inner`]: trait.RawData.html#tymethod.into_inner"]
-        #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
         pub struct $type($storage_type);
 
         impl $type {
@@ -210,14 +210,14 @@ impl_raw_data!(RawU32: u32, 32, 0xFFFF_FFFF, "32 bits");
 pub trait ByteOrder: private::Sealed {}
 
 /// Little endian byte order marker.
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub enum LittleEndian {}
 
 impl ByteOrder for LittleEndian {}
 impl private::Sealed for LittleEndian {}
 
 /// Big endian byte order marker.
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub enum BigEndian {}
 
 impl ByteOrder for BigEndian {}

--- a/embedded-graphics/src/pixelcolor/rgb_color.rs
+++ b/embedded-graphics/src/pixelcolor/rgb_color.rs
@@ -70,7 +70,7 @@ macro_rules! impl_rgb_color {
         #[doc = ""]
         #[doc = "[`RgbColor`]: trait.RgbColor.html"]
         #[doc = "[module-level documentation]: index.html"]
-        #[derive(Clone, Copy, PartialEq, Eq)]
+        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Default)]
         pub struct $type($storage_type);
 
         impl $type {

--- a/embedded-graphics/src/primitives/circle.rs
+++ b/embedded-graphics/src/primitives/circle.rs
@@ -51,7 +51,7 @@ use crate::{
 ///     .draw(&mut display)?;
 /// # Ok::<(), core::convert::Infallible>(())
 /// ```
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 pub struct Circle {
     /// Center point of circle
     pub center: Point,
@@ -122,7 +122,7 @@ impl Transform for Circle {
 }
 
 /// Pixel iterator for each pixel in the circle border
-#[derive(Debug, Copy, Clone)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 pub struct StyledCircleIterator<C: PixelColor> {
     center: Point,
     radius: u32,

--- a/embedded-graphics/src/primitives/circle.rs
+++ b/embedded-graphics/src/primitives/circle.rs
@@ -51,7 +51,7 @@ use crate::{
 ///     .draw(&mut display)?;
 /// # Ok::<(), core::convert::Infallible>(())
 /// ```
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub struct Circle {
     /// Center point of circle
     pub center: Point,

--- a/embedded-graphics/src/primitives/circle.rs
+++ b/embedded-graphics/src/primitives/circle.rs
@@ -51,7 +51,7 @@ use crate::{
 ///     .draw(&mut display)?;
 /// # Ok::<(), core::convert::Infallible>(())
 /// ```
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 pub struct Circle {
     /// Center point of circle
     pub center: Point,
@@ -122,7 +122,7 @@ impl Transform for Circle {
 }
 
 /// Pixel iterator for each pixel in the circle border
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub struct StyledCircleIterator<C: PixelColor> {
     center: Point,
     radius: u32,

--- a/embedded-graphics/src/primitives/line.rs
+++ b/embedded-graphics/src/primitives/line.rs
@@ -37,7 +37,7 @@ use crate::{
 ///     .draw(&mut display)?;
 /// # Ok::<(), core::convert::Infallible>(())
 /// ```
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub struct Line {
     /// Start point
     pub start: Point,

--- a/embedded-graphics/src/primitives/line.rs
+++ b/embedded-graphics/src/primitives/line.rs
@@ -37,7 +37,7 @@ use crate::{
 ///     .draw(&mut display)?;
 /// # Ok::<(), core::convert::Infallible>(())
 /// ```
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 pub struct Line {
     /// Start point
     pub start: Point,
@@ -149,7 +149,7 @@ where
 }
 
 /// Pixel iterator for each pixel in the line
-#[derive(Debug, Clone, Copy)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 pub struct StyledLineIterator<C>
 where
     C: PixelColor,

--- a/embedded-graphics/src/primitives/line.rs
+++ b/embedded-graphics/src/primitives/line.rs
@@ -37,7 +37,7 @@ use crate::{
 ///     .draw(&mut display)?;
 /// # Ok::<(), core::convert::Infallible>(())
 /// ```
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 pub struct Line {
     /// Start point
     pub start: Point,
@@ -149,7 +149,7 @@ where
 }
 
 /// Pixel iterator for each pixel in the line
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub struct StyledLineIterator<C>
 where
     C: PixelColor,

--- a/embedded-graphics/src/primitives/rectangle.rs
+++ b/embedded-graphics/src/primitives/rectangle.rs
@@ -43,7 +43,7 @@ use crate::{
 ///     .draw(&mut display)?;
 /// # Ok::<(), core::convert::Infallible>(())
 /// ```
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 pub struct Rectangle {
     /// Top left point of the rect
     pub top_left: Point,
@@ -136,7 +136,7 @@ where
 }
 
 /// Pixel iterator for each pixel in the rect border
-#[derive(Debug, Clone, Copy)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 pub struct StyledRectangleIterator<C: PixelColor>
 where
     C: PixelColor,

--- a/embedded-graphics/src/primitives/rectangle.rs
+++ b/embedded-graphics/src/primitives/rectangle.rs
@@ -43,7 +43,7 @@ use crate::{
 ///     .draw(&mut display)?;
 /// # Ok::<(), core::convert::Infallible>(())
 /// ```
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 pub struct Rectangle {
     /// Top left point of the rect
     pub top_left: Point,
@@ -136,7 +136,7 @@ where
 }
 
 /// Pixel iterator for each pixel in the rect border
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub struct StyledRectangleIterator<C: PixelColor>
 where
     C: PixelColor,

--- a/embedded-graphics/src/primitives/rectangle.rs
+++ b/embedded-graphics/src/primitives/rectangle.rs
@@ -43,7 +43,7 @@ use crate::{
 ///     .draw(&mut display)?;
 /// # Ok::<(), core::convert::Infallible>(())
 /// ```
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub struct Rectangle {
     /// Top left point of the rect
     pub top_left: Point,

--- a/embedded-graphics/src/primitives/triangle.rs
+++ b/embedded-graphics/src/primitives/triangle.rs
@@ -60,7 +60,7 @@ use core::borrow::Borrow;
 /// # assert_eq!(tri, Triangle::new(p1, p2, p3));
 /// # assert_eq!(tri_ref, Triangle::new(p1, p2, p3));
 /// ```
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub struct Triangle {
     /// First point of the triangle
     pub p1: Point,

--- a/embedded-graphics/src/primitives/triangle.rs
+++ b/embedded-graphics/src/primitives/triangle.rs
@@ -60,7 +60,7 @@ use core::borrow::Borrow;
 /// # assert_eq!(tri, Triangle::new(p1, p2, p3));
 /// # assert_eq!(tri_ref, Triangle::new(p1, p2, p3));
 /// ```
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 pub struct Triangle {
     /// First point of the triangle
     pub p1: Point,
@@ -221,7 +221,7 @@ enum IterState {
 }
 
 /// Pixel iterator for each pixel in the triangle border
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub struct StyledTriangleIterator<C: PixelColor>
 where
     C: PixelColor,

--- a/embedded-graphics/src/primitives/triangle.rs
+++ b/embedded-graphics/src/primitives/triangle.rs
@@ -60,7 +60,7 @@ use core::borrow::Borrow;
 /// # assert_eq!(tri, Triangle::new(p1, p2, p3));
 /// # assert_eq!(tri_ref, Triangle::new(p1, p2, p3));
 /// ```
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 pub struct Triangle {
     /// First point of the triangle
     pub p1: Point,
@@ -221,7 +221,7 @@ enum IterState {
 }
 
 /// Pixel iterator for each pixel in the triangle border
-#[derive(Debug, Clone, Copy)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 pub struct StyledTriangleIterator<C: PixelColor>
 where
     C: PixelColor,

--- a/embedded-graphics/src/style/primitive_style.rs
+++ b/embedded-graphics/src/style/primitive_style.rs
@@ -14,7 +14,7 @@ use core::convert::TryFrom;
 /// [`PrimitiveStyleBuilder`]: ../style/struct.PrimitiveStyleBuilder.html
 /// [`non_exhaustive`]: https://blog.rust-lang.org/2019/12/19/Rust-1.40.0.html#[non_exhaustive]-structs,-enums,-and-variants
 /// [`primitive_style!`]: ../macro.primitive_style.html
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 #[non_exhaustive]
 pub struct PrimitiveStyle<C>
 where
@@ -142,7 +142,7 @@ where
 ///
 /// [`PrimitiveStyle`]: ./struct.PrimitiveStyle.html
 /// [`primitive_style!`]: ../macro.primitive_style.html
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 pub struct PrimitiveStyleBuilder<C>
 where
     C: PixelColor,

--- a/embedded-graphics/src/style/primitive_style.rs
+++ b/embedded-graphics/src/style/primitive_style.rs
@@ -41,11 +41,7 @@ where
 {
     /// Creates a primitive style without fill and stroke.
     pub fn new() -> Self {
-        Self {
-            fill_color: None,
-            stroke_color: None,
-            stroke_width: 0,
-        }
+        Self::default()
     }
 
     /// Creates a stroke primitive style.
@@ -81,7 +77,11 @@ where
     C: PixelColor,
 {
     fn default() -> Self {
-        Self::new()
+        Self {
+            fill_color: None,
+            stroke_color: None,
+            stroke_width: 0,
+        }
     }
 }
 
@@ -192,6 +192,23 @@ where
 mod tests {
     use super::*;
     use crate::pixelcolor::{BinaryColor, Rgb888, RgbColor};
+
+    #[test]
+    fn default_style() {
+        assert_eq!(
+            PrimitiveStyle::<BinaryColor>::default(),
+            PrimitiveStyle {
+                fill_color: None,
+                stroke_color: None,
+                stroke_width: 0,
+            }
+        );
+
+        assert_eq!(
+            PrimitiveStyle::<BinaryColor>::default(),
+            PrimitiveStyle::new()
+        );
+    }
 
     #[test]
     fn constructors() {

--- a/embedded-graphics/src/style/styled.rs
+++ b/embedded-graphics/src/style/styled.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 
 /// Styled.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 pub struct Styled<T, S> {
     /// Primitive.
     pub primitive: T,

--- a/embedded-graphics/src/style/text_style.rs
+++ b/embedded-graphics/src/style/text_style.rs
@@ -11,7 +11,7 @@ use crate::{fonts::Font, pixelcolor::PixelColor};
 /// [`non_exhaustive`]: https://blog.rust-lang.org/2019/12/19/Rust-1.40.0.html#[non_exhaustive]-structs,-enums,-and-variants
 /// [`text_style!`]: ../macro.text_style.html
 /// [`TextStyleBuilder`]: ./struct.TextStyleBuilder.html
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 #[non_exhaustive]
 pub struct TextStyle<C, F>
 where
@@ -126,7 +126,7 @@ where
 /// [`egtext!`]: ../macro.egtext.html
 /// [`Text`]: ../fonts/struct.Text.html
 /// [`TextStyle`]: ./struct.TextStyle.html
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 pub struct TextStyleBuilder<C, F>
 where
     C: PixelColor,

--- a/simulator/Cargo.toml
+++ b/simulator/Cargo.toml
@@ -35,7 +35,7 @@ required-features = ["bmp"]
 sdl2 = "0.32.2"
 
 [dependencies.embedded-graphics]
-version = "0.6.0-alpha.2"
+version = "0.6.0-alpha.3"
 features = [ "bmp", "tga" ]
 
 [dev-dependencies]

--- a/tinybmp/Cargo.toml
+++ b/tinybmp/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tinybmp"
 description = "No-std, low memory footprint BMP image loader"
-version = "0.1.2-alpha.0"
+version = "0.1.1"
 authors = ["James Waples <james@wapl.es>"]
 edition = "2018"
 repository = "https://github.com/jamwaffles/embedded-graphics/tree/master/tinybmp"

--- a/tinybmp/src/header.rs
+++ b/tinybmp/src/header.rs
@@ -10,14 +10,14 @@ use nom::{
 };
 
 /// Bitmap file type
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub enum FileType {
     /// Default "BM" magic bytes marker for most commonly encountered bitmaps
     BM,
 }
 
 /// BMP header information
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub struct Header {
     /// Bitmap file type
     pub file_type: FileType,

--- a/tinybmp/src/lib.rs
+++ b/tinybmp/src/lib.rs
@@ -44,7 +44,7 @@ use crate::header::parse_header;
 pub use crate::header::{FileType, Header};
 
 /// A BMP-format bitmap
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub struct Bmp<'a> {
     /// Image header
     pub header: Header,
@@ -128,7 +128,7 @@ impl<'a> IntoIterator for &'a Bmp<'a> {
 /// Iterator over individual BMP pixels
 ///
 /// Each pixel is returned as a `u32` regardless of the bit depth of the source image.
-#[derive(Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub struct BmpIterator<'a> {
     /// Reference to original BMP image
     bmp: &'a Bmp<'a>,

--- a/tinytga/Cargo.toml
+++ b/tinytga/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tinytga"
-version = "0.2.1-alpha.0"
+version = "0.2.0"
 description = "No-std, low memory footprint TGA image loader"
 authors = ["James Waples <james@wapl.es>"]
 edition = "2018"

--- a/tinytga/src/footer.rs
+++ b/tinytga/src/footer.rs
@@ -4,7 +4,7 @@ use nom::{bytes::complete::tag, number::complete::le_u32, IResult};
 pub const FOOTER_LEN: usize = 26;
 
 /// TGA footer structure, referenced from <http://tfc.duke.free.fr/coding/tga_specs.pdf>
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 pub struct TgaFooter {
     /// Extension area byte offset from beginning of file
     pub extension_area_offset: u32,

--- a/tinytga/src/header.rs
+++ b/tinytga/src/header.rs
@@ -10,7 +10,7 @@ use nom::{
 pub const HEADER_LEN: usize = 18;
 
 /// Image type
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub enum ImageType {
     /// Image contains no pixel data
     Empty = 0,
@@ -35,7 +35,7 @@ pub enum ImageType {
 }
 
 /// TGA header structure, referenced from <https://www.fileformat.info/format/tga/egff.htm>
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub struct TgaHeader {
     /// Image ID field length
     pub id_len: u8,

--- a/tinytga/src/lib.rs
+++ b/tinytga/src/lib.rs
@@ -26,7 +26,7 @@ pub use crate::footer::TgaFooter;
 pub use crate::header::{ImageType, TgaHeader};
 
 /// TGA image
-#[derive(Debug, Copy, Clone)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub struct Tga<'a> {
     /// TGA header
     pub header: TgaHeader,
@@ -152,7 +152,7 @@ impl<'a> IntoIterator for &'a Tga<'a> {
 /// Iterator over individual TGA pixels
 ///
 /// This can be used to build a raw image buffer to pass around
-#[derive(Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub struct TgaIterator<'a> {
     /// Reference to original TGA image
     tga: &'a Tga<'a>,

--- a/tinytga/src/packet/mod.rs
+++ b/tinytga/src/packet/mod.rs
@@ -6,7 +6,7 @@ pub use self::rle_packet::{rle_packet, RlePacket};
 use nom::{bits::complete::take, branch::alt, combinator::map, IResult};
 
 /// A Run Length Encoded (RLE) packet
-#[derive(Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub enum Packet<'a> {
     /// Data in this packet is Run Length Encoded
     RlePacket(RlePacket<'a>),

--- a/tinytga/src/packet/raw_packet.rs
+++ b/tinytga/src/packet/raw_packet.rs
@@ -6,7 +6,7 @@ use nom::{
     IResult,
 };
 
-#[derive(Debug, PartialEq)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 pub struct RawPacket<'a> {
     /// Number of pixels of this packet
     pub num_pixels: u8,

--- a/tinytga/src/packet/raw_packet.rs
+++ b/tinytga/src/packet/raw_packet.rs
@@ -6,7 +6,7 @@ use nom::{
     IResult,
 };
 
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub struct RawPacket<'a> {
     /// Number of pixels of this packet
     pub num_pixels: u8,

--- a/tinytga/src/packet/rle_packet.rs
+++ b/tinytga/src/packet/rle_packet.rs
@@ -6,7 +6,7 @@ use nom::{
     IResult,
 };
 
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub struct RlePacket<'a> {
     /// Number of pixels in this run
     pub run_length: u8,

--- a/tinytga/src/packet/rle_packet.rs
+++ b/tinytga/src/packet/rle_packet.rs
@@ -6,7 +6,7 @@ use nom::{
     IResult,
 };
 
-#[derive(Debug, PartialEq)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 pub struct RlePacket<'a> {
     /// Number of pixels in this run
     pub run_length: u8,

--- a/tinytga/src/parse_error.rs
+++ b/tinytga/src/parse_error.rs
@@ -1,5 +1,5 @@
 /// Possible parse errors
-#[derive(Debug, Copy, Clone)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub enum ParseError {
     /// An invalid color map value was encountered. Valid values are `0` (no color map) or `1`
     /// (color map included)


### PR DESCRIPTION
Hi! Thank you for helping out with Embedded Graphics development! Please:

- [x] Check that you've added passing tests and documentation
- [x] Add a simulator example(s) where applicable
- [x] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc)
- [x] Run `rustfmt` on the project
- [x] Run `./build.sh` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

TODO

- [x] Add a shit load of derives. This was a find and replace with some manual fixes where some derives couldn't be used, so some might not make sense. Closes #238.
- [x] Add fallible conversions for `(u32, u32)` and `Point`. Closes #242.
- [x] Revert dependency fudging (due to alpha version numbers in `Cargo.toml`s I think)
- [x] ~Decide whether to add the following~ - not doing it. It can be added later if it's a common usage pattern.

  ```rust
  impl TryFrom<Size> for (i32, i32) { ... }
  impl TryFrom<(i32, i32)> for Size { ... }
  ```
- [x] https://github.com/jamwaffles/embedded-graphics/pull/243#discussion_r367593226