### PR TITLE
Add Polyline primitive

### DIFF
--- a/embedded-graphics/CHANGELOG.md
+++ b/embedded-graphics/CHANGELOG.md
@@ -17,6 +17,7 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 - [#331](https://github.com/jamwaffles/embedded-graphics/pull/331) Added stroke alignment to `PrimitiveStyle`.
 - [#331](https://github.com/jamwaffles/embedded-graphics/pull/331) Added `Rectangle::with_center`.
 - [#331](https://github.com/jamwaffles/embedded-graphics/pull/331) Added `From<&PrimitiveStyle>` for `PrimitiveStyleBuilder`.
+- [#292](https://github.com/jamwaffles/embedded-graphics/pull/292) Added the `Polyline` primitive.
 
 ### Changed
 

--- a/embedded-graphics/src/lib.rs
+++ b/embedded-graphics/src/lib.rs
@@ -347,6 +347,40 @@
 //! </div>
 //! </div>
 //!
+//! ## Draw a polyline
+//!
+//! This example draws a polyline with 1px cyan stroke.
+//!
+//! <div style="display: flex">
+//! <img style="width: 128px; height: 128px; margin-right: 8px;" alt="Draw a polyline example screenshot" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAIAAABMXPacAAACb0lEQVR4nO3RgU7jQAwA0eP/P5qjrE7NEYiyydpj03kSCNF01/G8/RHKADADwAwAMwDMADADwAwAMwDMADADwAwAMwDMADADwAwAmw/w/v7x6z9v84fon/ndGWCpFbvbJ9kyz6EV2zHADfHbMc+h+Pc3wCH6/V8+D/2GBvj4qesF8tR+BwOU9ivy9JjyewYorUmeKnOsZ4DSyuTJu6kWA5S2zxOWJOrc3gxQyIhhAIwBMMGrH2JP780AMAPADIBJWf2QcUc/BoAZAGYATOLqh7ybejAAzAAwA2DSVz9k31eXAWAGgBkAA61+YG6txQAwA8AMgEFXP5B38wwAMwDMAJgCqx/4CRgGgBkA9kIBxqtGO7/KMc/554PFzzFeONr5hY55zj8fLGuOOq9dZ5JPWXPUee06k3zKnYN9efb2H+ROw66Avf0HxDTUIqh7DxHTUIug7j3ETZO5jsy7JnEzZS4l865J9Ew5q8m55RJ6ppzV5NxySY2Z4hYUd/IiNSaLW1PcyYtUmixiWRFnLlVpsohlRZy5VL3JVq1s1TnB6s23anGrzglWdb7767t/Qoqq891f3/0TUtSe79oSr30LUnvKa6u89i1IhylnFzr7PKrDlLMLnX0e1WPKhzNrPfNMMX1mPbPcM88U02nWh+MVH39aUqdZH45XfPxpSZ1mfdovev+fJvpN/LBf9/4/TfSb+Gm79O3frfSb+Gm79O3frfSb+Ku2qx+6zv1kAN1hAJgBYAaAGQBmAJgBYAaAGQBmAJgBYAaAGQBmAJgBYAaAGQBmAJgBYAaAGQBmAJgBYAaAGQBmAJgBYAaAGQBmANhfnlfkgaL6FZsAAAAASUVORK5CYII=" />
+//! <div style="flex-grow: 1;">
+//!
+//! ```rust
+//! # let mut display = embedded_graphics::mock_display::MockDisplay::default();
+//! use embedded_graphics::{
+//!     pixelcolor::Rgb888,
+//!     prelude::*,
+//!     primitives::Polyline,
+//!     style::PrimitiveStyle,
+//! };
+//!
+//! let points: [Point; 5] = [
+//!     Point::new(8, 8),
+//!     Point::new(48, 16),
+//!     Point::new(32, 48),
+//!     Point::new(16, 32),
+//!     Point::new(32, 32),
+//! ];
+//!
+//! Polyline::new(&points)
+//!     .into_styled(PrimitiveStyle::with_stroke(Rgb888::CYAN, 1))
+//!     .draw(&mut display)?;
+//! # Ok::<(), core::convert::Infallible>(())
+//! ```
+//!
+//! </div>
+//! </div>
+//!
 //! ## Draw some text
 //!
 //! This example draws the text "Hello,\nRust!" with the [`Font6x8`] font in green.

--- a/embedded-graphics/src/primitives/mod.rs
+++ b/embedded-graphics/src/primitives/mod.rs
@@ -3,12 +3,14 @@
 pub mod circle;
 pub mod ellipse;
 pub mod line;
+pub mod polyline;
 pub mod rectangle;
 mod thick_line_iterator;
 pub mod triangle;
 
 pub use self::{
-    circle::Circle, ellipse::Ellipse, line::Line, rectangle::Rectangle, triangle::Triangle,
+    circle::Circle, ellipse::Ellipse, line::Line, polyline::Polyline, rectangle::Rectangle,
+    triangle::Triangle,
 };
 use crate::{
     geometry::{Dimensions, Point},

--- a/embedded-graphics/src/primitives/polyline.rs
+++ b/embedded-graphics/src/primitives/polyline.rs
@@ -257,7 +257,11 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{geometry::Size, pixelcolor::Rgb565, prelude::*};
+    use crate::{
+        mock_display::MockDisplay,
+        pixelcolor::{BinaryColor, Rgb565},
+        prelude::*,
+    };
 
     // A "heartbeat" shaped polyline
     const HEARTBEAT: [Point; 10] = [
@@ -271,6 +275,14 @@ mod tests {
         Point::new(110, 84),
         Point::new(120, 64),
         Point::new(300, 64),
+    ];
+
+    // Smaller test pattern for mock display
+    const SMALL: [Point; 4] = [
+        Point::new(2, 5),
+        Point::new(5, 2),
+        Point::new(10, 5),
+        Point::new(15, 2),
     ];
 
     #[test]
@@ -330,5 +342,50 @@ mod tests {
         let thin = polyline.into_styled(PrimitiveStyle::with_stroke(Rgb565::RED, 1));
 
         assert!(thick.into_iter().eq(thin.into_iter()));
+    }
+
+    #[test]
+    fn mock_display() {
+        let mut display: MockDisplay<BinaryColor> = MockDisplay::new();
+
+        Polyline::new(&SMALL)
+            .into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 1))
+            .draw(&mut display)
+            .unwrap();
+
+        assert_eq!(
+            display,
+            MockDisplay::from_pattern(&[
+                "                ",
+                "                ",
+                "     #         #",
+                "    # ##     ## ",
+                "   #    ## ##   ",
+                "  #       #     ",
+            ])
+        );
+    }
+
+    // Ensure that consecutive points are always different
+    #[test]
+    fn no_duplicate_points() {
+        let expected: [Point; 14] = [
+            Point::new(2, 5),
+            Point::new(3, 4),
+            Point::new(4, 3),
+            Point::new(5, 2),
+            Point::new(6, 3),
+            Point::new(7, 3),
+            Point::new(8, 4),
+            Point::new(9, 4),
+            Point::new(10, 5),
+            Point::new(11, 4),
+            Point::new(12, 4),
+            Point::new(13, 3),
+            Point::new(14, 3),
+            Point::new(15, 2),
+        ];
+
+        assert!(Polyline::new(&SMALL).points().eq(expected.iter().copied()))
     }
 }

--- a/embedded-graphics/src/primitives/polyline.rs
+++ b/embedded-graphics/src/primitives/polyline.rs
@@ -5,7 +5,10 @@ use crate::{
     drawable::{Drawable, Pixel},
     geometry::{Dimensions, Point},
     pixelcolor::PixelColor,
-    primitives::{line::Line, thick_line_iterator::ThickLineIterator, Primitive, Rectangle},
+    primitives::{
+        line::{self, Line},
+        Primitive, Rectangle,
+    },
     style::{PrimitiveStyle, Styled},
     transform::Transform,
 };
@@ -156,7 +159,7 @@ impl<'a> Transform for Polyline<'a> {
 pub struct Points<'a> {
     vertices: &'a [Point],
     translate: Point,
-    segment_iter: ThickLineIterator,
+    segment_iter: line::Points,
 }
 
 impl<'a> Points<'a> {
@@ -167,7 +170,7 @@ impl<'a> Points<'a> {
         Points {
             vertices: polyline.vertices,
             translate: polyline.translate,
-            segment_iter: ThickLineIterator::new(&Line::new(Point::zero(), Point::zero()), 1),
+            segment_iter: Line::new(Point::zero(), Point::zero()).points(),
         }
     }
 }
@@ -188,10 +191,7 @@ impl<'a> Iterator for Points<'a> {
 
             self.vertices = rest;
 
-            self.segment_iter = ThickLineIterator::new(
-                &Line::new(*start + self.translate, *end + self.translate),
-                1,
-            );
+            self.segment_iter = Line::new(*start + self.translate, *end + self.translate).points();
 
             // Skip first point of next line, otherwise we overlap with the previous line
             self.nth(1)

--- a/embedded-graphics/src/primitives/polyline.rs
+++ b/embedded-graphics/src/primitives/polyline.rs
@@ -1,0 +1,235 @@
+//! The line primitive
+
+// TODO: Group imports
+use crate::draw_target::DrawTarget;
+use crate::drawable::Drawable;
+use crate::drawable::Pixel;
+use crate::geometry::Dimensions;
+use crate::geometry::Size;
+use crate::pixelcolor::PixelColor;
+use crate::primitives::Primitive;
+use crate::style::PrimitiveStyle;
+use crate::style::Styled;
+use crate::{
+    geometry::Point,
+    primitives::{line::Line, thick_line_iterator::ThickLineIterator},
+};
+
+/// Polyline primitive
+///
+/// Creates an unfilled chained line shape
+///
+/// # Examples
+///
+/// ## Create some lines with different styles
+///
+/// ```rust
+/// use embedded_graphics::{
+///     pixelcolor::Rgb565, prelude::*, primitives::Line, style::PrimitiveStyle,
+/// };
+/// # use embedded_graphics::mock_display::MockDisplay;
+/// # let mut display = MockDisplay::default();
+///
+/// // TODO: Example
+/// # Ok::<(), core::convert::Infallible>(())
+/// ```
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+pub struct Polyline<'a> {
+    /// All vertices in the line
+    pub vertices: &'a [Point],
+}
+
+impl<'a> Polyline<'a> {
+    /// Create a new polyline from a list of vertices
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if the number of vertices is less than 2
+    pub fn new(vertices: &'a [Point]) -> Self {
+        if vertices.len() < 2 {
+            panic!("Polyline must contain at least two vertices");
+        }
+
+        Self { vertices }
+    }
+}
+
+impl<'a> Primitive for Polyline<'a> {}
+
+impl<'a> Dimensions for Polyline<'a> {
+    fn top_left(&self) -> Point {
+        self.vertices
+            .iter()
+            .fold(Point::new(core::i32::MAX, core::i32::MAX), |accum, v| {
+                Point::new(accum.x.min(v.x), accum.y.min(v.y))
+            })
+    }
+
+    fn bottom_right(&self) -> Point {
+        self.vertices
+            .iter()
+            .fold(Point::new(core::i32::MIN, core::i32::MIN), |accum, v| {
+                Point::new(accum.x.max(v.x), accum.y.max(v.y))
+            })
+    }
+
+    fn size(&self) -> Size {
+        Size::from_bounding_box(self.top_left(), self.bottom_right())
+    }
+}
+
+/// TODO: Docs
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+pub struct PolylineIterator<'a> {
+    stop: bool,
+    vertices: &'a [Point],
+    segment_iter: ThickLineIterator,
+}
+
+impl<'a> Iterator for PolylineIterator<'a> {
+    type Item = Point;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.stop {
+            return None;
+        }
+
+        if let Some(p) = self.segment_iter.next() {
+            Some(p)
+        } else {
+            let (start, rest) = self.vertices.split_first()?;
+            let end = rest.get(0)?;
+
+            self.vertices = rest;
+
+            self.segment_iter = ThickLineIterator::new(&Line::new(*start, *end), 1);
+
+            Self::next(self)
+        }
+    }
+}
+
+impl<'a> IntoIterator for Polyline<'a> {
+    type Item = Point;
+    type IntoIter = PolylineIterator<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.vertices
+            .split_first()
+            .and_then(|(start, rest)| {
+                // Polyline is 2 or more vertices long, return an iterator for it
+                rest.get(0).map(|end| Self::IntoIter {
+                    stop: false,
+                    vertices: rest,
+                    segment_iter: ThickLineIterator::new(&Line::new(*start, *end), 1),
+                })
+            })
+            .unwrap_or_else(||
+                // Polyline is less than 2 vertices long. Return a dummy iterator that will short
+                // circuit due to `stop: true`
+                Self::IntoIter {
+                    stop: true,
+                    vertices: &[],
+                    segment_iter: ThickLineIterator::new(&Line::new(Point::zero(), Point::zero()), 1),
+                })
+    }
+}
+
+impl<'a, C> IntoIterator for &'a Styled<Polyline<'a>, PrimitiveStyle<C>>
+where
+    C: PixelColor,
+{
+    type Item = Pixel<C>;
+    type IntoIter = StyledPolylineIterator<'a, C>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        StyledPolylineIterator {
+            style: self.style,
+
+            line_iter: self.primitive.into_iter(),
+        }
+    }
+}
+
+/// Pixel iterator for each pixel in the line
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+pub struct StyledPolylineIterator<'a, C>
+where
+    C: PixelColor,
+{
+    style: PrimitiveStyle<C>,
+
+    line_iter: PolylineIterator<'a>,
+}
+
+// [Bresenham's line algorithm](https://en.wikipedia.org/wiki/Bresenham%27s_line_algorithm)
+impl<'a, C: PixelColor> Iterator for StyledPolylineIterator<'a, C> {
+    type Item = Pixel<C>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // Break if stroke width is zero
+        if self.style.stroke_width == 0 {
+            return None;
+        }
+
+        // Return none if stroke color is none
+        let stroke_color = self.style.stroke_color?;
+
+        self.line_iter
+            .next()
+            .map(|point| Pixel(point, stroke_color))
+    }
+}
+
+impl<'a, C: 'a> Drawable<C> for &Styled<Polyline<'a>, PrimitiveStyle<C>>
+where
+    C: PixelColor,
+{
+    fn draw<D: DrawTarget<C>>(self, display: &mut D) -> Result<(), D::Error> {
+        display.draw_iter(self.into_iter())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{drawable::Pixel, pixelcolor::BinaryColor};
+
+    // A "heartbeat" shaped polyline
+    const HEARTBEAT: [Point; 10] = [
+        Point::new(10, 64),
+        Point::new(50, 64),
+        Point::new(60, 44),
+        Point::new(70, 64),
+        Point::new(80, 64),
+        Point::new(90, 74),
+        Point::new(100, 10),
+        Point::new(110, 84),
+        Point::new(120, 64),
+        Point::new(300, 64),
+    ];
+
+    #[test]
+    fn positive_dimensions() {
+        let polyline = Polyline::new(&HEARTBEAT);
+
+        assert_eq!(polyline.top_left(), Point::new(10, 10));
+        assert_eq!(polyline.bottom_right(), Point::new(300, 84));
+        assert_eq!(polyline.size(), Size::new(290, 74));
+    }
+
+    #[test]
+    fn negative_dimensions() {
+        let mut negative: [Point; 10] = [Point::zero(); 10];
+
+        for (i, v) in HEARTBEAT.iter().enumerate() {
+            negative[i] = *v - Point::new(100, 100);
+        }
+
+        let polyline = Polyline::new(&negative);
+
+        assert_eq!(polyline.top_left(), Point::new(-90, -90));
+        assert_eq!(polyline.bottom_right(), Point::new(200, -16));
+        assert_eq!(polyline.size(), Size::new(290, 74));
+    }
+}

--- a/embedded-graphics/src/primitives/polyline.rs
+++ b/embedded-graphics/src/primitives/polyline.rs
@@ -15,8 +15,8 @@ use crate::{
 
 /// Polyline primitive
 ///
-/// Creates an unfilled chained line shape. Styles with a width greater than 1px are not currently
-/// supported and will always render as a 1px wide line.
+/// Creates an unfilled chained line shape. Styles with a stroke width greater than 1px are not
+/// currently supported and will always render as a 1px wide line.
 ///
 /// # Examples
 ///

--- a/embedded-graphics/src/primitives/polyline.rs
+++ b/embedded-graphics/src/primitives/polyline.rs
@@ -76,7 +76,7 @@ impl<'a> Polyline<'a> {
 }
 
 impl<'a> Primitive for Polyline<'a> {
-    type PointsIter = PolylineIterator<'a>;
+    type PointsIter = Points<'a>;
 
     fn points(&self) -> Self::PointsIter {
         self.into_iter()
@@ -159,14 +159,14 @@ impl<'a> Transform for Polyline<'a> {
 
 /// An iterator over all pixel positions on the polyline
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
-pub struct PolylineIterator<'a> {
+pub struct Points<'a> {
     stop: bool,
     vertices: &'a [Point],
     translate: Point,
     segment_iter: ThickLineIterator,
 }
 
-impl<'a> Iterator for PolylineIterator<'a> {
+impl<'a> Iterator for Points<'a> {
     type Item = Point;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -197,7 +197,7 @@ impl<'a> Iterator for PolylineIterator<'a> {
 
 impl<'a> IntoIterator for Polyline<'a> {
     type Item = Point;
-    type IntoIter = PolylineIterator<'a>;
+    type IntoIter = Points<'a>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.vertices
@@ -250,7 +250,7 @@ where
 {
     style: PrimitiveStyle<C>,
 
-    line_iter: PolylineIterator<'a>,
+    line_iter: Points<'a>,
 }
 
 impl<'a, C: PixelColor> Iterator for StyledPolylineIterator<'a, C> {

--- a/embedded-graphics/src/primitives/polyline.rs
+++ b/embedded-graphics/src/primitives/polyline.rs
@@ -194,9 +194,7 @@ impl<'a> Iterator for Points<'a> {
             );
 
             // Skip first point of next line, otherwise we overlap with the previous line
-            Self::next(self);
-
-            Self::next(self)
+            self.nth(1)
         }
     }
 }

--- a/embedded-graphics/src/primitives/polyline.rs
+++ b/embedded-graphics/src/primitives/polyline.rs
@@ -279,9 +279,10 @@ mod tests {
 
         let bb = polyline.bounding_box();
 
-        assert_eq!(bb.top_left, Point::new(10, 10));
-        assert_eq!(bb.top_left + bb.size, Point::new(301, 85));
-        assert_eq!(bb.size, Size::new(291, 75));
+        assert_eq!(
+            bb,
+            Rectangle::with_corners(Point::new(10, 10), Point::new(300, 84))
+        );
     }
 
     #[test]
@@ -296,9 +297,10 @@ mod tests {
 
         let bb = polyline.bounding_box();
 
-        assert_eq!(bb.top_left, Point::new(-90, -90));
-        assert_eq!(bb.top_left + bb.size, Point::new(201, -15));
-        assert_eq!(bb.size, Size::new(291, 75));
+        assert_eq!(
+            bb,
+            Rectangle::with_corners(Point::new(-90, -90), Point::new(200, -16))
+        );
     }
 
     #[test]
@@ -307,9 +309,10 @@ mod tests {
 
         let bb = polyline.bounding_box();
 
-        assert_eq!(bb.top_left, Point::new(-90, -90));
-        assert_eq!(bb.top_left + bb.size, Point::new(201, -15));
-        assert_eq!(bb.size, Size::new(291, 75));
+        assert_eq!(
+            bb,
+            Rectangle::with_corners(Point::new(-90, -90), Point::new(200, -16))
+        );
     }
 
     #[test]

--- a/embedded-graphics/src/primitives/polyline.rs
+++ b/embedded-graphics/src/primitives/polyline.rs
@@ -60,14 +60,8 @@ pub struct Polyline<'a> {
 impl<'a> Polyline<'a> {
     /// Create a new polyline from a list of vertices
     ///
-    /// # Panics
-    ///
-    /// This method will panic if the number of vertices is less than 2
+    /// If fewer than two vertices are provided, the line will not render anything when drawn.
     pub fn new(vertices: &'a [Point]) -> Self {
-        if vertices.len() < 2 {
-            panic!("Polyline must contain at least two vertices");
-        }
-
         Self {
             vertices,
             translate: Point::zero(),
@@ -336,7 +330,6 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
     fn one_point() {
         let _polyline = Polyline::new(&[Point::zero()]);
     }

--- a/embedded-graphics/src/primitives/polyline.rs
+++ b/embedded-graphics/src/primitives/polyline.rs
@@ -78,6 +78,8 @@ impl<'a> Dimensions for Polyline<'a> {
     }
 }
 
+// TODO: Find a way to impl Transform
+
 /// TODO: Docs
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub struct PolylineIterator<'a> {
@@ -232,4 +234,13 @@ mod tests {
         assert_eq!(polyline.bottom_right(), Point::new(200, -16));
         assert_eq!(polyline.size(), Size::new(290, 74));
     }
+
+    // #[test]
+    // fn transformed_dimensions() {
+    //     let polyline = Polyline::new(&HEARTBEAT).translate(Point::new(-100, -100));
+
+    //     assert_eq!(polyline.top_left(), Point::new(-90, -90));
+    //     assert_eq!(polyline.bottom_right(), Point::new(200, -16));
+    //     assert_eq!(polyline.size(), Size::new(290, 74));
+    // }
 }

--- a/embedded-graphics/src/primitives/polyline.rs
+++ b/embedded-graphics/src/primitives/polyline.rs
@@ -7,7 +7,7 @@ use crate::drawable::Pixel;
 use crate::geometry::Dimensions;
 use crate::geometry::Size;
 use crate::pixelcolor::PixelColor;
-use crate::primitives::Primitive;
+use crate::primitives::{Primitive, Rectangle};
 use crate::style::PrimitiveStyle;
 use crate::style::Styled;
 use crate::{
@@ -57,24 +57,22 @@ impl<'a> Polyline<'a> {
 impl<'a> Primitive for Polyline<'a> {}
 
 impl<'a> Dimensions for Polyline<'a> {
-    fn top_left(&self) -> Point {
-        self.vertices
+    fn bounding_box(&self) -> Rectangle {
+        let top_left = self
+            .vertices
             .iter()
             .fold(Point::new(core::i32::MAX, core::i32::MAX), |accum, v| {
                 Point::new(accum.x.min(v.x), accum.y.min(v.y))
-            })
-    }
+            });
 
-    fn bottom_right(&self) -> Point {
-        self.vertices
+        let bottom_right = self
+            .vertices
             .iter()
             .fold(Point::new(core::i32::MIN, core::i32::MIN), |accum, v| {
                 Point::new(accum.x.max(v.x), accum.y.max(v.y))
-            })
-    }
+            });
 
-    fn size(&self) -> Size {
-        Size::from_bounding_box(self.top_left(), self.bottom_right())
+        Rectangle::with_corners(top_left, bottom_right)
     }
 }
 

--- a/embedded-graphics/src/primitives/polyline.rs
+++ b/embedded-graphics/src/primitives/polyline.rs
@@ -443,4 +443,14 @@ mod tests {
             .into_iter()
             .eq(core::iter::empty()));
     }
+
+    #[test]
+    #[ignore]
+    fn equal_points() {
+        let points: [Point; 3] = [Point::new(2, 5), Point::new(2, 5), Point::new(2, 5)];
+
+        assert!(Polyline::new(&points)
+            .points()
+            .eq(core::iter::once(Point::new(2, 5))));
+    }
 }

--- a/embedded-graphics/src/primitives/polyline.rs
+++ b/embedded-graphics/src/primitives/polyline.rs
@@ -187,6 +187,9 @@ impl<'a> Iterator for PolylineIterator<'a> {
                 1,
             );
 
+            // Skip first point of next line, otherwise we overlap with the previous line
+            Self::next(self);
+
             Self::next(self)
         }
     }

--- a/embedded-graphics/src/primitives/polyline.rs
+++ b/embedded-graphics/src/primitives/polyline.rs
@@ -16,13 +16,13 @@ use crate::{
 /// Polyline primitive
 ///
 /// Creates an unfilled chained line shape. Styles with a width greater than 1px are not currently
-/// supported.
+/// supported and will always render as a 1px wide line.
 ///
 /// # Examples
 ///
 /// ## Draw a "heartbeat" shaped polyline
 ///
-/// This example draws a stylized cardiogram in
+/// This example draws a stylized cardiogram in a 1px green stroke.
 ///
 /// ```rust
 /// use embedded_graphics::{
@@ -54,7 +54,8 @@ use crate::{
 /// ```
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 pub struct Polyline<'a> {
-    translate: Point,
+    /// An offset to apply to the polyline as a whole
+    pub translate: Point,
 
     /// All vertices in the line
     pub vertices: &'a [Point],

--- a/embedded-graphics/src/primitives/polyline.rs
+++ b/embedded-graphics/src/primitives/polyline.rs
@@ -164,27 +164,11 @@ impl<'a> Points<'a> {
     where
         'a: 'b,
     {
-        polyline.vertices
-            .split_first()
-            .and_then(|(start, rest)| {
-                // Polyline is 2 or more vertices long, return an iterator for it
-                rest.get(0).map(|end| Points {
-                    vertices: rest,
-                    translate: polyline.translate,
-                    segment_iter:ThickLineIterator::new(
-                        &Line::new(*start + polyline.translate, *end + polyline.translate),
-                        1,
-                    ),
-                })
-            })
-            .unwrap_or_else(||
-                // Polyline is less than 2 vertices long. Return a dummy iterator that will short
-                // circuit due to `stop: true`
-                Points {
-                    vertices: &[],
-                    translate: Point::zero(),
-                    segment_iter: ThickLineIterator::new(&Line::new(Point::zero(), Point::zero()), 1),
-                })
+        Points {
+            vertices: polyline.vertices,
+            translate: polyline.translate,
+            segment_iter: ThickLineIterator::new(&Line::new(Point::zero(), Point::zero()), 1),
+        }
     }
 }
 

--- a/embedded-graphics/src/primitives/polyline.rs
+++ b/embedded-graphics/src/primitives/polyline.rs
@@ -160,7 +160,6 @@ impl<'a> Transform for Polyline<'a> {
 /// An iterator over all pixel positions on the polyline
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub struct Points<'a> {
-    stop: bool,
     vertices: &'a [Point],
     translate: Point,
     segment_iter: ThickLineIterator,
@@ -176,7 +175,6 @@ impl<'a> Points<'a> {
             .and_then(|(start, rest)| {
                 // Polyline is 2 or more vertices long, return an iterator for it
                 rest.get(0).map(|end| Points {
-                    stop: false,
                     vertices: rest,
                     translate: polyline.translate,
                     segment_iter:ThickLineIterator::new(
@@ -189,7 +187,6 @@ impl<'a> Points<'a> {
                 // Polyline is less than 2 vertices long. Return a dummy iterator that will short
                 // circuit due to `stop: true`
                 Points {
-                    stop: true,
                     vertices: &[],
                     translate: Point::zero(),
                     segment_iter: ThickLineIterator::new(&Line::new(Point::zero(), Point::zero()), 1),
@@ -201,7 +198,7 @@ impl<'a> Iterator for Points<'a> {
     type Item = Point;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.stop {
+        if self.vertices.len() < 2 {
             return None;
         }
 

--- a/embedded-graphics/src/primitives/polyline.rs
+++ b/embedded-graphics/src/primitives/polyline.rs
@@ -223,10 +223,7 @@ where
     type IntoIter = StyledPolylineIterator<'a, C>;
 
     fn into_iter(self) -> Self::IntoIter {
-        StyledPolylineIterator {
-            stroke_color: self.style.effective_stroke_color(),
-            line_iter: self.primitive.points(),
-        }
+        StyledPolylineIterator::new(self)
     }
 }
 
@@ -240,7 +237,22 @@ where
     line_iter: Points<'a>,
 }
 
-impl<'a, C: PixelColor> Iterator for StyledPolylineIterator<'a, C> {
+impl<'a, C> StyledPolylineIterator<'a, C>
+where
+    C: PixelColor,
+{
+    fn new(styled: &Styled<Polyline<'a>, PrimitiveStyle<C>>) -> Self {
+        StyledPolylineIterator {
+            stroke_color: styled.style.effective_stroke_color(),
+            line_iter: styled.primitive.points(),
+        }
+    }
+}
+
+impl<'a, C> Iterator for StyledPolylineIterator<'a, C>
+where
+    C: PixelColor,
+{
     type Item = Pixel<C>;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/embedded-graphics/src/primitives/polyline.rs
+++ b/embedded-graphics/src/primitives/polyline.rs
@@ -232,8 +232,8 @@ where
 
     fn into_iter(self) -> Self::IntoIter {
         StyledPolylineIterator {
-            style: self.style,
-
+            stroke_width: self.style.stroke_width,
+            stroke_color: self.style.stroke_color,
             line_iter: self.primitive.points(),
         }
     }
@@ -245,8 +245,8 @@ pub struct StyledPolylineIterator<'a, C>
 where
     C: PixelColor,
 {
-    style: PrimitiveStyle<C>,
-
+    stroke_width: u32,
+    stroke_color: Option<C>,
     line_iter: Points<'a>,
 }
 
@@ -255,12 +255,12 @@ impl<'a, C: PixelColor> Iterator for StyledPolylineIterator<'a, C> {
 
     fn next(&mut self) -> Option<Self::Item> {
         // Break if stroke width is zero
-        if self.style.stroke_width == 0 {
+        if self.stroke_width == 0 {
             return None;
         }
 
         // Return none if stroke color is none
-        let stroke_color = self.style.stroke_color?;
+        let stroke_color = self.stroke_color?;
 
         self.line_iter
             .next()

--- a/embedded-graphics/src/style/primitive_style.rs
+++ b/embedded-graphics/src/style/primitive_style.rs
@@ -116,6 +116,14 @@ where
     pub(crate) fn is_transparent(&self) -> bool {
         (self.stroke_color.is_none() || self.stroke_width == 0) && self.fill_color.is_none()
     }
+
+    /// Returns the effective stroke color of the style.
+    ///
+    /// If the stroke width is 0, this method will return `None` regardless of the value in
+    /// `stroke_color`.
+    pub(crate) fn effective_stroke_color(&self) -> Option<C> {
+        self.stroke_color.filter(|_| self.stroke_width > 0)
+    }
 }
 
 impl<C> Default for PrimitiveStyle<C>
@@ -390,6 +398,19 @@ mod tests {
                 .fill_color(BinaryColor::On)
                 .build(),
             PrimitiveStyle::with_fill(BinaryColor::On)
+        );
+    }
+
+    #[test]
+    fn effective_stroke_color() {
+        assert_eq!(
+            PrimitiveStyle::with_stroke(BinaryColor::On, 1).effective_stroke_color(),
+            Some(BinaryColor::On)
+        );
+
+        assert_eq!(
+            PrimitiveStyle::with_stroke(BinaryColor::On, 0).effective_stroke_color(),
+            None
         );
     }
 }

--- a/simulator/benches/primitives.rs
+++ b/simulator/benches/primitives.rs
@@ -3,7 +3,7 @@ use embedded_graphics::{
     drawable::Pixel,
     geometry::{Point, Size},
     pixelcolor::Gray8,
-    primitives::{Circle, Ellipse, Line, Primitive, Rectangle, Triangle},
+    primitives::*,
     style::{PrimitiveStyle, PrimitiveStyleBuilder},
 };
 
@@ -107,6 +107,23 @@ fn filled_ellipse(c: &mut Criterion) {
     });
 }
 
+fn polyline(c: &mut Criterion) {
+    c.bench_function("polyline", |b| {
+        let points = [
+            Point::new(5, 10),
+            Point::new(15, 20),
+            Point::new(5, 20),
+            Point::new(30, 50),
+            Point::new(100, 100),
+        ];
+
+        let object =
+            &Polyline::new(&points).into_styled(PrimitiveStyle::with_stroke(Gray8::new(1), 1));
+
+        b.iter(|| object.into_iter().collect::<Vec<Pixel<Gray8>>>())
+    });
+}
+
 criterion_group!(
     primitives,
     filled_circle,
@@ -118,6 +135,7 @@ criterion_group!(
     triangle,
     filled_triangle,
     ellipse,
-    filled_ellipse
+    filled_ellipse,
+    polyline
 );
 criterion_main!(primitives);

--- a/simulator/examples/primitives-polyline.rs
+++ b/simulator/examples/primitives-polyline.rs
@@ -1,0 +1,40 @@
+//! # Example: Polyline
+//!
+//! This example draws a crude "heartbeat" shape using the `Polyline` primitive
+
+use embedded_graphics::{
+    pixelcolor::Rgb888, prelude::*, primitives::Polyline, style::PrimitiveStyle,
+};
+use embedded_graphics_simulator::{OutputSettings, SimulatorDisplay, Window};
+
+const PADDING: i32 = 16;
+
+fn main() -> Result<(), core::convert::Infallible> {
+    let (w, h) = (320i32, 256i32);
+
+    let mut display: SimulatorDisplay<Rgb888> =
+        SimulatorDisplay::new(Size::new(w as u32, h as u32));
+
+    let line_style = PrimitiveStyle::with_stroke(Rgb888::GREEN, 1);
+
+    let points = [
+        Point::new(PADDING, h / 2),
+        Point::new(50, h / 2),
+        Point::new(60, h / 2 - 20),
+        Point::new(70, h / 2),
+        Point::new(80, h / 2),
+        Point::new(90, h / 2 + 10),
+        Point::new(100, PADDING),
+        Point::new(110, h / 2 + 20),
+        Point::new(120, h / 2),
+        Point::new(w - PADDING, h / 2),
+    ];
+
+    Polyline::new(&points)
+        .into_styled(line_style)
+        .draw(&mut display)?;
+
+    Window::new("Polyline", &OutputSettings::default()).show_static(&display);
+
+    Ok(())
+}

--- a/simulator/src/bin/generate-example-screenshots.rs
+++ b/simulator/src/bin/generate-example-screenshots.rs
@@ -176,6 +176,29 @@ some display drivers implement accelerated drawing of iterators."#,
 
     op!(
         display,
+        "Draw a polyline",
+        "This example draws a polyline with 1px cyan stroke.",
+        {
+            use embedded_graphics::{
+                pixelcolor::Rgb888, prelude::*, primitives::Polyline, style::PrimitiveStyle,
+            };
+            {}
+            let points: [Point; 5] = [
+                Point::new(8, 8),
+                Point::new(48, 16),
+                Point::new(32, 48),
+                Point::new(16, 32),
+                Point::new(32, 32),
+            ];
+            {}
+            Polyline::new(&points)
+                .into_styled(PrimitiveStyle::with_stroke(Rgb888::CYAN, 1))
+                .draw(&mut display)?;
+        }
+    );
+
+    op!(
+        display,
         "Draw some text",
         "This example draws the text \"Hello,\\nRust!\" with the [`Font6x8`] font in green.",
         {


### PR DESCRIPTION
Hi! Thank you for helping out with Embedded Graphics development! Please:

- [x] Check that you've added passing tests and documentation
- [x] Add a simulator example(s) where applicable
- [x] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) and appropriate crate (`embedded-graphics`, `simulator`, `tinytga`, `tinybmp`) if your changes affect the **public API**
- [x] Run `rustfmt` on the project
- [x] Run `./build.sh` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

This PR adds the `Polyline` primitive, allowing non-filled shapes to be drawn.

Polylines won't yet support stroke thickness even after #271 is merged as we need a good solution for line caps/joiners which I'll tackle later on.

Closes #77 