### PR TITLE
add draw_image to allow optimizations

### DIFF
--- a/embedded-graphics/CHANGELOG.md
+++ b/embedded-graphics/CHANGELOG.md
@@ -6,6 +6,10 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+- Added `draw_image` to `DrawTarget` trait with default implementation.
+
 ## [0.6.0-beta.1] - 2020-02-17
 
 ### Added

--- a/embedded-graphics/src/draw_target.rs
+++ b/embedded-graphics/src/draw_target.rs
@@ -1,6 +1,7 @@
 use crate::{
     drawable::{self, Drawable},
-    geometry::{Point, Size},
+    geometry::{Dimensions, Point, Size},
+    image::{Image, ImageDimensions, IntoPixelIter},
     pixelcolor::PixelColor,
     primitives::{self, Primitive},
     style::{PrimitiveStyle, Styled},
@@ -339,5 +340,27 @@ where
         item: &Styled<primitives::Circle, PrimitiveStyle<C>>,
     ) -> Result<(), Self::Error> {
         self.draw_iter(item)
+    }
+
+    /// Draws an image with known size
+    ///
+    /// This default trait method can be overridden if a display provides hardware-accelerated
+    /// methods for drawing an image with known size.
+    ///
+    /// # Caution
+    ///
+    /// This method should not be called directly from application code. It is used to define the
+    /// internals of the [`draw`] method used for the [`Image`] primitive. To draw an
+    /// image, call [`draw`] on a `Image` object.
+    ///
+    /// [`Image`]: ../image/struct.Image.html
+    /// [`draw`]: ./trait.DrawTarget.html#method.draw
+    fn draw_image<'a, 'b, I>(&mut self, item: &'a Image<'b, I, C>) -> Result<(), Self::Error>
+    where
+        &'b I: IntoPixelIter<C>,
+        I: ImageDimensions,
+        C: PixelColor + From<<C as PixelColor>::Raw>,
+    {
+        self.draw_iter(item.into_iter())
     }
 }

--- a/embedded-graphics/src/draw_target.rs
+++ b/embedded-graphics/src/draw_target.rs
@@ -1,6 +1,6 @@
 use crate::{
     drawable::{self, Drawable},
-    geometry::{Dimensions, Point, Size},
+    geometry::{Point, Size},
     image::{Image, ImageDimensions, IntoPixelIter},
     pixelcolor::PixelColor,
     primitives::{self, Primitive},

--- a/embedded-graphics/src/image/mod.rs
+++ b/embedded-graphics/src/image/mod.rs
@@ -188,10 +188,11 @@ impl<I, C> Transform for Image<'_, I, C> {
 impl<'a, 'b, I, C> Drawable<C> for &'a Image<'b, I, C>
 where
     &'b I: IntoPixelIter<C>,
+    I: ImageDimensions,
     C: PixelColor + From<<C as PixelColor>::Raw>,
 {
     fn draw<D: DrawTarget<C>>(self, display: &mut D) -> Result<(), D::Error> {
-        display.draw_iter(self.into_iter())
+        display.draw_image(self)
     }
 }
 


### PR DESCRIPTION
Hi! Thank you for helping out with Embedded Graphics development! Please:

- [x] Check that you've added passing tests and documentation
- [ ] Add a simulator example(s) where applicable
- [x] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) and appropriate crate (`embedded-graphics`, `simulator`, `tinytga`, `tinybmp`) if your changes affect the **public API**
- [x] Run `rustfmt` on the project
- [x] Run `./build.sh` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

Individual primitives have `draw_<primitive>` calls in the `DrawTarget` trait to allow optimizing where applicable. Images however always just call `draw_pixel` which results in extremely sub-par performance with most drivers.

This adds `draw_image` to the `DrawTarget` trait to enable drivers to optimize rednering, especially given that images are rectangular.