### PR TITLE
Speed/clean up builds a bit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,6 @@ target_steps: &target_steps
           echo "Target $TARGET is already installed"
         fi
     - run: cargo update
-    - run: ./build_target.sh
     - run: ./build_target.sh --release
     - save_cache:
         key: v1-embedded-graphics-{{ .Environment.CIRCLE_JOB }}-{{ checksum "embedded-graphics/Cargo.toml" }}-{{ checksum "tinybmp/Cargo.toml" }}-{{ checksum "tinytga/Cargo.toml" }}-{{ checksum "simulator/Cargo.toml" }}-{{ .Environment.TARGET }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,10 +52,6 @@ jobs:
     environment:
       - RUST_VERSION: 'beta'
     <<: *precheck_steps
-  precheck-nightly:
-    environment:
-      - RUST_VERSION: 'nightly'
-    <<: *precheck_steps
 
   target-arm-unknown-linux-eabi:
     environment:


### PR DESCRIPTION
* Removes nightly checks. They're only in there to see if the crate still works in future versions of Rust, but a) nightly sometimes doesn't have all artifacts available and b) testing on beta is a good enough canary for future support.
* Removes redundant non-release call of  `build_target.sh`