### PR TITLE
Add scalar div and mul for Point and Size

### DIFF
--- a/embedded-graphics/CHANGELOG.md
+++ b/embedded-graphics/CHANGELOG.md
@@ -6,6 +6,10 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+- [#285](https://github.com/jamwaffles/embedded-graphics/pull/285) Add multiplication and division by a scalar for `Point` and `Size`.
+
 ### Changed
 
 - **(breaking)** [#274](https://github.com/jamwaffles/embedded-graphics/pull/274) The `Circle` is now defined by its bounding box top-left corner and its diameter instead of its center and its radius. To convert your code, you can replace `Circle::new(point, radius)` by `Circle::with_center(point, 2 * radius + 1)`.

--- a/embedded-graphics/src/geometry/point.rs
+++ b/embedded-graphics/src/geometry/point.rs
@@ -1,7 +1,7 @@
 use crate::geometry::Size;
 use core::{
     convert::{TryFrom, TryInto},
-    ops::{Add, AddAssign, Index, Neg, Sub, SubAssign},
+    ops::{Add, AddAssign, Div, DivAssign, Index, Mul, MulAssign, Neg, Sub, SubAssign},
 };
 
 /// 2D point.
@@ -202,6 +202,36 @@ impl SubAssign<Size> for Point {
 
         self.x -= width;
         self.y -= height;
+    }
+}
+
+impl Mul<i32> for Point {
+    type Output = Point;
+
+    fn mul(self, rhs: i32) -> Point {
+        Point::new(self.x * rhs, self.y * rhs)
+    }
+}
+
+impl MulAssign<i32> for Point {
+    fn mul_assign(&mut self, rhs: i32) {
+        self.x *= rhs;
+        self.y *= rhs;
+    }
+}
+
+impl Div<i32> for Point {
+    type Output = Point;
+
+    fn div(self, rhs: i32) -> Point {
+        Point::new(self.x / rhs, self.y / rhs)
+    }
+}
+
+impl DivAssign<i32> for Point {
+    fn div_assign(&mut self, rhs: i32) {
+        self.x /= rhs;
+        self.y /= rhs;
     }
 }
 
@@ -437,6 +467,26 @@ mod tests {
         let right = Size::new(31, 42);
 
         assert_eq!(left - right, Point::new(-21, -22));
+    }
+
+    #[test]
+    fn points_can_be_multiplied_by_scalar() {
+        let p = Point::new(1, 2);
+        assert_eq!(p * 3, Point::new(3, 6));
+
+        let mut p = Point::new(3, 4);
+        p *= -5;
+        assert_eq!(p, Point::new(-15, -20));
+    }
+
+    #[test]
+    fn points_can_be_divided_by_scalar() {
+        let p = Point::new(10, 20);
+        assert_eq!(p / 2, Point::new(5, 10));
+
+        let mut p = Point::new(-10, 10);
+        p /= -5;
+        assert_eq!(p, Point::new(2, -2));
     }
 
     #[test]

--- a/embedded-graphics/src/geometry/size.rs
+++ b/embedded-graphics/src/geometry/size.rs
@@ -1,5 +1,5 @@
 use crate::geometry::Point;
-use core::ops::{Add, AddAssign, Index, Sub, SubAssign};
+use core::ops::{Add, AddAssign, Div, DivAssign, Index, Mul, MulAssign, Sub, SubAssign};
 
 /// 2D size.
 ///
@@ -119,6 +119,36 @@ impl SubAssign for Size {
     }
 }
 
+impl Mul<u32> for Size {
+    type Output = Size;
+
+    fn mul(self, rhs: u32) -> Size {
+        Size::new(self.width * rhs, self.height * rhs)
+    }
+}
+
+impl MulAssign<u32> for Size {
+    fn mul_assign(&mut self, rhs: u32) {
+        self.width *= rhs;
+        self.height *= rhs;
+    }
+}
+
+impl Div<u32> for Size {
+    type Output = Size;
+
+    fn div(self, rhs: u32) -> Size {
+        Size::new(self.width / rhs, self.height / rhs)
+    }
+}
+
+impl DivAssign<u32> for Size {
+    fn div_assign(&mut self, rhs: u32) {
+        self.width /= rhs;
+        self.height /= rhs;
+    }
+}
+
 impl Index<usize> for Size {
     type Output = u32;
 
@@ -208,6 +238,26 @@ mod tests {
         let right = Size::new(10, 20);
 
         assert_eq!(left - right, Size::new(20, 20));
+    }
+
+    #[test]
+    fn sizes_can_be_multiplied_by_scalar() {
+        let s = Size::new(1, 2);
+        assert_eq!(s * 3, Size::new(3, 6));
+
+        let mut s = Size::new(2, 3);
+        s *= 4;
+        assert_eq!(s, Size::new(8, 12));
+    }
+
+    #[test]
+    fn sizes_can_be_divided_by_scalar() {
+        let s = Size::new(10, 20);
+        assert_eq!(s / 2, Size::new(5, 10));
+
+        let mut s = Size::new(20, 30);
+        s /= 5;
+        assert_eq!(s, Size::new(4, 6));
     }
 
     #[test]

--- a/embedded-graphics/src/primitives/circle.rs
+++ b/embedded-graphics/src/primitives/circle.rs
@@ -77,7 +77,7 @@ impl Circle {
 
     /// Return the center point of the circle
     pub fn center(&self) -> Point {
-        self.top_left + Size::new(self.diameter / 2, self.diameter / 2)
+        self.top_left + Size::new(self.diameter, self.diameter) / 2
     }
 }
 


### PR DESCRIPTION
Hi! Thank you for helping out with Embedded Graphics development! Please:

- [x] Check that you've added passing tests and documentation
- [x] Add a simulator example(s) where applicable
- [x] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) and appropriate crate (`embedded-graphics`, `simulator`, `tinytga`, `tinybmp`) if your changes affect the **public API**
- [x] Run `rustfmt` on the project
- [x] Run `./build.sh` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

This PR adds multiplication and division by a scalar for `Point` and `Size`.

@jamwaffles  I think we've discussed adding this before, but I'm not sure if you thought that this is a good idea. But in my recent experience with trying to implementing code using the geometry types I've noticed that this could often be useful.
