### PR TITLE
Add automatic color conversion for SimulatorDisplay

### DIFF
--- a/simulator/CHANGELOG.md
+++ b/simulator/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ## [Unreleased] - ReleaseDate
 
+### Changed
+
+- **(breaking)** Change `DrawTarget` implementation for `SimulatorDisplay` to automatically convert colors which implement `Into<C>`.
+
 ## [0.2.0-beta.2] - 2020-02-17
 
 ### Added

--- a/simulator/README.md
+++ b/simulator/README.md
@@ -23,7 +23,7 @@ use embedded_graphics::{
 use embedded_graphics_simulator::{BinaryColorTheme, SimulatorDisplay, WindowBuilder};
 
 fn main() -> Result<(), core::convert::Infallible> {
-    let mut display = SimulatorDisplay::new(Size::new(129, 129));
+    let mut display: SimulatorDisplay<BinaryColor> = SimulatorDisplay::new(Size::new(129, 129));
 
     let line_style = PrimitiveStyle::with_stroke(BinaryColor::On, 1);
 

--- a/simulator/examples/analog-clock.rs
+++ b/simulator/examples/analog-clock.rs
@@ -139,7 +139,8 @@ fn draw_digital_clock<'a>(time_str: &'a str) -> impl Iterator<Item = Pixel<Binar
 }
 
 fn main() -> Result<(), core::convert::Infallible> {
-    let mut display = SimulatorDisplay::new(Size::new(DISP_SIZE as u32, DISP_SIZE as u32));
+    let mut display: SimulatorDisplay<BinaryColor> =
+        SimulatorDisplay::new(Size::new(DISP_SIZE as u32, DISP_SIZE as u32));
     let mut window = WindowBuilder::new(&display).title("Clock").scale(2).build();
 
     'running: loop {

--- a/simulator/examples/chaining.rs
+++ b/simulator/examples/chaining.rs
@@ -10,7 +10,7 @@ use embedded_graphics::{
 use embedded_graphics_simulator::{BinaryColorTheme, SimulatorDisplay, WindowBuilder};
 
 fn main() -> Result<(), core::convert::Infallible> {
-    let mut display = SimulatorDisplay::new(Size::new(129, 129));
+    let mut display: SimulatorDisplay<BinaryColor> = SimulatorDisplay::new(Size::new(129, 129));
     let mut objects = Circle::new(Point::new(64, 64), 64)
         .into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 1))
         .into_iter()

--- a/simulator/examples/custom-font/main.rs
+++ b/simulator/examples/custom-font/main.rs
@@ -17,7 +17,7 @@ impl Font for SevenSegmentFont {
 }
 
 fn main() -> Result<(), core::convert::Infallible> {
-    let mut display = SimulatorDisplay::new(Size::new(128, 128));
+    let mut display: SimulatorDisplay<BinaryColor> = SimulatorDisplay::new(Size::new(128, 128));
 
     let position = Point::new(27, 22);
     let row_offset = Point::new(0, 44);

--- a/simulator/examples/fill-macros.rs
+++ b/simulator/examples/fill-macros.rs
@@ -8,7 +8,7 @@ use embedded_graphics_simulator::{SimulatorDisplay, WindowBuilder};
 static CIRCLE_SIZE: i32 = 32;
 
 fn main() -> Result<(), core::convert::Infallible> {
-    let mut display = SimulatorDisplay::new(Size::new(384, 128));
+    let mut display: SimulatorDisplay<BinaryColor> = SimulatorDisplay::new(Size::new(384, 128));
 
     egcircle!(
         center = (CIRCLE_SIZE, CIRCLE_SIZE),

--- a/simulator/examples/fill.rs
+++ b/simulator/examples/fill.rs
@@ -9,7 +9,7 @@ use embedded_graphics_simulator::{SimulatorDisplay, WindowBuilder};
 static CIRCLE_SIZE: i32 = 32;
 
 fn main() -> Result<(), core::convert::Infallible> {
-    let mut display = SimulatorDisplay::new(Size::new(304, 128));
+    let mut display: SimulatorDisplay<BinaryColor> = SimulatorDisplay::new(Size::new(304, 128));
 
     let stroke = PrimitiveStyle::with_stroke(BinaryColor::On, 1);
 

--- a/simulator/examples/fonts.rs
+++ b/simulator/examples/fonts.rs
@@ -9,7 +9,7 @@ use embedded_graphics::{
 use embedded_graphics_simulator::{SimulatorDisplay, WindowBuilder};
 
 fn main() -> Result<(), core::convert::Infallible> {
-    let mut display = SimulatorDisplay::new(Size::new(256, 128));
+    let mut display: SimulatorDisplay<BinaryColor> = SimulatorDisplay::new(Size::new(256, 128));
 
     // Show smallest font with black font on white background (default value for fonts)
     Text::new("Hello World! - default style 6x8", Point::new(15, 15))
@@ -52,7 +52,7 @@ fn main() -> Result<(), core::convert::Infallible> {
     egtext!(
         text = "Hello 12x16!",
         top_left = (15, 105),
-        style = text_style!(font = Font12x16)
+        style = text_style!(font = Font12x16, text_color = BinaryColor::On)
     )
     .draw(&mut display)?;
 

--- a/simulator/examples/hello.rs
+++ b/simulator/examples/hello.rs
@@ -8,7 +8,7 @@ use embedded_graphics::{
 use embedded_graphics_simulator::{BinaryColorTheme, SimulatorDisplay, WindowBuilder};
 
 fn main() -> Result<(), core::convert::Infallible> {
-    let mut display = SimulatorDisplay::new(Size::new(129, 129));
+    let mut display: SimulatorDisplay<BinaryColor> = SimulatorDisplay::new(Size::new(129, 129));
 
     let line_style = PrimitiveStyle::with_stroke(BinaryColor::On, 1);
 

--- a/simulator/examples/input-handling.rs
+++ b/simulator/examples/input-handling.rs
@@ -36,7 +36,7 @@ fn move_circle(
 }
 
 fn main() -> Result<(), core::convert::Infallible> {
-    let mut display = SimulatorDisplay::new(Size::new(800, 480));
+    let mut display: SimulatorDisplay<Rgb888> = SimulatorDisplay::new(Size::new(800, 480));
     let mut window = WindowBuilder::new(&display)
         .title("Click to move circle")
         .build();

--- a/simulator/examples/offscreen.rs
+++ b/simulator/examples/offscreen.rs
@@ -4,7 +4,7 @@ use embedded_graphics::{
 use embedded_graphics_simulator::{SimulatorDisplay, WindowBuilder};
 
 fn main() -> Result<(), core::convert::Infallible> {
-    let mut display = SimulatorDisplay::new(Size::new(32, 32));
+    let mut display: SimulatorDisplay<BinaryColor> = SimulatorDisplay::new(Size::new(32, 32));
 
     // Outline
     Rectangle::new(Point::new(0, 0), Point::new(16, 16))

--- a/simulator/examples/stroke.rs
+++ b/simulator/examples/stroke.rs
@@ -9,7 +9,7 @@ use embedded_graphics_simulator::{SimulatorDisplay, WindowBuilder};
 const PADDING: i32 = 16;
 
 fn main() -> Result<(), core::convert::Infallible> {
-    let mut display = SimulatorDisplay::new(Size::new(320, 256));
+    let mut display: SimulatorDisplay<BinaryColor> = SimulatorDisplay::new(Size::new(320, 256));
 
     let thin_stroke = PrimitiveStyle::with_stroke(BinaryColor::On, 1);
     let medium_stroke = PrimitiveStyle::with_stroke(BinaryColor::On, 3);

--- a/simulator/examples/transparent-fonts.rs
+++ b/simulator/examples/transparent-fonts.rs
@@ -5,7 +5,7 @@ use embedded_graphics::{
 use embedded_graphics_simulator::{SimulatorDisplay, WindowBuilder};
 
 fn main() -> Result<(), core::convert::Infallible> {
-    let mut display = SimulatorDisplay::new(Size::new(256, 128));
+    let mut display: SimulatorDisplay<Rgb565> = SimulatorDisplay::new(Size::new(256, 128));
 
     egcircle!(
         center = (20, 20),

--- a/simulator/examples/triangles.rs
+++ b/simulator/examples/triangles.rs
@@ -6,7 +6,7 @@ use embedded_graphics_simulator::{SimulatorDisplay, WindowBuilder};
 const PAD: i32 = 10;
 
 fn main() -> Result<(), core::convert::Infallible> {
-    let mut display = SimulatorDisplay::new(Size::new(512, 128));
+    let mut display: SimulatorDisplay<BinaryColor> = SimulatorDisplay::new(Size::new(512, 128));
 
     let style = PrimitiveStyle::with_stroke(BinaryColor::On, 1);
 

--- a/simulator/src/display.rs
+++ b/simulator/src/display.rs
@@ -62,14 +62,14 @@ where
     }
 }
 
-impl<CP, CD> DrawTarget<CP> for SimulatorDisplay<CD>
+impl<PixelC, DisplayC> DrawTarget<PixelC> for SimulatorDisplay<DisplayC>
 where
-    CP: PixelColor + Into<CD>,
-    CD: PixelColor,
+    PixelC: PixelColor + Into<DisplayC>,
+    DisplayC: PixelColor,
 {
     type Error = core::convert::Infallible;
 
-    fn draw_pixel(&mut self, pixel: Pixel<CP>) -> Result<(), Self::Error> {
+    fn draw_pixel(&mut self, pixel: Pixel<PixelC>) -> Result<(), Self::Error> {
         let Pixel(point, color) = pixel;
 
         if let Some(index) = self.point_to_index(point) {

--- a/simulator/src/display.rs
+++ b/simulator/src/display.rs
@@ -62,17 +62,18 @@ where
     }
 }
 
-impl<C> DrawTarget<C> for SimulatorDisplay<C>
+impl<CP, CD> DrawTarget<CP> for SimulatorDisplay<CD>
 where
-    C: PixelColor,
+    CP: PixelColor + Into<CD>,
+    CD: PixelColor,
 {
     type Error = core::convert::Infallible;
 
-    fn draw_pixel(&mut self, pixel: Pixel<C>) -> Result<(), Self::Error> {
+    fn draw_pixel(&mut self, pixel: Pixel<CP>) -> Result<(), Self::Error> {
         let Pixel(point, color) = pixel;
 
         if let Some(index) = self.point_to_index(point) {
-            self.pixels[index] = color;
+            self.pixels[index] = color.into();
         }
 
         Ok(())

--- a/simulator/src/lib.rs
+++ b/simulator/src/lib.rs
@@ -44,12 +44,12 @@
 //! use std::time::Duration;
 //!
 //! fn main() {
-//!     let mut display = SimulatorDisplay::new(Size::new(128, 64));
+//!     let mut display: SimulatorDisplay<BinaryColor> = SimulatorDisplay::new(Size::new(128, 64));
 //!     let mut window = WindowBuilder::new(&display)
 //!         .theme(BinaryColorTheme::OledBlue)
 //!         .build();
 //!
-//!     egtext!(text = "Hello World!", top_left = Point::zero(), style = text_style!(font = Font6x8)).draw(&mut display);
+//!     egtext!(text = "Hello World!", top_left = Point::zero(), style = text_style!(font = Font6x8, text_color = BinaryColor::On)).draw(&mut display);
 //!
 //!     egcircle!(center = (96, 32), radius = 31, style = primitive_style!(stroke_color = BinaryColor::On)).draw(&mut display);
 //!

--- a/simulator/src/window_builder.rs
+++ b/simulator/src/window_builder.rs
@@ -18,6 +18,7 @@ impl WindowBuilder {
     pub fn new<C>(display: &SimulatorDisplay<C>) -> Self
     where
         C: PixelColor,
+        SimulatorDisplay<C>: DrawTarget<C>,
     {
         Self {
             display_size: display.size(),


### PR DESCRIPTION
Hi! Thank you for helping out with Embedded Graphics development! Please:

- [x] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) and appropriate crate (`embedded-graphics`, `simulator`, `tinytga`, `tinybmp`) if your changes affect the **public API**
- [x] Run `rustfmt` on the project
- [x] Run `./build.sh` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

The simulator used to implement `DrawTarget` for all `C`s that can be converted `Into` the color type used to build the `SimulatorDisplay`. This feature was somehow lost during the refactoring of the simulator some time ago. This PR reimplements that feature.

After this changes an explicit type annotation on the `SimulatorDisplay` variables is required. But IMO that's beneficial because this way the type of the framebuffer data is always unambiguously defined.
