### PR TITLE
Unstyled iterator for lines

### DIFF
--- a/embedded-graphics/CHANGELOG.md
+++ b/embedded-graphics/CHANGELOG.md
@@ -6,6 +6,10 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 
 ## [Unreleased] - ReleaseDate
 
+### Fixed
+
+- [#262](https://github.com/jamwaffles/embedded-graphics/pull/262) `Triangle`s with a fill color but no stroke color are now rendered instead of not rendered at all.
+
 ### Added
 
 - Added `draw_image` to `DrawTarget` trait with default implementation.

--- a/embedded-graphics/CHANGELOG.md
+++ b/embedded-graphics/CHANGELOG.md
@@ -9,6 +9,8 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 ### Fixed
 
 - [#262](https://github.com/jamwaffles/embedded-graphics/pull/262) `Triangle`s with a fill color but no stroke color are now rendered instead of not rendered at all.
+- [#262](https://github.com/jamwaffles/embedded-graphics/pull/262) A triangle with a different stroke and fill color now renders its left-most border with the stroke color, instead of fill color
+- [#262](https://github.com/jamwaffles/embedded-graphics/pull/262) Triangles with a stroke width of 0 no longer draw the triangle outline and draw nothing as intended.
 
 ### Added
 

--- a/embedded-graphics/CHANGELOG.md
+++ b/embedded-graphics/CHANGELOG.md
@@ -10,7 +10,7 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 
 - [#262](https://github.com/jamwaffles/embedded-graphics/pull/262) `Triangle`s with a fill color but no stroke color are now rendered instead of not rendered at all.
 - [#262](https://github.com/jamwaffles/embedded-graphics/pull/262) A triangle with a different stroke and fill color now renders its left-most border with the stroke color, instead of fill color
-- [#262](https://github.com/jamwaffles/embedded-graphics/pull/262) Triangles with a stroke width of 0 no longer draw the triangle outline and draw nothing as intended.
+- [#262](https://github.com/jamwaffles/embedded-graphics/pull/262) Triangles and lines with a stroke width of 0 (and no fill for triangles) are no longer drawn.
 
 ### Added
 

--- a/embedded-graphics/src/primitives/line.rs
+++ b/embedded-graphics/src/primitives/line.rs
@@ -43,9 +43,7 @@ use crate::{
 /// Call `.into_iter()` on a `Line` to get an iterator over all points along it.
 ///
 /// ```rust
-/// use embedded_graphics::{
-///     primitives::Line, prelude::*
-/// };
+/// use embedded_graphics::{prelude::*, primitives::Line};
 ///
 /// let line = Line::new(Point::new(10, 10), Point::new(20, 20));
 ///

--- a/embedded-graphics/src/primitives/line.rs
+++ b/embedded-graphics/src/primitives/line.rs
@@ -287,7 +287,7 @@ mod tests {
         let line =
             Line::new(start, end).into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 0));
 
-        assert_eq!(line.into_iter().next(), None);
+        assert!(line.into_iter().eq(core::iter::empty()));
     }
 
     #[test]

--- a/embedded-graphics/src/primitives/line.rs
+++ b/embedded-graphics/src/primitives/line.rs
@@ -211,6 +211,11 @@ impl<C: PixelColor> Iterator for StyledLineIterator<C> {
     type Item = Pixel<C>;
 
     fn next(&mut self) -> Option<Self::Item> {
+        // Break if stroke width is zero
+        if self.style.stroke_width == 0 {
+            return None;
+        }
+
         // Return none if stroke color is none
         let stroke_color = self.style.stroke_color?;
 
@@ -272,6 +277,17 @@ mod tests {
         let end = Point::new(10, 10);
         let expected = [];
         test_expected_line(start, end, &expected);
+    }
+
+    #[test]
+    fn no_stroke_width_no_line() {
+        let start = Point::new(2, 3);
+        let end = Point::new(3, 2);
+
+        let line =
+            Line::new(start, end).into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 0));
+
+        assert_eq!(line.into_iter().next(), None);
     }
 
     #[test]

--- a/embedded-graphics/src/primitives/triangle.rs
+++ b/embedded-graphics/src/primitives/triangle.rs
@@ -363,7 +363,11 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{pixelcolor::BinaryColor, style::PrimitiveStyleBuilder};
+    use crate::{
+        mock_display::MockDisplay,
+        pixelcolor::{BinaryColor, Rgb888, RgbColor},
+        style::PrimitiveStyleBuilder,
+    };
 
     #[test]
     fn dimensions() {
@@ -383,11 +387,42 @@ mod tests {
 
     #[test]
     fn unfilled_no_stroke_width_no_triangle() {
-        let mut tri = Triangle::new(Point::new(2, 2), Point::new(2, 4), Point::new(2, 4))
+        let mut tri = Triangle::new(Point::new(2, 2), Point::new(4, 2), Point::new(2, 4))
             .into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 0))
             .into_iter();
 
         assert_eq!(tri.next(), None);
+    }
+
+    #[test]
+    fn stroke_fill_colors() {
+        let mut display: MockDisplay<Rgb888> = MockDisplay::new();
+
+        Triangle::new(Point::new(2, 2), Point::new(8, 2), Point::new(2, 8))
+            .into_styled(
+                PrimitiveStyleBuilder::new()
+                    .stroke_width(1)
+                    .stroke_color(Rgb888::RED)
+                    .fill_color(Rgb888::GREEN)
+                    .build(),
+            )
+            .draw(&mut display)
+            .unwrap();
+
+        assert_eq!(
+            display,
+            MockDisplay::from_pattern(&[
+                "          ",
+                "          ",
+                "  RRRRRRR ",
+                "  RGGGGR  ",
+                "  RGGGR   ",
+                "  RGGR    ",
+                "  RGR     ",
+                "  RR      ",
+                "  R       ",
+            ])
+        );
     }
 
     #[test]

--- a/embedded-graphics/src/primitives/triangle.rs
+++ b/embedded-graphics/src/primitives/triangle.rs
@@ -194,9 +194,9 @@ where
     fn into_iter(self) -> Self::IntoIter {
         let (v1, v2, v3) = sort_yx(self.primitive.p1, self.primitive.p2, self.primitive.p3);
 
-        let mut line_a = Line::new(v1, v2).into_iter();
-        let mut line_b = Line::new(v1, v3).into_iter();
-        let mut line_c = Line::new(v2, v3).into_iter();
+        let mut line_a = LineIterator::new(&Line::new(v1, v2));
+        let mut line_b = LineIterator::new(&Line::new(v1, v3));
+        let mut line_c = LineIterator::new(&Line::new(v2, v3));
 
         let next_ac = line_a.next().or_else(|| line_c.next());
         let next_b = line_b.next();

--- a/embedded-graphics/src/primitives/triangle.rs
+++ b/embedded-graphics/src/primitives/triangle.rs
@@ -357,8 +357,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::pixelcolor::BinaryColor;
-    use crate::style::PrimitiveStyleBuilder;
+    use crate::{pixelcolor::BinaryColor, style::PrimitiveStyleBuilder};
 
     #[test]
     fn dimensions() {

--- a/embedded-graphics/src/primitives/triangle.rs
+++ b/embedded-graphics/src/primitives/triangle.rs
@@ -103,7 +103,7 @@ impl Triangle {
         Triangle { p1, p2, p3 }
     }
 
-    /// Create sa new triangle from an array of points.
+    /// Creates a new triangle from an array of points.
     ///
     /// This supports both [`Point`]s, as well as anything that implements `Into<Point>` like
     /// `(i32, i32)`.
@@ -284,7 +284,7 @@ where
                         } else if n_ac.y > n_b.y {
                             self.update_b()
                         } else {
-                            let (l, r) = sort_two_yx(ac, b);
+                            let (l, r) = sort_two_yx(n_ac, n_b);
                             IterState::LeftRight(l, r)
                         }
                     }

--- a/embedded-graphics/src/primitives/triangle.rs
+++ b/embedded-graphics/src/primitives/triangle.rs
@@ -362,6 +362,7 @@ where
 mod tests {
     use super::*;
     use crate::pixelcolor::BinaryColor;
+    use crate::style::PrimitiveStyleBuilder;
 
     #[test]
     fn dimensions() {
@@ -393,6 +394,27 @@ mod tests {
     fn it_draws_unfilled_tri_line_y() {
         let mut tri = Triangle::new(Point::new(2, 2), Point::new(2, 4), Point::new(2, 4))
             .into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 1))
+            .into_iter();
+
+        // Nodes are returned twice. first line a and b yield the same point.
+        // After that line a ends where line c starts.
+        assert_eq!(tri.next(), Some(Pixel(Point::new(2, 2), BinaryColor::On)));
+        assert_eq!(tri.next(), Some(Pixel(Point::new(2, 2), BinaryColor::On)));
+        assert_eq!(tri.next(), Some(Pixel(Point::new(2, 3), BinaryColor::On)));
+        assert_eq!(tri.next(), Some(Pixel(Point::new(2, 3), BinaryColor::On)));
+        assert_eq!(tri.next(), Some(Pixel(Point::new(2, 4), BinaryColor::On)));
+        assert_eq!(tri.next(), Some(Pixel(Point::new(2, 4), BinaryColor::On)));
+        assert_eq!(tri.next(), None);
+    }
+
+    #[test]
+    fn it_draws_filled_strokeless_tri() {
+        let mut tri = Triangle::new(Point::new(2, 2), Point::new(2, 4), Point::new(2, 4))
+            .into_styled(
+                PrimitiveStyleBuilder::new()
+                    .fill_color(BinaryColor::On)
+                    .build(),
+            )
             .into_iter();
 
         // Nodes are returned twice. first line a and b yield the same point.

--- a/embedded-graphics/src/primitives/triangle.rs
+++ b/embedded-graphics/src/primitives/triangle.rs
@@ -315,8 +315,13 @@ where
             match self.points() {
                 IterState::Border(point) => {
                     // Draw edges of the triangle
-                    if let Some(color) = self.style.stroke_color.or_else(|| self.style.fill_color) {
-                        if point.x >= 0 && point.y >= 0 {
+                    if point.x >= 0 && point.y >= 0 {
+                        if self.style.stroke_width > 0 {
+                            if let Some(color) = self.style.stroke_color {
+                                self.x += 1;
+                                return Some(Pixel(point, color));
+                            }
+                        } else if let Some(color) = self.style.fill_color {
                             self.x += 1;
                             return Some(Pixel(point, color));
                         }
@@ -374,6 +379,15 @@ mod tests {
         assert_eq!(moved.p2, Point::new(5, 14));
         assert_eq!(moved.p3, Point::new(-5, 14));
         assert_eq!(moved.size(), Size::new(10, 15));
+    }
+
+    #[test]
+    fn unfilled_no_stroke_width_no_triangle() {
+        let mut tri = Triangle::new(Point::new(2, 2), Point::new(2, 4), Point::new(2, 4))
+            .into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 0))
+            .into_iter();
+
+        assert_eq!(tri.next(), None);
     }
 
     #[test]

--- a/embedded-graphics/src/primitives/triangle.rs
+++ b/embedded-graphics/src/primitives/triangle.rs
@@ -317,13 +317,13 @@ where
                     // Draw edges of the triangle
                     if point.x >= 0 && point.y >= 0 {
                         if self.style.stroke_width > 0 {
-                            if let Some(color) = self.style.stroke_color {
+                            if let Some(stroke_color) = self.style.stroke_color {
                                 self.x += 1;
-                                return Some(Pixel(point, color));
+                                return Some(Pixel(point, stroke_color));
                             }
-                        } else if let Some(color) = self.style.fill_color {
+                        } else if let Some(fill_color) = self.style.fill_color {
                             self.x += 1;
-                            return Some(Pixel(point, color));
+                            return Some(Pixel(point, fill_color));
                         }
                     }
                 }

--- a/embedded-graphics/src/primitives/triangle.rs
+++ b/embedded-graphics/src/primitives/triangle.rs
@@ -454,23 +454,24 @@ mod tests {
 
     #[test]
     fn it_draws_filled_strokeless_tri() {
-        let mut tri = Triangle::new(Point::new(2, 2), Point::new(2, 4), Point::new(2, 4))
-            .into_styled(
-                PrimitiveStyleBuilder::new()
-                    .fill_color(BinaryColor::On)
-                    .build(),
-            )
-            .into_iter();
+        let mut display: MockDisplay<BinaryColor> = MockDisplay::new();
 
-        // Nodes are returned twice. first line a and b yield the same point.
-        // After that line a ends where line c starts.
-        assert_eq!(tri.next(), Some(Pixel(Point::new(2, 2), BinaryColor::On)));
-        assert_eq!(tri.next(), Some(Pixel(Point::new(2, 2), BinaryColor::On)));
-        assert_eq!(tri.next(), Some(Pixel(Point::new(2, 3), BinaryColor::On)));
-        assert_eq!(tri.next(), Some(Pixel(Point::new(2, 3), BinaryColor::On)));
-        assert_eq!(tri.next(), Some(Pixel(Point::new(2, 4), BinaryColor::On)));
-        assert_eq!(tri.next(), Some(Pixel(Point::new(2, 4), BinaryColor::On)));
-        assert_eq!(tri.next(), None);
+        Triangle::new(Point::new(2, 2), Point::new(2, 4), Point::new(4, 2))
+            .into_styled(PrimitiveStyle::with_fill(BinaryColor::On))
+            .draw(&mut display)
+            .unwrap();
+
+        #[rustfmt::skip]
+        assert_eq!(
+            display,
+            MockDisplay::from_pattern(&[
+                "     ",
+                "     ",
+                "  ###",
+                "  ## ",
+                "  #  ",
+            ])
+        );
     }
 
     #[test]

--- a/embedded-graphics/src/primitives/triangle.rs
+++ b/embedded-graphics/src/primitives/triangle.rs
@@ -317,6 +317,7 @@ where
                     // Draw edges of the triangle
                     if let Some(color) = self.style.stroke_color.or_else(|| self.style.fill_color) {
                         if point.x >= 0 && point.y >= 0 {
+                            self.x += 1;
                             return Some(Pixel(point, color));
                         }
                     }


### PR DESCRIPTION
Hi! Thank you for helping out with Embedded Graphics development! Please:

- [x] Check that you've added passing tests and documentation
- [x] Add a simulator example(s) where applicable
- [x] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) and appropriate crate (`embedded-graphics`, `simulator`, `tinytga`, `tinybmp`) if your changes affect the **public API**
- [x] Run `rustfmt` on the project
- [x] Run `./build.sh` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

* Adds `IntoIterator` impl for `&Line`, alongside the impl for `Styled<Line>`
* Uses unstyled line iterator in `Triangle` so triangles without stroke can be rendered - closes #260 

Questions:

1. [ ] Is this the right direction, or should we add a `points()` or `iter()` method to the `Primitive` trait? 
1. [ ] If we continue down this path of adding `IntoIterator` impls, should we add a bound to `Primitive` so it becomes `Primitive: IntoIter`? I can't remember if this is possible with all the associated type stuff
1. [ ] Should we do all the other primitives, ~and if so should we do it in this PR?~ - if yes, let's do it in another PR so this one can focus on closing #260 
