### PR TITLE
circle: define by top-left + diameter instead of center + radius

### DIFF
--- a/embedded-graphics/CHANGELOG.md
+++ b/embedded-graphics/CHANGELOG.md
@@ -6,6 +6,10 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 
 ## [Unreleased] - ReleaseDate
 
+### Changed
+
+- **(breaking)** [#274](https://github.com/jamwaffles/embedded-graphics/pull/274) The `Circle` is now defined by its bounding box top-left corner and its diameter instead of its center and its radius. To convert your code, you can replace `Circle::new(point, radius)` by `Circle::with_center(point, 2 * radius + 1)`.
+
 ## [0.6.0] - 2020-03-20
 
 ### Added

--- a/embedded-graphics/README.md
+++ b/embedded-graphics/README.md
@@ -136,7 +136,7 @@ fn main() -> Result<(), std::convert::Infallible> {
         .draw(&mut display)?;
 
     // Draw a circle with a 3px wide stroke.
-    Circle::new(Point::new(96, yoffset + 8), 8)
+    Circle::new(Point::new(88, yoffset), 17)
         .into_styled(thick_stroke)
         .draw(&mut display)?;
 
@@ -184,10 +184,10 @@ fn main() {
     // This will be whichever display driver you decide to use, like the SSD1306, SSD1351, etc
     let mut display = Display::new();
 
-    // Draw a circle centered at (64, 64) with a radius of 64 and a white 1px stroke
+    // Draw a circle with top-left at (0, 0) with a diameter of 128 and a white 1px stroke
     egcircle!(
-        center = (64, 64),
-        radius = 64,
+        top_left = (0, 0),
+        diameter = 128,
         style = primitive_style!(stroke_color = Rgb565::WHITE)
     )
     .draw(&mut display);

--- a/embedded-graphics/src/draw_target.rs
+++ b/embedded-graphics/src/draw_target.rs
@@ -91,10 +91,10 @@ use crate::{
 ///     iface: SPI1,
 /// };
 ///
-/// // Draw a circle centered around `(32, 32)` with a radius of `10` and a white stroke
+/// // Draw a circle with top-left at `(22, 22)` with a diameter of `20` and a white stroke
 /// let circle = egcircle!(
-///     center = (32, 32),
-///     radius = 10,
+///     top_left = (22, 22),
+///     diameter = 20,
 ///     style = primitive_style!(stroke_color = Gray8::WHITE, stroke_width = 1)
 /// );
 /// circle.draw(&mut display)?;

--- a/embedded-graphics/src/lib.rs
+++ b/embedded-graphics/src/lib.rs
@@ -101,7 +101,7 @@
 //! // replaced by a draw target that is provided by a display driver crate.
 //! let mut display = MockDisplay::default();
 //!
-//! let c = Circle::new(Point::new(20, 20), 8).into_styled(PrimitiveStyle::with_fill(Rgb565::RED));
+//! let c = Circle::new(Point::new(12, 12), 17).into_styled(PrimitiveStyle::with_fill(Rgb565::RED));
 //! let t = Text::new("Hello Rust!", Point::new(20, 16))
 //!     .into_styled(TextStyle::new(Font6x8, Rgb565::GREEN));
 //!
@@ -126,8 +126,8 @@
 //! let mut display = MockDisplay::default();
 //!
 //! let c = egcircle!(
-//!     center = (20, 20),
-//!     radius = 8,
+//!     top_left = (12, 12),
+//!     diameter = 17,
 //!     style = primitive_style!(fill_color = Rgb565::RED)
 //! );
 //! let t = egtext!(
@@ -159,8 +159,8 @@
 //!     egrectangle!(top_left = (0, 0), bottom_right = (40, 40))
 //!         .into_iter()
 //!         .chain(&egcircle!(
-//!             center = (20, 20),
-//!             radius = 8,
+//!             top_left = (12, 12),
+//!             diameter = 17,
 //!             style = primitive_style!(fill_color = Rgb565::RED)
 //!         ))
 //!         .chain(&egtext!(

--- a/embedded-graphics/src/primitives/circle.rs
+++ b/embedded-graphics/src/primitives/circle.rs
@@ -65,6 +65,20 @@ impl Circle {
     pub const fn new(top_left: Point, diameter: u32) -> Self {
         Circle { top_left, diameter }
     }
+
+    /// Create a new circle centered around a given point with a specific diameter
+    pub const fn with_center(center: Point, diameter: u32) -> Self {
+        let top_left = Point::new(
+            center.x - diameter as i32 / 2,
+            center.y - diameter as i32 / 2,
+        );
+        Circle { top_left, diameter }
+    }
+
+    /// Return the center point of the circle
+    pub fn center(&self) -> Point {
+        self.top_left + Size::new(self.diameter / 2, self.diameter / 2)
+    }
 }
 
 impl Primitive for Circle {}
@@ -374,5 +388,14 @@ mod tests {
         assert!(negative.into_iter().eq(positive
             .into_iter()
             .map(|Pixel(p, c)| Pixel(p - Point::new(20, 20), c))));
+    }
+
+    #[test]
+    fn center_is_correct() {
+        let circle = Circle::with_center(Point::new(10, 10), 5);
+
+        assert_eq!(circle.top_left(), Point::new(8, 8));
+        assert_eq!(circle.center(), Point::new(10, 10));
+        assert_eq!(circle.bottom_right(), Point::new(12, 12));
     }
 }

--- a/embedded-graphics/src/primitives/circle.rs
+++ b/embedded-graphics/src/primitives/circle.rs
@@ -28,12 +28,12 @@ use crate::{
 /// # use embedded_graphics::mock_display::MockDisplay;
 /// # let mut display = MockDisplay::default();
 ///
-/// // Circle with 1 pixel wide white stroke centered around (10, 20) with a radius of 30
+/// // Circle with 1 pixel wide white stroke with top-left point at (10, 20) with a diameter of 30
 /// Circle::new(Point::new(10, 20), 30)
 ///     .into_styled(PrimitiveStyle::with_stroke(Rgb565::WHITE, 1))
 ///     .draw(&mut display)?;
 ///
-/// // Circle with styled stroke and fill centered around (50, 20) with a radius of 30
+/// // Circle with styled stroke and fill with top-left point at (50, 20) with a diameter of 30
 /// let style = PrimitiveStyleBuilder::new()
 ///     .stroke_color(Rgb565::RED)
 ///     .stroke_width(3)
@@ -53,17 +53,17 @@ use crate::{
 /// ```
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 pub struct Circle {
-    /// Center point of circle
-    pub center: Point,
+    /// Top-left point of circle's bounding box
+    pub top_left: Point,
 
-    /// Radius of the circle
-    pub radius: u32,
+    /// Diameter of the circle
+    pub diameter: u32,
 }
 
 impl Circle {
-    /// Create a new circle centered around a given point with a specific radius
-    pub const fn new(center: Point, radius: u32) -> Self {
-        Circle { center, radius }
+    /// Create a new circle delimited with a top-left point with a specific diameter
+    pub const fn new(top_left: Point, diameter: u32) -> Self {
+        Circle { top_left, diameter }
     }
 }
 
@@ -71,9 +71,7 @@ impl Primitive for Circle {}
 
 impl Dimensions for Circle {
     fn top_left(&self) -> Point {
-        let radius_coord = Point::new(self.radius as i32, self.radius as i32);
-
-        self.center - radius_coord
+        self.top_left
     }
 
     fn bottom_right(&self) -> Point {
@@ -81,12 +79,16 @@ impl Dimensions for Circle {
     }
 
     fn size(&self) -> Size {
-        Size::new(self.radius * 2, self.radius * 2)
+        if self.diameter < 1 {
+            Size::new(0, 0)
+        } else {
+            Size::new(self.diameter - 1, self.diameter - 1)
+        }
     }
 }
 
 impl Transform for Circle {
-    /// Translate the circle center from its current position to a new position by (x, y) pixels,
+    /// Translate the circle from its current position to a new position by (x, y) pixels,
     /// returning a new `Circle`. For a mutating transform, see `translate_mut`.
     ///
     /// ```
@@ -95,16 +97,16 @@ impl Transform for Circle {
     /// let circle = Circle::new(Point::new(5, 10), 10);
     /// let moved = circle.translate(Point::new(10, 10));
     ///
-    /// assert_eq!(moved.center, Point::new(15, 20));
+    /// assert_eq!(moved.top_left, Point::new(15, 20));
     /// ```
     fn translate(&self, by: Point) -> Self {
         Self {
-            center: self.center + by,
+            top_left: self.top_left + by,
             ..*self
         }
     }
 
-    /// Translate the circle center from its current position to a new position by (x, y) pixels.
+    /// Translate the circle from its current position to a new position by (x, y) pixels.
     ///
     /// ```
     /// # use embedded_graphics::primitives::Circle;
@@ -112,10 +114,10 @@ impl Transform for Circle {
     /// let mut circle = Circle::new(Point::new(5, 10), 10);
     /// circle.translate_mut(Point::new(10, 10));
     ///
-    /// assert_eq!(circle.center, Point::new(15, 20));
+    /// assert_eq!(circle.top_left, Point::new(15, 20));
     /// ```
     fn translate_mut(&mut self, by: Point) -> &mut Self {
-        self.center += by;
+        self.top_left += by;
 
         self
     }
@@ -124,10 +126,11 @@ impl Transform for Circle {
 /// Pixel iterator for each pixel in the circle border
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub struct StyledCircleIterator<C: PixelColor> {
-    center: Point,
-    radius: u32,
+    top_left: Point,
+    diameter: u32,
     style: PrimitiveStyle<C>,
     p: Point,
+    c: Point,
     outer_threshold: i32,
     inner_threshold: i32,
 }
@@ -148,7 +151,7 @@ where
         }
 
         loop {
-            let len = (2 * self.p.x).pow(2) + (2 * self.p.y).pow(2);
+            let len = (self.c.x - 2 * self.p.x).pow(2) + (self.c.y - 2 * self.p.y).pow(2);
 
             let color = if len < self.inner_threshold {
                 self.style.fill_color
@@ -158,16 +161,16 @@ where
             } else {
                 None
             };
-            let item = color.map(|c| Pixel(self.center + self.p, c));
+            let item = color.map(|c| Pixel(self.p, c));
 
             self.p.x += 1;
 
-            if self.p.x > self.radius as i32 {
-                self.p.x = -(self.radius as i32);
+            if self.p.x > self.top_left.x + self.diameter as i32 {
+                self.p.x = self.top_left.x;
                 self.p.y += 1;
             }
 
-            if self.p.y > self.radius as i32 {
+            if self.p.y > self.top_left.y + self.diameter as i32 {
                 break None;
             }
 
@@ -187,13 +190,11 @@ where
     }
 }
 
-fn radius_to_threshold(radius: i32) -> i32 {
-    if radius == 1 {
-        // Special case for small circles. This kludge removes the top-left pixel and leaves the
-        // circle as a `+` shape.
-        5
+fn diameter_to_threshold(diameter: i32) -> i32 {
+    if diameter <= 4 {
+        diameter.pow(2) - diameter / 2
     } else {
-        4 * (radius.pow(2) + radius) + 1
+        diameter.pow(2)
     }
 }
 
@@ -205,22 +206,21 @@ where
     type IntoIter = StyledCircleIterator<C>;
 
     fn into_iter(self) -> Self::IntoIter {
-        let top_left = Point::new(
-            -(self.primitive.radius as i32),
-            -(self.primitive.radius as i32),
-        );
+        let center = Point::new(2 * self.primitive.top_left.x, 2 * self.primitive.top_left.y)
+            + self.primitive.size();
 
-        let inner_radius = self.primitive.radius as i32 - self.style.stroke_width_i32();
-        let outer_radius = self.primitive.radius as i32;
+        let inner_diameter = self.primitive.diameter as i32 - 2 * self.style.stroke_width_i32();
+        let outer_diameter = self.primitive.diameter as i32;
 
-        let inner_threshold = radius_to_threshold(inner_radius);
-        let outer_threshold = radius_to_threshold(outer_radius);
+        let inner_threshold = diameter_to_threshold(core::cmp::max(inner_diameter, 0));
+        let outer_threshold = diameter_to_threshold(outer_diameter);
 
         StyledCircleIterator {
-            center: self.primitive.center,
-            radius: self.primitive.radius,
+            top_left: self.primitive.top_left,
+            diameter: self.primitive.diameter,
             style: self.style,
-            p: top_left,
+            p: self.primitive.top_left,
+            c: center,
             outer_threshold,
             inner_threshold,
         }
@@ -256,7 +256,7 @@ mod tests {
     fn tiny_circle() -> Result<(), core::convert::Infallible> {
         let mut display = MockDisplay::new();
 
-        Circle::new(Point::new(1, 1), 1)
+        Circle::new(Point::new(0, 0), 3)
             .into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 1))
             .draw(&mut display)?;
 
@@ -278,7 +278,7 @@ mod tests {
     fn tiny_circle_filled() -> Result<(), core::convert::Infallible> {
         let mut display = MockDisplay::new();
 
-        Circle::new(Point::new(1, 1), 1)
+        Circle::new(Point::new(0, 0), 3)
             .into_styled(PrimitiveStyle::with_fill(BinaryColor::On))
             .draw(&mut display)?;
 
@@ -327,7 +327,7 @@ mod tests {
 
     #[test]
     fn negative_dimensions() {
-        let circle = Circle::new(Point::new(-10, -10), 5);
+        let circle = Circle::new(Point::new(-15, -15), 11);
 
         assert_eq!(circle.top_left(), Point::new(-15, -15));
         assert_eq!(circle.bottom_right(), Point::new(-5, -5));
@@ -336,7 +336,7 @@ mod tests {
 
     #[test]
     fn dimensions() {
-        let circle = Circle::new(Point::new(10, 20), 5);
+        let circle = Circle::new(Point::new(5, 15), 11);
 
         assert_eq!(circle.top_left(), Point::new(5, 15));
         assert_eq!(circle.bottom_right(), Point::new(15, 25));
@@ -344,8 +344,8 @@ mod tests {
     }
 
     #[test]
-    fn large_radius() {
-        let circle = Circle::new(Point::new(5, 5), 10);
+    fn large_diameter() {
+        let circle = Circle::new(Point::new(-5, -5), 21);
 
         assert_eq!(circle.top_left(), Point::new(-5, -5));
         assert_eq!(circle.bottom_right(), Point::new(15, 15));
@@ -354,8 +354,9 @@ mod tests {
 
     #[test]
     fn transparent_border() {
-        let circle: Styled<Circle, PrimitiveStyle<BinaryColor>> = Circle::new(Point::new(5, 5), 10)
-            .into_styled(PrimitiveStyle::with_fill(BinaryColor::On));
+        let circle: Styled<Circle, PrimitiveStyle<BinaryColor>> =
+            Circle::new(Point::new(-5, -5), 21)
+                .into_styled(PrimitiveStyle::with_fill(BinaryColor::On));
 
         assert!(circle.into_iter().count() > 0);
     }

--- a/embedded-graphics/src/primitives/mod.rs
+++ b/embedded-graphics/src/primitives/mod.rs
@@ -42,7 +42,7 @@ pub trait Primitive: Dimensions {
 ///     egcircle!(top_left = (10, 20), diameter = 30);
 ///
 /// let filled_circle: Styled<Circle, PrimitiveStyle<Rgb565>> = egcircle!(
-///     top_left = (10, 20),
+///     center = (10, 20),
 ///     diameter = 30,
 ///     style = primitive_style!(stroke_color = Rgb565::RED, fill_color = Rgb565::GREEN)
 /// );
@@ -95,6 +95,17 @@ macro_rules! egcircle {
     }};
     (top_left = $top_left:expr, diameter = $d:expr, style = $style:expr $(,)?) => {{
         $crate::primitives::Circle::new($crate::geometry::Point::from($top_left), $d)
+            .into_styled($style)
+    }};
+    (center = $center:expr, diameter = $d:expr $(,)?) => {{
+        $crate::egcircle!(
+            center = $center,
+            diameter = $d,
+            style = $crate::style::PrimitiveStyle::default()
+        )
+    }};
+    (center = $center:expr, diameter = $d:expr, style = $style:expr $(,)?) => {{
+        $crate::primitives::Circle::with_center($crate::geometry::Point::from($center), $d)
             .into_styled($style)
     }};
 }
@@ -341,8 +352,15 @@ mod tests {
             egcircle!(top_left = Point::new(10, 20), diameter = 30);
         let _c: Styled<Circle, PrimitiveStyle<Rgb565>> =
             egcircle!(top_left = (10, 20), diameter = 30);
+        let _c: Styled<Circle, PrimitiveStyle<Rgb565>> =
+            egcircle!(center = (10, 20), diameter = 30);
         let _c: Styled<Circle, PrimitiveStyle<Rgb565>> = egcircle!(
             top_left = (10, 20),
+            diameter = 30,
+            style = primitive_style!(stroke_color = Rgb565::RED, fill_color = Rgb565::GREEN),
+        );
+        let _c: Styled<Circle, PrimitiveStyle<Rgb565>> = egcircle!(
+            center = (10, 20),
             diameter = 30,
             style = primitive_style!(stroke_color = Rgb565::RED, fill_color = Rgb565::GREEN),
         );

--- a/embedded-graphics/src/primitives/mod.rs
+++ b/embedded-graphics/src/primitives/mod.rs
@@ -39,11 +39,11 @@ pub trait Primitive: Dimensions {
 ///
 /// // Coordinates can be defined as any type that implements `Into<Point>`
 /// let line_circle: Styled<Circle, PrimitiveStyle<Rgb565>> =
-///     egcircle!(center = (10, 20), radius = 30);
+///     egcircle!(top_left = (10, 20), diameter = 30);
 ///
 /// let filled_circle: Styled<Circle, PrimitiveStyle<Rgb565>> = egcircle!(
-///     center = (10, 20),
-///     radius = 30,
+///     top_left = (10, 20),
+///     diameter = 30,
 ///     style = primitive_style!(stroke_color = Rgb565::RED, fill_color = Rgb565::GREEN)
 /// );
 /// ```
@@ -64,8 +64,8 @@ pub trait Primitive: Dimensions {
 /// };
 ///
 /// let circle_1: Styled<Circle, PrimitiveStyle<Rgb565>> = egcircle!(
-///     center = (10, 20),
-///     radius = 30,
+///     top_left = (10, 20),
+///     diameter = 30,
 ///     style = primitive_style!(
 ///         stroke_color = Rgb565::RED,
 ///         fill_color = Rgb565::GREEN,
@@ -86,15 +86,15 @@ pub trait Primitive: Dimensions {
 /// ```
 #[macro_export]
 macro_rules! egcircle {
-    (center = $center:expr, radius = $r:expr $(,)?) => {{
+    (top_left = $top_left:expr, diameter = $d:expr $(,)?) => {{
         $crate::egcircle!(
-            center = $center,
-            radius = $r,
+            top_left = $top_left,
+            diameter = $d,
             style = $crate::style::PrimitiveStyle::default()
         )
     }};
-    (center = $center:expr, radius = $r:expr, style = $style:expr $(,)?) => {{
-        $crate::primitives::Circle::new($crate::geometry::Point::from($center), $r)
+    (top_left = $top_left:expr, diameter = $d:expr, style = $style:expr $(,)?) => {{
+        $crate::primitives::Circle::new($crate::geometry::Point::from($top_left), $d)
             .into_styled($style)
     }};
 }
@@ -338,11 +338,12 @@ mod tests {
     #[test]
     fn circle() {
         let _c: Styled<Circle, PrimitiveStyle<Rgb565>> =
-            egcircle!(center = Point::new(10, 20), radius = 30);
-        let _c: Styled<Circle, PrimitiveStyle<Rgb565>> = egcircle!(center = (10, 20), radius = 30);
+            egcircle!(top_left = Point::new(10, 20), diameter = 30);
+        let _c: Styled<Circle, PrimitiveStyle<Rgb565>> =
+            egcircle!(top_left = (10, 20), diameter = 30);
         let _c: Styled<Circle, PrimitiveStyle<Rgb565>> = egcircle!(
-            center = (10, 20),
-            radius = 30,
+            top_left = (10, 20),
+            diameter = 30,
             style = primitive_style!(stroke_color = Rgb565::RED, fill_color = Rgb565::GREEN),
         );
     }

--- a/embedded-graphics/src/style/primitive_style.rs
+++ b/embedded-graphics/src/style/primitive_style.rs
@@ -98,7 +98,7 @@ where
 /// ## Build a style with configured stroke and fill
 ///
 /// This example builds a style for a circle with a 3px red stroke and a solid green fill. The
-/// circle is centered at (20, 20) with a radius of 10px.
+/// circle has its top-left at (10, 10) with a diameter of 20px.
 ///
 /// ```rust
 /// use embedded_graphics::{
@@ -115,7 +115,7 @@ where
 ///     .fill_color(Rgb565::GREEN)
 ///     .build();
 ///
-/// let circle = Circle::new(Point::new(20, 20), 10).into_styled(style);
+/// let circle = Circle::new(Point::new(10, 10), 20).into_styled(style);
 /// ```
 ///
 /// ## Build a style with stroke and no fill

--- a/embedded-graphics/tests/chaining.rs
+++ b/embedded-graphics/tests/chaining.rs
@@ -44,7 +44,7 @@ fn it_supports_chaining() -> Result<(), core::convert::Infallible> {
         .into_styled(PrimitiveStyle::default())
         .into_iter()
         .chain(
-            Circle::new(Point::new(2, 2), 1)
+            Circle::new(Point::new(1, 1), 3)
                 .into_styled(PrimitiveStyle::default())
                 .into_iter(),
         );
@@ -57,7 +57,7 @@ fn multi() -> impl Iterator<Item = Pixel<TestPixelColor>> {
         .into_styled(PrimitiveStyle::with_stroke(1u8.into(), 1))
         .into_iter();
 
-    let circle = Circle::new(Point::new(5, 5), 3)
+    let circle = Circle::new(Point::new(2, 2), 7)
         .into_styled(PrimitiveStyle::with_stroke(1u8.into(), 1))
         .into_iter();
 
@@ -81,7 +81,7 @@ fn implicit_into_iter() -> Result<(), core::convert::Infallible> {
         .into_styled(PrimitiveStyle::default())
         .into_iter()
         .chain(
-            Circle::new(Point::new(2, 2), 1)
+            Circle::new(Point::new(1, 1), 3)
                 .into_styled(PrimitiveStyle::default())
                 .into_iter(),
         );

--- a/simulator/README.md
+++ b/simulator/README.md
@@ -27,7 +27,7 @@ fn main() -> Result<(), core::convert::Infallible> {
 
     let line_style = PrimitiveStyle::with_stroke(BinaryColor::On, 1);
 
-    Circle::new(Point::new(64, 64), 64)
+    Circle::new(Point::new(0, 0), 129)
         .into_styled(line_style)
         .draw(&mut display)?;
 

--- a/simulator/examples/analog-clock.rs
+++ b/simulator/examples/analog-clock.rs
@@ -45,8 +45,8 @@ fn draw_face() -> impl Iterator<Item = Pixel<BinaryColor>> {
 
     // Use the circle macro to create the outer face
     let face = egcircle!(
-        top_left = (0, 0),
-        diameter = DISP_SIZE as u32,
+        center = CENTER,
+        diameter = 2 * SIZE + 1,
         style = primitive_style!(stroke_color = BinaryColor::On, stroke_width = 2)
     );
 
@@ -82,7 +82,7 @@ fn draw_seconds_hand(seconds: u32) -> impl Iterator<Item = Pixel<BinaryColor>> {
     let hand = Line::new(CENTER, end).into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 1));
 
     // Decoration position
-    let decoration_position = polar(seconds_radians, SIZE as f32 - 20.0) - Size::new(5, 5);
+    let decoration_position = polar(seconds_radians, SIZE as f32 - 20.0);
 
     // Decoration style
     let decoration_style = PrimitiveStyleBuilder::new()
@@ -92,7 +92,7 @@ fn draw_seconds_hand(seconds: u32) -> impl Iterator<Item = Pixel<BinaryColor>> {
         .build();
 
     // Add a fancy circle near the end of the hand
-    let decoration = Circle::new(decoration_position, 11).into_styled(decoration_style);
+    let decoration = Circle::with_center(decoration_position, 11).into_styled(decoration_style);
 
     hand.into_iter().chain(&decoration)
 }
@@ -171,7 +171,7 @@ fn main() -> Result<(), core::convert::Infallible> {
 
         // Draw a small circle over the hands in the center of the clock face. This has to happen
         // after the hands are drawn so they're covered up
-        Circle::new(CENTER - Size::new(4, 4), 9)
+        Circle::with_center(CENTER, 9)
             .into_styled(PrimitiveStyle::with_fill(BinaryColor::On))
             .draw(&mut display)?;
 

--- a/simulator/examples/analog-clock.rs
+++ b/simulator/examples/analog-clock.rs
@@ -45,8 +45,8 @@ fn draw_face() -> impl Iterator<Item = Pixel<BinaryColor>> {
 
     // Use the circle macro to create the outer face
     let face = egcircle!(
-        center = CENTER,
-        radius = SIZE,
+        top_left = (0, 0),
+        diameter = DISP_SIZE as u32,
         style = primitive_style!(stroke_color = BinaryColor::On, stroke_width = 2)
     );
 
@@ -82,7 +82,7 @@ fn draw_seconds_hand(seconds: u32) -> impl Iterator<Item = Pixel<BinaryColor>> {
     let hand = Line::new(CENTER, end).into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 1));
 
     // Decoration position
-    let decoration_position = polar(seconds_radians, SIZE as f32 - 20.0);
+    let decoration_position = polar(seconds_radians, SIZE as f32 - 20.0) - Size::new(5, 5);
 
     // Decoration style
     let decoration_style = PrimitiveStyleBuilder::new()
@@ -92,7 +92,7 @@ fn draw_seconds_hand(seconds: u32) -> impl Iterator<Item = Pixel<BinaryColor>> {
         .build();
 
     // Add a fancy circle near the end of the hand
-    let decoration = Circle::new(decoration_position, 5).into_styled(decoration_style);
+    let decoration = Circle::new(decoration_position, 11).into_styled(decoration_style);
 
     hand.into_iter().chain(&decoration)
 }
@@ -171,7 +171,7 @@ fn main() -> Result<(), core::convert::Infallible> {
 
         // Draw a small circle over the hands in the center of the clock face. This has to happen
         // after the hands are drawn so they're covered up
-        Circle::new(CENTER, 4)
+        Circle::new(CENTER - Size::new(4, 4), 9)
             .into_styled(PrimitiveStyle::with_fill(BinaryColor::On))
             .draw(&mut display)?;
 

--- a/simulator/examples/chaining.rs
+++ b/simulator/examples/chaining.rs
@@ -50,8 +50,8 @@ fn main() -> Result<(), core::convert::Infallible> {
                 .into_iter(),
         )
         .chain(
-            // Draw a square with a 3px wide stroke.
-            Circle::new(Point::new(96, yoffset + 8), 8)
+            // Draw a circle with a 3px wide stroke.
+            Circle::new(Point::new(88, yoffset), 17)
                 .into_styled(thick_stroke)
                 .into_iter(),
         )

--- a/simulator/examples/hello-world.rs
+++ b/simulator/examples/hello-world.rs
@@ -46,7 +46,7 @@ fn main() -> Result<(), std::convert::Infallible> {
         .draw(&mut display)?;
 
     // Draw a circle with a 3px wide stroke.
-    Circle::new(Point::new(96, yoffset + 8), 8)
+    Circle::new(Point::new(88, yoffset), 17)
         .into_styled(thick_stroke)
         .draw(&mut display)?;
 

--- a/simulator/examples/input-handling.rs
+++ b/simulator/examples/input-handling.rs
@@ -20,16 +20,16 @@ const KEYBOARD_DELTA: i32 = 20;
 
 fn move_circle(
     display: &mut SimulatorDisplay<Rgb888>,
-    old_pos: Point,
-    new_pos: Point,
+    old_center: Point,
+    new_center: Point,
 ) -> Result<(), core::convert::Infallible> {
     // Clear old circle
-    Circle::new(old_pos, 200)
+    Circle::with_center(old_center, 200)
         .into_styled(PrimitiveStyle::with_fill(BACKGROUND_COLOR))
         .draw(display)?;
 
     // Draw circle at new location
-    Circle::new(new_pos, 200)
+    Circle::with_center(new_center, 200)
         .into_styled(PrimitiveStyle::with_fill(FOREGROUND_COLOR))
         .draw(display)?;
 
@@ -40,8 +40,8 @@ fn main() -> Result<(), core::convert::Infallible> {
     let mut display: SimulatorDisplay<Rgb888> = SimulatorDisplay::new(Size::new(800, 480));
     let mut window = Window::new("Click to move circle", &OutputSettings::default());
 
-    let mut position = Point::new(100, 100);
-    Circle::new(position, 200)
+    let mut position = Point::new(200, 200);
+    Circle::with_center(position, 200)
         .into_styled(PrimitiveStyle::with_fill(FOREGROUND_COLOR))
         .draw(&mut display)?;
 
@@ -64,7 +64,6 @@ fn main() -> Result<(), core::convert::Infallible> {
                     position = new_position;
                 }
                 SimulatorEvent::MouseButtonUp { point, .. } => {
-                    let point = point - Size::new(100, 100);
                     move_circle(&mut display, position, point)?;
                     position = point;
                 }

--- a/simulator/examples/input-handling.rs
+++ b/simulator/examples/input-handling.rs
@@ -20,16 +20,16 @@ const KEYBOARD_DELTA: i32 = 20;
 
 fn move_circle(
     display: &mut SimulatorDisplay<Rgb888>,
-    old_center: Point,
-    new_center: Point,
+    old_pos: Point,
+    new_pos: Point,
 ) -> Result<(), core::convert::Infallible> {
     // Clear old circle
-    Circle::new(old_center, 100)
+    Circle::new(old_pos, 200)
         .into_styled(PrimitiveStyle::with_fill(BACKGROUND_COLOR))
         .draw(display)?;
 
     // Draw circle at new location
-    Circle::new(new_center, 100)
+    Circle::new(new_pos, 200)
         .into_styled(PrimitiveStyle::with_fill(FOREGROUND_COLOR))
         .draw(display)?;
 
@@ -40,8 +40,8 @@ fn main() -> Result<(), core::convert::Infallible> {
     let mut display: SimulatorDisplay<Rgb888> = SimulatorDisplay::new(Size::new(800, 480));
     let mut window = Window::new("Click to move circle", &OutputSettings::default());
 
-    let mut position = Point::new(200, 200);
-    Circle::new(position, 100)
+    let mut position = Point::new(100, 100);
+    Circle::new(position, 200)
         .into_styled(PrimitiveStyle::with_fill(FOREGROUND_COLOR))
         .draw(&mut display)?;
 
@@ -64,6 +64,7 @@ fn main() -> Result<(), core::convert::Infallible> {
                     position = new_position;
                 }
                 SimulatorEvent::MouseButtonUp { point, .. } => {
+                    let point = point - Size::new(100, 100);
                     move_circle(&mut display, position, point)?;
                     position = point;
                 }

--- a/simulator/examples/primitives-fill-macros.rs
+++ b/simulator/examples/primitives-fill-macros.rs
@@ -8,21 +8,21 @@ use embedded_graphics::{
 };
 use embedded_graphics_simulator::{OutputSettingsBuilder, SimulatorDisplay, Window};
 
-static CIRCLE_SIZE: i32 = 32;
+static CIRCLE_SIZE: i32 = 65;
 
 fn main() -> Result<(), core::convert::Infallible> {
     let mut display: SimulatorDisplay<BinaryColor> = SimulatorDisplay::new(Size::new(384, 128));
 
     egcircle!(
-        center = (CIRCLE_SIZE, CIRCLE_SIZE),
-        radius = CIRCLE_SIZE as u32,
+        top_left = (0, 0),
+        diameter = CIRCLE_SIZE as u32,
         style = primitive_style!(stroke_color = BinaryColor::On, stroke_width = 1,)
     )
     .draw(&mut display)?;
 
     egcircle!(
-        center = (CIRCLE_SIZE, CIRCLE_SIZE),
-        radius = CIRCLE_SIZE as u32,
+        top_left = (0, 0),
+        diameter = CIRCLE_SIZE as u32,
         style = primitive_style!(
             stroke_color = BinaryColor::Off,
             stroke_width = 1,
@@ -33,15 +33,15 @@ fn main() -> Result<(), core::convert::Infallible> {
     .draw(&mut display)?;
 
     egcircle!(
-        center = (CIRCLE_SIZE, CIRCLE_SIZE),
-        radius = CIRCLE_SIZE as u32,
+        top_left = (0, 0),
+        diameter = CIRCLE_SIZE as u32,
         style = primitive_style!(
             stroke_color = BinaryColor::Off,
             stroke_width = 1,
             fill_color = BinaryColor::Off
         )
     )
-    .translate(Point::new(CIRCLE_SIZE, CIRCLE_SIZE))
+    .translate(Point::new(CIRCLE_SIZE / 2, CIRCLE_SIZE / 2))
     .draw(&mut display)?;
 
     egrectangle!(

--- a/simulator/examples/primitives-fill.rs
+++ b/simulator/examples/primitives-fill.rs
@@ -10,7 +10,7 @@ use embedded_graphics::{
 };
 use embedded_graphics_simulator::{OutputSettingsBuilder, SimulatorDisplay, Window};
 
-static CIRCLE_SIZE: i32 = 32;
+static CIRCLE_SIZE: i32 = 65;
 
 fn main() -> Result<(), core::convert::Infallible> {
     let mut display: SimulatorDisplay<BinaryColor> = SimulatorDisplay::new(Size::new(304, 128));
@@ -29,17 +29,17 @@ fn main() -> Result<(), core::convert::Infallible> {
         .fill_color(BinaryColor::On)
         .build();
 
-    Circle::new(Point::new(CIRCLE_SIZE, CIRCLE_SIZE), CIRCLE_SIZE as u32)
+    Circle::new(Point::new(0, 0), CIRCLE_SIZE as u32)
         .into_styled(stroke)
         .draw(&mut display)?;
 
-    Circle::new(Point::new(CIRCLE_SIZE, CIRCLE_SIZE), CIRCLE_SIZE as u32)
+    Circle::new(Point::new(0, 0), CIRCLE_SIZE as u32)
         .translate(Point::new(16, 16))
         .into_styled(stroke_off_fill_on)
         .draw(&mut display)?;
 
-    Circle::new(Point::new(CIRCLE_SIZE, CIRCLE_SIZE), CIRCLE_SIZE as u32)
-        .translate(Point::new(CIRCLE_SIZE, CIRCLE_SIZE))
+    Circle::new(Point::new(0, 0), CIRCLE_SIZE as u32)
+        .translate(Point::new(CIRCLE_SIZE / 2, CIRCLE_SIZE / 2))
         .into_styled(stroke_off_fill_off)
         .draw(&mut display)?;
 

--- a/simulator/examples/primitives-stroke.rs
+++ b/simulator/examples/primitives-stroke.rs
@@ -24,7 +24,7 @@ fn main() -> Result<(), core::convert::Infallible> {
         Rectangle::new(Point::new(0, 0), Point::new(64, 64)).translate(Point::new(64 + PADDING, 0));
     let line = Line::new(Point::new(0, 0), Point::new(64, 64))
         .translate(Point::new((64 + PADDING) * 2, 0));
-    let circle = Circle::new(Point::new(32, 32), 32).translate(Point::new((64 + PADDING) * 3, 0));
+    let circle = Circle::new(Point::new(0, 0), 64).translate(Point::new((64 + PADDING) * 3, 0));
 
     circle
         .into_styled(thin_stroke)

--- a/simulator/examples/text-transparent.rs
+++ b/simulator/examples/text-transparent.rs
@@ -12,8 +12,8 @@ fn main() -> Result<(), core::convert::Infallible> {
     let mut display: SimulatorDisplay<Rgb565> = SimulatorDisplay::new(Size::new(256, 128));
 
     egcircle!(
-        center = (20, 20),
-        radius = 20 as u32,
+        top_left = (0, 0),
+        diameter = 41,
         style = primitive_style!(fill_color = Rgb565::RED)
     )
     .into_iter()

--- a/simulator/src/lib.rs
+++ b/simulator/src/lib.rs
@@ -52,7 +52,7 @@
 //!
 //!     egtext!(text = "Hello World!", top_left = Point::zero(), style = text_style!(font = Font6x8, text_color = BinaryColor::On)).draw(&mut display);
 //!
-//!     egcircle!(center = (96, 32), radius = 31, style = primitive_style!(stroke_color = BinaryColor::On)).draw(&mut display);
+//!     egcircle!(top_left = (65, 1), diameter = 63, style = primitive_style!(stroke_color = BinaryColor::On)).draw(&mut display);
 //!
 //!     egline!(start = (32, 32), end = (1, 32), style = primitive_style!(stroke_color = BinaryColor::On))
 //!         .translate(Point::new(64, 0))


### PR DESCRIPTION
Hi! Thank you for helping out with Embedded Graphics development! Please:

- [X] Check that you've added passing tests and documentation
- [X] Add a simulator example(s) where applicable
- [x] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) and appropriate crate (`embedded-graphics`, `simulator`, `tinytga`, `tinybmp`) if your changes affect the **public API**
- [X] Run `rustfmt` on the project
- [X] Run `./build.sh` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

This changes the API of `Circle` so that it is defined by `top-left` and `diameter` rather than by `center` and `radius`.

This is a breaking change. It should be 0.7.0 material.

This fixes #147