### PR TITLE
Get rid of an unnecessary unwrap by assigning the checked value to a var

### DIFF
--- a/embedded-graphics/src/primitives/line.rs
+++ b/embedded-graphics/src/primitives/line.rs
@@ -171,7 +171,7 @@ impl<C: PixelColor> Iterator for StyledLineIterator<C> {
 
     fn next(&mut self) -> Option<Self::Item> {
         // return none if stroke color is none
-        self.style.stroke_color?;
+        let stroke_color = self.style.stroke_color?;
 
         if !self.stop {
             let point = self.start;
@@ -189,7 +189,7 @@ impl<C: PixelColor> Iterator for StyledLineIterator<C> {
                 self.start += Point::new(0, self.direction.y);
             }
 
-            Some(Pixel(point, self.style.stroke_color.unwrap()))
+            Some(Pixel(point, stroke_color))
         } else {
             None
         }


### PR DESCRIPTION
Signed-off-by: Daniel Egger <daniel@eggers-club.de>

Hi! Thank you for helping out with Embedded Graphics development! Please:

- [ ] Check that you've added passing tests and documentation
- [ ] Add a simulator example(s) where applicable
- [ ] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc)
- [x] Run `rustfmt` on the project
- [x] Run `./build.sh` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

Get rid of an unnecessary unwrap by assigning the checked value to a variable. Doesn't really seem CHANGELOG worthy.