### PR TITLE
Change PR template to mention public API

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@ Hi! Thank you for helping out with Embedded Graphics development! Please:
 
 - [ ] Check that you've added passing tests and documentation
 - [ ] Add a simulator example(s) where applicable
-- [ ] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc)
+- [ ] Add a `CHANGELOG.md` entry if you're adding/fixing/changing the **public** API in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc)
 - [ ] Run `rustfmt` on the project
 - [ ] Run `./build.sh` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@ Hi! Thank you for helping out with Embedded Graphics development! Please:
 
 - [ ] Check that you've added passing tests and documentation
 - [ ] Add a simulator example(s) where applicable
-- [ ] Add a `CHANGELOG.md` entry if you're adding/fixing/changing the **public** API in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc)
+- [ ] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) if your changes affect the **public API**
 - [ ] Run `rustfmt` on the project
 - [ ] Run `./build.sh` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.
 


### PR DESCRIPTION
From https://github.com/jamwaffles/embedded-graphics/pull/251#pullrequestreview-355543845, the changelog from now on should probably just have any publicly changing items added to it.