### PR TITLE
Liberate triangle primitive from unwrap()

### DIFF
--- a/embedded-graphics/src/primitives/triangle.rs
+++ b/embedded-graphics/src/primitives/triangle.rs
@@ -13,6 +13,7 @@ use crate::{
     DrawTarget,
 };
 use core::borrow::Borrow;
+use core::cmp::{max, min};
 
 /// Triangle primitive
 ///
@@ -76,15 +77,15 @@ impl Primitive for Triangle {}
 
 impl Dimensions for Triangle {
     fn top_left(&self) -> Point {
-        let &x = [self.p1.x, self.p2.x, self.p3.x].iter().min().unwrap();
-        let &y = [self.p1.y, self.p2.y, self.p3.y].iter().min().unwrap();
+        let x = min(min(self.p1.x, self.p2.x), self.p3.x);
+        let y = min(min(self.p1.y, self.p2.y), self.p3.y);
 
         Point::new(x, y)
     }
 
     fn bottom_right(&self) -> Point {
-        let &x = [self.p1.x, self.p2.x, self.p3.x].iter().max().unwrap();
-        let &y = [self.p1.y, self.p2.y, self.p3.y].iter().max().unwrap();
+        let x = max(max(self.p1.x, self.p2.x), self.p3.x);
+        let y = max(max(self.p1.y, self.p2.y), self.p3.y);
 
         Point::new(x, y)
     }


### PR DESCRIPTION
Signed-off-by: Daniel Egger <daniel@eggers-club.de>

Hi! Thank you for helping out with Embedded Graphics development! Please:

- [ ] Check that you've added passing tests and documentation
- [ ] Add a simulator example(s) where applicable
- [x] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc)
- [x] Run `rustfmt` on the project
- [x] Run `./build.sh` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

Building up an array, iterator, iterating over it with the min/max function and calling unwrap() on the result just to find the minimum or maxmim of three values seemed like overkill so I replace them with two comparisons each instead.