### PR TITLE
Remove precheck-nightly job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,6 @@ build_jobs: &build_jobs
   jobs:
     - precheck-stable
     - precheck-beta
-    - precheck-nightly
 
     # Raspberry Pi 1
     - target-arm-unknown-linux-eabi:


### PR DESCRIPTION
We missed to remove `precheck-nightly` in the `build_jobs` section in PR #291, which causes CI failures.