### PR TITLE
ensure fill color is used for line without stroke

### DIFF
--- a/embedded-graphics/CHANGELOG.md
+++ b/embedded-graphics/CHANGELOG.md
@@ -10,6 +10,10 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 
 - Added `draw_image` to `DrawTarget` trait with default implementation.
 
+### Fixed
+
+- #260 - triangle fill now works as expected
+
 ## [0.6.0-beta.1] - 2020-02-17
 
 ### Added

--- a/embedded-graphics/src/primitives/line.rs
+++ b/embedded-graphics/src/primitives/line.rs
@@ -46,7 +46,20 @@ pub struct Line {
     pub end: Point,
 }
 
-impl Primitive for Line {}
+impl Primitive for Line {
+    /// Converts this primitive into a `Styled`.
+    fn into_styled<C>(self, style: PrimitiveStyle<C>) -> Styled<Self, PrimitiveStyle<C>>
+    where
+        C: PixelColor,
+        Self: Sized,
+    {
+        // ensure fill color is honored if stroke is not set
+        let mut new_style = style.clone();
+        new_style.stroke_color = style.stroke_color.or(style.fill_color);
+
+        Styled::new(self, new_style)
+    }
+}
 
 impl Dimensions for Line {
     fn top_left(&self) -> Point {

--- a/embedded-graphics/src/primitives/line.rs
+++ b/embedded-graphics/src/primitives/line.rs
@@ -53,7 +53,8 @@ impl Primitive for Line {
         C: PixelColor,
         Self: Sized,
     {
-        // ensure fill color is honored if stroke is not set
+        // ensure fill color is honored if stroke color is not set
+        // this is important for fillables that use lines to fill (e.g. triangle)
         let mut new_style = style.clone();
         new_style.stroke_color = style.stroke_color.or(style.fill_color);
 
@@ -224,8 +225,21 @@ mod tests {
     use crate::{drawable::Pixel, pixelcolor::BinaryColor};
 
     fn test_expected_line(start: Point, end: Point, expected: &[(i32, i32)]) {
-        let line =
-            Line::new(start, end).into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 1));
+        test_expected_line_styled(
+            start,
+            end,
+            expected,
+            PrimitiveStyle::with_stroke(BinaryColor::On, 1),
+        )
+    }
+
+    fn test_expected_line_styled(
+        start: Point,
+        end: Point,
+        expected: &[(i32, i32)],
+        style: PrimitiveStyle<BinaryColor>,
+    ) {
+        let line = Line::new(start, end).into_styled(style);
         let mut expected_iter = expected.iter();
         for Pixel(coord, _) in line.into_iter() {
             match expected_iter.next() {
@@ -269,6 +283,19 @@ mod tests {
         let end = Point::new(3, 2);
         let expected = [(2, 3), (3, 2)];
         test_expected_line(start, end, &expected);
+    }
+
+    #[test]
+    fn draws_short_with_fill_only_correctly() {
+        let start = Point::new(2, 3);
+        let end = Point::new(3, 2);
+        let expected = [(2, 3), (3, 2)];
+        test_expected_line_styled(
+            start,
+            end,
+            &expected,
+            PrimitiveStyle::with_fill(BinaryColor::On),
+        );
     }
 
     #[test]

--- a/embedded-graphics/src/primitives/line.rs
+++ b/embedded-graphics/src/primitives/line.rs
@@ -55,7 +55,7 @@ impl Primitive for Line {
     {
         // ensure fill color is honored if stroke color is not set
         // this is important for fillables that use lines to fill (e.g. triangle)
-        let mut new_style = style.clone();
+        let mut new_style = style;
         new_style.stroke_color = style.stroke_color.or(style.fill_color);
 
         Styled::new(self, new_style)


### PR DESCRIPTION
Hi! Thank you for helping out with Embedded Graphics development! Please:

- [x] Check that you've added passing tests and documentation
- [ ] Add a simulator example(s) where applicable
- [x] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) and appropriate crate (`embedded-graphics`, `simulator`, `tinytga`, `tinybmp`) if your changes affect the **public API**
- [x] Run `rustfmt` on the project
- [x] Run `./build.sh` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

Fixes #260 with a thin work-around.
