### PR TITLE
Make SDL2 an optional simulator dependency

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -xe
 
 cargo clean --doc
 
@@ -8,6 +8,10 @@ cargo fmt --all -- --check
 cargo test --release
 cargo test --release --all-features
 cargo bench --no-run
+
+pushd simulator
+cargo build --release --no-default-features
+popd
 
 cargo doc --all-features
 linkchecker target/doc/embedded_graphics/index.html

--- a/simulator/CHANGELOG.md
+++ b/simulator/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+- [#298](https://github.com/jamwaffles/embedded-graphics/pull/298) Added the `with-sdl` option (enabled by default) to allow optionally disabling SDL2 support.
+
 ## [0.2.0] - 2020-03-20
 
 ### Added
@@ -45,7 +49,7 @@
 - The builtin simulator now supports colour pixel types, like `RGB565`.
 
 <!-- next-url -->
+
 [unreleased]: https://github.com/jamwaffles/embedded-graphics-simulator/compare/embedded-graphics-simulator-v0.2.0...HEAD
 [0.2.0]: https://github.com/jamwaffles/embedded-graphics-simulator/compare/embedded-graphics-simulator-v0.2.0-beta.2...embedded-graphics-simulator-v0.2.0
-
 [0.2.0-beta.2]: https://github.com/jamwaffles/embedded-graphics/compare/embedded-graphics-simulator-v0.2.0-alpha.1...embedded-graphics-simulator-v0.2.0-beta.2

--- a/simulator/Cargo.toml
+++ b/simulator/Cargo.toml
@@ -32,8 +32,11 @@ name = "image"
 required-features = ["bmp"]
 
 [dependencies]
-sdl2 = "0.32.2"
 image = "0.23.0"
+
+[dependencies.sdl2]
+version = "0.32.2"
+optional = true
 
 [dependencies.embedded-graphics]
 version = "0.6.0"
@@ -43,3 +46,7 @@ chrono = "0.4.10"
 criterion = { version = "0.3.0", default-features = false }
 tinybmp = { version = "0.2.2", features = [ "graphics" ] }
 tinytga = { version = "0.3.2", features = [ "graphics" ] }
+
+[features]
+default = [ "with-sdl" ]
+with-sdl = [ "sdl2" ]

--- a/simulator/README.md
+++ b/simulator/README.md
@@ -73,16 +73,17 @@ any format supported by `image`.
 
 # Usage without SDL2
 
-The `with-sdl` feature can be disabled by adding `default-features = false` to the dependency. This
-will remove the requirement on SDL2 build files being present and removes the `OutputSettings::output_to_display` and `OutputSettings::pixel_pitch` methods. For example:
+When the simulator is used in headless/CI environments that don't require showing a window, SDL2
+support can be disabled. This removes the requirement of SDL2 being installed on the target machine,
+but still allows the simulator to be used to generate images.
+
+The `with-sdl` feature is enabled by default and can be disabled by adding `default-features = false` to the dependency:
 
 ```toml
-[dependencies]
-embedded-graphics-simulator = "0.2.0"
+[dependencies.embedded-graphics-simulator]
+version = "0.2.0"
 default-features = false
 ```
-
-This may be useful for screenshot generation in headless/CI environments where extra dependencies are undesirable.
 
 See the [Choosing
 Features](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#choosing-features)

--- a/simulator/README.md
+++ b/simulator/README.md
@@ -74,13 +74,15 @@ any format supported by `image`.
 # Usage without SDL2
 
 The `with-sdl` feature can be disabled by adding `default-features = false` to the dependency. This
-will remove the requirement on SDL2 build files being present. For example:
+will remove the requirement on SDL2 build files being present and removes the `OutputSettings::output_to_display` and `OutputSettings::pixel_pitch` methods. For example:
 
 ```toml
 [dependencies]
 embedded-graphics-simulator = "0.2.0"
 default-features = false
 ```
+
+This may be useful for screenshot generation in headless/CI environments where extra dependencies are undesirable.
 
 See the [Choosing
 Features](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#choosing-features)

--- a/simulator/README.md
+++ b/simulator/README.md
@@ -70,3 +70,18 @@ If a program doesn't require to display a window and only needs to export one or
 `SimulatorDisplay` can also be converted to an `image` crate `ImageBuffer` by using the
 `to_image_buffer` method. The resulting buffer can then be used to save the display content to
 any format supported by `image`.
+
+# Usage without SDL2
+
+The `with-sdl` feature can be disabled by adding `default-features = false` to the dependency. This
+will remove the requirement on SDL2 build files being present. For example:
+
+```toml
+[dependencies]
+embedded-graphics-simulator = "0.2.0"
+default-features = false
+```
+
+See the [Choosing
+Features](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#choosing-features)
+Cargo manifest documentation for more details.

--- a/simulator/src/lib.rs
+++ b/simulator/src/lib.rs
@@ -86,11 +86,15 @@ mod display;
 mod framebuffer;
 mod output_settings;
 mod theme;
+
+#[cfg(feature = "with-sdl")]
 mod window;
+
+#[cfg(feature = "with-sdl")]
+pub use window::{SimulatorEvent, Window};
 
 pub use crate::{
     display::SimulatorDisplay,
     output_settings::{OutputSettings, OutputSettingsBuilder},
     theme::BinaryColorTheme,
-    window::{SimulatorEvent, Window},
 };

--- a/simulator/src/output_settings.rs
+++ b/simulator/src/output_settings.rs
@@ -31,11 +31,13 @@ impl OutputSettings {
     }
 
     /// Translates a output coordinate to the corresponding display coordinate.
+    #[allow(unused)]
     pub(crate) const fn output_to_display(&self, output_point: Point) -> Point {
         let pitch = self.pixel_pitch() as i32;
         Point::new(output_point.x / pitch, output_point.y / pitch)
     }
 
+    #[allow(unused)]
     pub(crate) const fn pixel_pitch(&self) -> u32 {
         self.scale + self.pixel_spacing
     }

--- a/simulator/src/output_settings.rs
+++ b/simulator/src/output_settings.rs
@@ -29,15 +29,16 @@ impl OutputSettings {
 
         Size::new(output_width, output_height)
     }
+}
 
+#[cfg(feature = "with-sdl")]
+impl OutputSettings {
     /// Translates a output coordinate to the corresponding display coordinate.
-    #[allow(unused)]
     pub(crate) const fn output_to_display(&self, output_point: Point) -> Point {
         let pitch = self.pixel_pitch() as i32;
         Point::new(output_point.x / pitch, output_point.y / pitch)
     }
 
-    #[allow(unused)]
     pub(crate) const fn pixel_pitch(&self) -> u32 {
         self.scale + self.pixel_spacing
     }


### PR DESCRIPTION
Hi! Thank you for helping out with Embedded Graphics development! Please:

- [x] Check that you've added passing tests and documentation
- [x] Add a simulator example(s) where applicable
- [x] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) and appropriate crate (`embedded-graphics`, `simulator`, `tinytga`, `tinybmp`) if your changes affect the **public API**
- [x] Run `rustfmt` on the project
- [x] Run `./build.sh` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

This is a non-breaking change, so can be merged into `master` for a future 0.6 release.

Makes `sdl2` an optional dependency for `simulator`. It is enabled by default, but can be disabled by adding `default-features = false` to the dependency import.

Closes #294 
