### PR TITLE
Change Rectangle to use top_left and size

### DIFF
--- a/embedded-graphics/CHANGELOG.md
+++ b/embedded-graphics/CHANGELOG.md
@@ -10,6 +10,8 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 
 - **(breaking)** [#274](https://github.com/jamwaffles/embedded-graphics/pull/274) The `Circle` is now defined by its bounding box top-left corner and its diameter instead of its center and its radius. To convert your code, you can replace `Circle::new(point, radius)` by `Circle::with_center(point, 2 * radius + 1)`.
 
+- **(breaking)** [#306](https://github.com/jamwaffles/embedded-graphics/pull/306) The `Rectangle` is now defined by its top-left corner and its size instead of the top-left and bottom-right corner. To convert your code, you can replace `Rectangle::new` by `Rectangle::with_corners`.
+
 ## [0.6.1] - 2020-04-01
 
 ### Added

--- a/embedded-graphics/src/draw_target.rs
+++ b/embedded-graphics/src/draw_target.rs
@@ -192,8 +192,7 @@ use crate::{
 ///
 /// // Draw a rectangle from (10, 20) to (30, 40) with a white stroke
 /// let rect = egrectangle!(
-///     top_left = (10, 20),
-///     bottom_right = (30, 40),
+///     corners = [(10, 20), (30, 40)],
 ///     style = primitive_style!(stroke_color = Gray8::WHITE, stroke_width = 1)
 /// )
 /// .draw(&mut display)?;
@@ -253,7 +252,7 @@ where
     where
         Self: Sized,
     {
-        primitives::Rectangle::new(Point::zero(), Point::zero() + self.size())
+        primitives::Rectangle::new(Point::zero(), self.size())
             .into_styled(PrimitiveStyle::with_fill(color))
             .draw(self)
     }

--- a/embedded-graphics/src/drawable.rs
+++ b/embedded-graphics/src/drawable.rs
@@ -11,7 +11,6 @@ use crate::{geometry::Point, pixelcolor::PixelColor, DrawTarget};
 /// use embedded_graphics::{
 ///     egrectangle, egtext,
 ///     fonts::Font6x8,
-///     geometry::Point,
 ///     pixelcolor::{BinaryColor, PixelColor, Rgb888},
 ///     prelude::*,
 ///     primitive_style, text_style,
@@ -19,7 +18,7 @@ use crate::{geometry::Point, pixelcolor::PixelColor, DrawTarget};
 ///
 /// struct Button<'a, C: PixelColor> {
 ///     top_left: Point,
-///     bottom_right: Point,
+///     size: Size,
 ///     bg_color: C,
 ///     fg_color: C,
 ///     text: &'a str,
@@ -32,7 +31,7 @@ use crate::{geometry::Point, pixelcolor::PixelColor, DrawTarget};
 ///     fn draw<D: DrawTarget<C>>(self, display: &mut D) -> Result<(), D::Error> {
 ///         egrectangle!(
 ///             top_left = self.top_left,
-///             bottom_right = self.bottom_right,
+///             size = self.size,
 ///             style = primitive_style!(fill_color = self.bg_color)
 ///         )
 ///         .draw(display);
@@ -47,7 +46,7 @@ use crate::{geometry::Point, pixelcolor::PixelColor, DrawTarget};
 ///
 /// let mut button = Button {
 ///     top_left: Point::zero(),
-///     bottom_right: Point::new(100, 50),
+///     size: Size::new(100, 50),
 ///     bg_color: Rgb888::RED,
 ///     fg_color: Rgb888::BLUE,
 ///     text: "Click me!",

--- a/embedded-graphics/src/geometry/size.rs
+++ b/embedded-graphics/src/geometry/size.rs
@@ -82,8 +82,8 @@ impl Size {
 
     /// Creates a size from two corner points of a bounding box.
     pub(crate) fn from_bounding_box(corner_1: Point, corner_2: Point) -> Self {
-        let width = (corner_1.x - corner_2.x).abs() as u32;
-        let height = (corner_1.y - corner_2.y).abs() as u32;
+        let width = (corner_1.x - corner_2.x).abs() as u32 + 1;
+        let height = (corner_1.y - corner_2.y).abs() as u32 + 1;
 
         Self { width, height }
     }

--- a/embedded-graphics/src/lib.rs
+++ b/embedded-graphics/src/lib.rs
@@ -163,7 +163,7 @@
 //! let mut display: MockDisplay<Rgb565> = MockDisplay::default();
 //!
 //! fn build_thing(text: &'static str) -> impl Iterator<Item = Pixel<Rgb565>> {
-//!     egrectangle!(top_left = (0, 0), bottom_right = (40, 40))
+//!     egrectangle!(top_left = (0, 0), size = (40, 40))
 //!         .into_iter()
 //!         .chain(&egcircle!(
 //!             top_left = (12, 12),
@@ -239,7 +239,7 @@
 //! This example draws a rectangle with a 2px thick red stroke and cyan fill color.
 //!
 //! <div style="display: flex">
-//! <img style="width: 128px; height: 128px; margin-right: 8px;" alt="Draw a rectangle example screenshot" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAIAAABMXPacAAAB2klEQVR4nO3RMWokURAE0Z37H3pWRoISCjUylIQE8aChv5NGxeufUAaAGQBmAJgBYAaAGQBmAJgBYAaAGQBmAJgBYAaAGQBmAJgBYAaAGQBmAJgBYAaAGQBmAJgBYAaAGQBmAJgBYAaAGQBmAJgBYAaAGQBmAJgBYAaAGQBmAJgBYAaAGQBmAJgBYAaAGQBmANg8wPvj+/t2Z9othwGe7ZbDAM92y2GAZ7vl6ACvd79+u/fr8ziffz9ttxx9cgNcu+Xokxvg2i1Hn9wA1245+uQGuHbL0Sc3wLVbjj65Aa7dcvTJDXDtlqNPboBrtxx9cgNcu+Xokxvg2i1Hn9wA1245+uQGuHbL0Sc3wLVbjj65Aa7dcvTJDXDtlqNPboBrtxx9cgNcu+Xokxvg2i1Hn9wA1245+uQGuHbL0Sc3wLVbjj65Aa7dcvTJDXDtlqNPboBrtxx9cgNcu+X4Syf/2u5Mu+UwwLPdchjg2W45DPBst6xvMQDMADADwAwAMwDMADADwAwAMwDMADADwAwAMwDMADADwAwAMwDMADADwAwAMwDMADADwAwAMwDMADADwAwAMwDMADADwAwAMwDMADADwAwAMwDMADADwAwAMwDMADADwAwAMwDsPzy9cIE/9mieAAAAAElFTkSuQmCC" />
+//! <img style="width: 128px; height: 128px; margin-right: 8px;" alt="Draw a rectangle example screenshot" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAIAAABMXPacAAABhUlEQVR4nO3RMWoDURAEUev+h5adyYomakqC92Bhf9LB1OOHlAAxAWICxASICRATICZATICYADEBYgLEBIgJEBMgJkBMgJgAMQFiAsQEiAkQEyAmQEyAmAAxAWICxASICRATICZATICYADEBYgLEBIgJEBMgJkBMgJgAMQFiAsQEiAkQEyAmQGwe4Pn3fbP1gdb7AhzW+wIc1vsCHNb7bwEez/+vz/V8vM7y+ttY7wtwWO8LcFjvC3BY7wtwWO8LcFjvC3BY7wtwWO8LcFjvC3BY7wtwWO8LcFjvC3BY7wtwWO8LcFjvC3BY7wtwWO8LcFjvC3BY7wtwWO8LcFjvC3BY7wtwWO8LcFjvvwX4RusDrfcFOKz3BTis9wU4rPc5CBATICZATICYADEBYgLEBIgJEBMgJkBMgJgAMQFiAsQEiAkQEyAmQEyAmAAxAWICxASICRATICZATICYADEBYgLEBIgJEBMgJkBMgJgAMQFiAsQEiAkQEyAmQEyAmAAxAWICxH4By6BogfSjbAMAAAAASUVORK5CYII=" />
 //! <div style="flex-grow: 1;">
 //!
 //! ```rust
@@ -251,7 +251,7 @@
 //!     style::PrimitiveStyleBuilder,
 //! };
 //!
-//! Rectangle::new(Point::new(16, 24), Point::new(48, 40))
+//! Rectangle::new(Point::new(16, 24), Size::new(32, 16))
 //!     .into_styled(
 //!         PrimitiveStyleBuilder::new()
 //!             .stroke_width(2)
@@ -271,7 +271,7 @@
 //! This example draws a circle with no stroke and a solid blue fill.
 //!
 //! <div style="display: flex">
-//! <img style="width: 128px; height: 128px; margin-right: 8px;" alt="Draw a circle example screenshot" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAIAAABMXPacAAACe0lEQVR4nO3RS1LEMAxFUdj/ovlkwisMJJZkPSfcU9VDyR3d1xdYEcCMAGYEMCOAGQHMCGBGADMCmBHAjABmBDAjgBkBzAhgRgAzApgRwIwAZgQwI4AZAcwIYEYAsxsFePv4zdv9A3f/f4IArWLnvmKvT97r3wgCGKw7+m/8n+//B4IABv1H/43nFJ5XBQFs9jm96j5I93uCAJ+63zvseXrVd5a+lwQBvvS9dNj/9KrjOB1vCAJ81/HG4V6nV2tPtHa7IMDP1m4/3Pf0atWhVu0VBPjLqr2HZ5xe1Z+rfqMgwLn6jYIA5+o3CgKcq994eN7pVeXRKncJAlxVuUsQ4KrKXYIAV1XuOjz79KrmdDVbBAHm1GwRBJhTs0UQYE7NFkGAOTVbBAHm1Gw5/J/Tq+wBs/OCABHZeUGAiOy8IEBEdl4QICI7LwgQkZ0XBIjIzgsCRGTnBQEisvOCABHZeUGAiOy8IEBEdl4QICI7LwgQkZ0XBIjIzgsCRGTnBQEisvOCABHZ+cH/yVBzupotggBzarYIAsyp2SIIMKdmiyDAnJotggBzarYMnp2h8miVuwQBrqrcJQhwVeUuQYCrKncNnpeh/lz1GwUBztVvFAQ4V79REOBc/cbBMzKsOtSqvYIAf1m1d3DfDGtPtHa7IMDP1m4f3CtDx3E63hAE+K7jjcH+GfrO0veSIMCXvpcGe2boPkj3e4IAn7rfG+yTwXMKz6uCABvpj+H/fP8/EATYyLoYe33yXv9GEGA7sSS7f+Du/08QAAsQwIwAZgQwI4AZAcwIYEYAMwKYEcCMAGYEMCOAGQHMCGBGADMCmBHAjABmBDAjgBkBzN4BABtSgS+nmkgAAAAASUVORK5CYII=" />
+//! <img style="width: 128px; height: 128px; margin-right: 8px;" alt="Draw a circle example screenshot" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAIAAABMXPacAAACV0lEQVR4nO3RUU7FMAwFUdj/ooF+UVUhkidpblrmSPzZKc/z+aEoA4QZIMwAYQYIM0CYAcIMEGaAMAOEGSDMAGEGCDNAmAHCDBBmgDADhBkgzABhBggzQJgBwgwQZoAwA4QZIMwAYQYIM0CYAcIMEPaCAF8/fxV7/eS9/hvEAItUD12VOUXmq4gBAu4++l/WnWXdlxADxKROf7biOCu+gRggYIej/+WuQ931LmKAmJ1Pfzb/XPNfRAwQ85TTn8082sy3EAPEPPH0Z3NON+cVxACHOa8gBjjMeQUxwGHOK0VPP/3Z6AFH9xED/BrdL3rT6c/4GfkmYoArvokY4IpvIga44ptFbz39GTkm2UEM0EZ2EAO0kR3EAG1kBzFAG9lBDNBGdhADtJEdxABtZKfoP5z+rHbS2jRigJ7aNGKAnto0YoCe2jRigJ7aNGKAnto0YoCe2jRigJ7aNGKAnto0YoCe2jRigJ7aNGKAnto0YoCe2jRigJ7aNGKAnto0YoCe2vSA/5CBHJPsIAZoIzuIAdrIDmKANrKDGKCN7CAGaCM7iAHayA5igDayM+CtGfgZ+SZigCu+iRjgim8iBrjimwPelGH0gKP7iAF+je4PeHqGOaeb8wpigMOcVxADHOa8ghjgMOeVAU/MMPNoM99CDLCFp2SYf675LyIG2MLOGe461F3vIgbYyA4xVhxnxTcQA2whlWHdWdZ9CTHARu6OkTlF5quIATZVDbPXT97rv0EMoAEGCDNAmAHCDBBmgDADhBkgzABhBggzQJgBwgwQZoAwA4QZIOwbbHdQgYxk5xMAAAAASUVORK5CYII=" />
 //! <div style="flex-grow: 1;">
 //!
 //! ```rust
@@ -283,7 +283,7 @@
 //!     style::PrimitiveStyle,
 //! };
 //!
-//! Circle::new(Point::new(32, 32), 20)
+//! Circle::new(Point::new(16, 16), 40)
 //!     .into_styled(PrimitiveStyle::with_fill(Rgb888::BLUE))
 //!     .draw(&mut display)?;
 //! # Ok::<(), core::convert::Infallible>(())

--- a/embedded-graphics/src/pixelcolor/mod.rs
+++ b/embedded-graphics/src/pixelcolor/mod.rs
@@ -53,21 +53,21 @@
 //!
 //! egrectangle!(
 //!     top_left = (0, 0),
-//!     bottom_right = (100, 100),
+//!     size = (100, 100),
 //!     style = primitive_style!(fill_color = EpdColor::White)
 //! )
 //! .draw(&mut display)?;
 //!
 //! egrectangle!(
 //!     top_left = (100, 0),
-//!     bottom_right = (200, 100),
+//!     size = (100, 100),
 //!     style = primitive_style!(fill_color = EpdColor::Black)
 //! )
 //! .draw(&mut display)?;
 //!
 //! egrectangle!(
 //!     top_left = (200, 0),
-//!     bottom_right = (300, 100),
+//!     size = (100, 100),
 //!     style = primitive_style!(fill_color = EpdColor::Red)
 //! )
 //! .draw(&mut display)?;

--- a/embedded-graphics/src/primitives/line.rs
+++ b/embedded-graphics/src/primitives/line.rs
@@ -57,7 +57,7 @@ impl Dimensions for Line {
     }
 
     fn bottom_right(&self) -> Point {
-        self.top_left() + self.size()
+        self.top_left() + (self.size() - Size::new(1, 1))
     }
 
     fn size(&self) -> Size {
@@ -190,18 +190,18 @@ mod tests {
     #[test]
     fn bounding_box() {
         let start = Point::new(10, 10);
-        let end = Point::new(20, 20);
+        let end = Point::new(19, 29);
 
         let line: Line = Line::new(start, end);
         let backwards_line: Line = Line::new(end, start);
 
         assert_eq!(line.top_left(), start);
         assert_eq!(line.bottom_right(), end);
-        assert_eq!(line.size(), Size::new(10, 10));
+        assert_eq!(line.size(), Size::new(10, 20));
 
         assert_eq!(backwards_line.top_left(), start);
         assert_eq!(backwards_line.bottom_right(), end);
-        assert_eq!(backwards_line.size(), Size::new(10, 10));
+        assert_eq!(backwards_line.size(), Size::new(10, 20));
     }
 
     #[test]

--- a/embedded-graphics/src/primitives/mod.rs
+++ b/embedded-graphics/src/primitives/mod.rs
@@ -204,11 +204,11 @@ macro_rules! egline {
 /// };
 ///
 /// let empty_rect: Styled<Rectangle, PrimitiveStyle<Rgb565>> =
-///     egrectangle!(top_left = (10, 20), bottom_right = (30, 40));
+///     egrectangle!(top_left = (10, 20), size = (20, 20));
 ///
 /// let filled_rect: Styled<Rectangle, PrimitiveStyle<Rgb565>> = egrectangle!(
 ///     top_left = (10, 20),
-///     bottom_right = (30, 40),
+///     size = (20, 20),
 ///     style = primitive_style!(stroke_color = Rgb565::RED, fill_color = Rgb565::GREEN)
 /// );
 /// ```
@@ -230,7 +230,7 @@ macro_rules! egline {
 ///
 /// let rectangle_1: Styled<Rectangle, PrimitiveStyle<Rgb565>> = egrectangle!(
 ///     top_left = (10, 20),
-///     bottom_right = (30, 40),
+///     size = (20, 20),
 ///     style = primitive_style!(
 ///         stroke_color = Rgb565::RED,
 ///         fill_color = Rgb565::GREEN,
@@ -245,23 +245,36 @@ macro_rules! egline {
 ///     .build();
 ///
 /// let rectangle_2: Styled<Rectangle, PrimitiveStyle<Rgb565>> =
-///     Rectangle::new(Point::new(10, 20), Point::new(30, 40)).into_styled(style);
+///     Rectangle::new(Point::new(10, 20), Size::new(20, 20)).into_styled(style);
 ///
 /// assert_eq!(rectangle_1, rectangle_2);
 /// ```
 #[macro_export]
 macro_rules! egrectangle {
-    (top_left = $top_left:expr, bottom_right = $bottom_right:expr $(,)?) => {{
+    (corners = [$corner_1:expr, $corner_2:expr] $(,)?) => {{
         $crate::egrectangle!(
-            top_left = $top_left,
-            bottom_right = $bottom_right,
+            corners = [$corner_1, $corner_2],
             style = $crate::style::PrimitiveStyle::default()
         )
     }};
-    (top_left = $top_left:expr, bottom_right = $bottom_right:expr, style = $style:expr $(,)?) => {{
+    (corners = [$corner_1:expr, $corner_2:expr], style = $style:expr $(,)?) => {{
+        $crate::primitives::Rectangle::with_corners(
+            $crate::geometry::Point::from($corner_1),
+            $crate::geometry::Point::from($corner_2),
+        )
+        .into_styled($style)
+    }};
+    (top_left = $top_left:expr, size = $size:expr $(,)?) => {{
+        $crate::egrectangle!(
+            top_left = $top_left,
+            size = $size,
+            style = $crate::style::PrimitiveStyle::default()
+        )
+    }};
+    (top_left = $top_left:expr, size = $size:expr, style = $style:expr $(,)?) => {{
         $crate::primitives::Rectangle::new(
             $crate::geometry::Point::from($top_left),
-            $crate::geometry::Point::from($bottom_right),
+            $crate::geometry::Size::from($size),
         )
         .into_styled($style)
     }};
@@ -342,7 +355,7 @@ macro_rules! egtriangle {
 mod tests {
     use super::*;
     use crate::{
-        geometry::Point,
+        geometry::{Point, Size},
         pixelcolor::{Rgb565, RgbColor},
         primitive_style,
         style::PrimitiveStyle,
@@ -382,15 +395,20 @@ mod tests {
 
     #[test]
     fn rectangle() {
-        let _r: Styled<Rectangle, PrimitiveStyle<Rgb565>> = egrectangle!(
-            top_left = Point::new(10, 20),
-            bottom_right = Point::new(30, 40),
-        );
         let _r: Styled<Rectangle, PrimitiveStyle<Rgb565>> =
-            egrectangle!(top_left = (10, 20), bottom_right = (30, 40),);
+            egrectangle!(top_left = Point::new(10, 20), size = Size::new(20, 20),);
+        let _r: Styled<Rectangle, PrimitiveStyle<Rgb565>> =
+            egrectangle!(top_left = (10, 20), size = (20, 20),);
         let _r: Styled<Rectangle, PrimitiveStyle<Rgb565>> = egrectangle!(
             top_left = (10, 20),
-            bottom_right = (30, 40),
+            size = (20, 20),
+            style = primitive_style!(stroke_color = Rgb565::RED, fill_color = Rgb565::GREEN)
+        );
+
+        let _r: Styled<Rectangle, PrimitiveStyle<Rgb565>> =
+            egrectangle!(corners = [Point::new(10, 20), Point::new(30, 40)]);
+        let _r: Styled<Rectangle, PrimitiveStyle<Rgb565>> = egrectangle!(
+            corners = [Point::new(10, 20), Point::new(30, 40)],
             style = primitive_style!(stroke_color = Rgb565::RED, fill_color = Rgb565::GREEN)
         );
     }

--- a/embedded-graphics/src/primitives/triangle.rs
+++ b/embedded-graphics/src/primitives/triangle.rs
@@ -374,12 +374,12 @@ mod tests {
         assert_eq!(tri.p1, Point::new(5, 10));
         assert_eq!(tri.p2, Point::new(15, 25));
         assert_eq!(tri.p3, Point::new(5, 25));
-        assert_eq!(tri.size(), Size::new(10, 15));
+        assert_eq!(tri.size(), Size::new(11, 16));
 
         assert_eq!(moved.p1, Point::new(-5, -1));
         assert_eq!(moved.p2, Point::new(5, 14));
         assert_eq!(moved.p3, Point::new(-5, 14));
-        assert_eq!(moved.size(), Size::new(10, 15));
+        assert_eq!(moved.size(), Size::new(11, 16));
     }
 
     #[test]

--- a/embedded-graphics/src/style/primitive_style.rs
+++ b/embedded-graphics/src/style/primitive_style.rs
@@ -137,7 +137,7 @@ where
 ///     .stroke_width(1)
 ///     .build();
 ///
-/// let rectangle = Rectangle::new(Point::new(20, 20), Point::new(40, 30)).into_styled(style);
+/// let rectangle = Rectangle::new(Point::new(20, 20), Size::new(20, 10)).into_styled(style);
 /// ```
 ///
 /// [`PrimitiveStyle`]: ./struct.PrimitiveStyle.html

--- a/embedded-graphics/tests/chaining.rs
+++ b/embedded-graphics/tests/chaining.rs
@@ -40,7 +40,7 @@ impl DrawTarget<TestPixelColor> for FakeDisplay {
 fn it_supports_chaining() -> Result<(), core::convert::Infallible> {
     let mut display = FakeDisplay {};
 
-    let mut chained = Rectangle::new(Point::new(0, 0), Point::new(1, 1))
+    let mut chained = Rectangle::new(Point::new(0, 0), Size::new(1, 1))
         .into_styled(PrimitiveStyle::default())
         .into_iter()
         .chain(
@@ -77,7 +77,7 @@ fn return_from_fn() -> Result<(), core::convert::Infallible> {
 fn implicit_into_iter() -> Result<(), core::convert::Infallible> {
     let mut display = FakeDisplay {};
 
-    let mut chained = Rectangle::new(Point::new(0, 0), Point::new(1, 1))
+    let mut chained = Rectangle::new(Point::new(0, 0), Size::new(1, 1))
         .into_styled(PrimitiveStyle::default())
         .into_iter()
         .chain(

--- a/simulator/benches/primitives.rs
+++ b/simulator/benches/primitives.rs
@@ -1,7 +1,7 @@
 use criterion::*;
 use embedded_graphics::{
     drawable::Pixel,
-    geometry::Point,
+    geometry::{Point, Size},
     pixelcolor::Gray8,
     primitives::{Circle, Line, Primitive, Rectangle, Triangle},
     style::{PrimitiveStyle, PrimitiveStyleBuilder},
@@ -29,7 +29,7 @@ fn filled_rect(c: &mut Criterion) {
             .stroke_width(1)
             .build();
 
-        let object = &Rectangle::new(Point::new(100, 100), Point::new(200, 200)).into_styled(style);
+        let object = &Rectangle::new(Point::new(100, 100), Size::new(100, 100)).into_styled(style);
 
         b.iter(|| object.into_iter().collect::<Vec<Pixel<Gray8>>>())
     });
@@ -37,7 +37,7 @@ fn filled_rect(c: &mut Criterion) {
 
 fn empty_rect(c: &mut Criterion) {
     c.bench_function("unfilled rectangle", |b| {
-        let object = &Rectangle::new(Point::new(100, 100), Point::new(200, 200))
+        let object = &Rectangle::new(Point::new(100, 100), Size::new(100, 100))
             .into_styled(PrimitiveStyle::with_stroke(Gray8::new(10), 1));
 
         b.iter(|| object.into_iter().collect::<Vec<Pixel<Gray8>>>())

--- a/simulator/examples/analog-clock.rs
+++ b/simulator/examples/analog-clock.rs
@@ -133,8 +133,9 @@ fn draw_digital_clock<'a>(time_str: &'a str) -> impl Iterator<Item = Pixel<Binar
 
     // Add a background around the time digits. Note that there is no bottom-right padding as this
     // is added by the font renderer itself
-    let background = Rectangle::new(text.top_left() - Size::new(3, 3), text.bottom_right())
-        .into_styled(PrimitiveStyle::with_fill(BinaryColor::On));
+    let background =
+        Rectangle::with_corners(text.top_left() - Point::new(3, 3), text.bottom_right())
+            .into_styled(PrimitiveStyle::with_fill(BinaryColor::On));
 
     // Draw the white background first, then the black text. Order matters here
     background.into_iter().chain(&text)

--- a/simulator/examples/chaining.rs
+++ b/simulator/examples/chaining.rs
@@ -27,10 +27,8 @@ fn main() -> Result<(), core::convert::Infallible> {
 
     let yoffset = 10;
 
-    let bottom_right = Point::zero() + display.size() - Point::new(1, 1);
-
     // Draw an 3px wide outline around the display.
-    Rectangle::new(Point::zero(), bottom_right)
+    Rectangle::new(Point::zero(), display.size())
         .into_styled(thick_stroke)
         .into_iter()
         .chain(
@@ -45,7 +43,7 @@ fn main() -> Result<(), core::convert::Infallible> {
         )
         .chain(
             // Draw a filled square
-            Rectangle::new(Point::new(52, yoffset), Point::new(52 + 16, 16 + yoffset))
+            Rectangle::new(Point::new(52, yoffset), Size::new(16, 16))
                 .into_styled(fill)
                 .into_iter(),
         )

--- a/simulator/examples/hello-world.rs
+++ b/simulator/examples/hello-world.rs
@@ -26,8 +26,7 @@ fn main() -> Result<(), std::convert::Infallible> {
     let yoffset = 10;
 
     // Draw a 3px wide outline around the display.
-    let bottom_right = Point::zero() + display.size() - Point::new(1, 1);
-    Rectangle::new(Point::zero(), bottom_right)
+    Rectangle::new(Point::zero(), display.size())
         .into_styled(thick_stroke)
         .draw(&mut display)?;
 
@@ -41,7 +40,7 @@ fn main() -> Result<(), std::convert::Infallible> {
     .draw(&mut display)?;
 
     // Draw a filled square
-    Rectangle::new(Point::new(52, yoffset), Point::new(52 + 16, 16 + yoffset))
+    Rectangle::new(Point::new(52, yoffset), Size::new(16, 16))
         .into_styled(fill)
         .draw(&mut display)?;
 

--- a/simulator/examples/primitives-fill-macros.rs
+++ b/simulator/examples/primitives-fill-macros.rs
@@ -46,7 +46,7 @@ fn main() -> Result<(), core::convert::Infallible> {
 
     egrectangle!(
         top_left = (0, 0),
-        bottom_right = (64, 64),
+        size = (64, 64),
         style = primitive_style!(stroke_color = BinaryColor::On, stroke_width = 1,)
     )
     .translate(Point::new(96, 0))
@@ -54,7 +54,7 @@ fn main() -> Result<(), core::convert::Infallible> {
 
     egrectangle!(
         top_left = (0, 0),
-        bottom_right = (64, 64),
+        size = (64, 64),
         style = primitive_style!(
             stroke_color = BinaryColor::Off,
             stroke_width = 1,
@@ -66,7 +66,7 @@ fn main() -> Result<(), core::convert::Infallible> {
 
     egrectangle!(
         top_left = (0, 0),
-        bottom_right = (64, 64),
+        size = (64, 64),
         style = primitive_style!(
             stroke_color = BinaryColor::Off,
             stroke_width = 1,

--- a/simulator/examples/primitives-fill.rs
+++ b/simulator/examples/primitives-fill.rs
@@ -43,17 +43,17 @@ fn main() -> Result<(), core::convert::Infallible> {
         .into_styled(stroke_off_fill_off)
         .draw(&mut display)?;
 
-    Rectangle::new(Point::new(0, 0), Point::new(64, 64))
+    Rectangle::new(Point::new(0, 0), Size::new(64, 64))
         .translate(Point::new(96, 0))
         .into_styled(stroke)
         .draw(&mut display)?;
 
-    Rectangle::new(Point::new(0, 0), Point::new(64, 64))
+    Rectangle::new(Point::new(0, 0), Size::new(64, 64))
         .translate(Point::new(96 + 16, 16))
         .into_styled(stroke_off_fill_on)
         .draw(&mut display)?;
 
-    Rectangle::new(Point::new(0, 0), Point::new(64, 64))
+    Rectangle::new(Point::new(0, 0), Size::new(64, 64))
         .translate(Point::new(96 + 32, 32))
         .into_styled(stroke_off_fill_off)
         .draw(&mut display)?;

--- a/simulator/examples/primitives-stroke.rs
+++ b/simulator/examples/primitives-stroke.rs
@@ -21,7 +21,7 @@ fn main() -> Result<(), core::convert::Infallible> {
 
     let triangle = Triangle::new(Point::new(0, 64), Point::new(64, 0), Point::new(64, 64));
     let rectangle =
-        Rectangle::new(Point::new(0, 0), Point::new(64, 64)).translate(Point::new(64 + PADDING, 0));
+        Rectangle::new(Point::new(0, 0), Size::new(64, 64)).translate(Point::new(64 + PADDING, 0));
     let line = Line::new(Point::new(0, 0), Point::new(64, 64))
         .translate(Point::new((64 + PADDING) * 2, 0));
     let circle = Circle::new(Point::new(0, 0), 64).translate(Point::new((64 + PADDING) * 3, 0));

--- a/simulator/examples/text-transparent.rs
+++ b/simulator/examples/text-transparent.rs
@@ -19,7 +19,7 @@ fn main() -> Result<(), core::convert::Infallible> {
     .into_iter()
     .chain(&egrectangle!(
         top_left = (20, 20),
-        bottom_right = (100, 80),
+        size = (80, 60),
         style = primitive_style!(fill_color = Rgb565::RED)
     ))
     .draw(&mut display)

--- a/simulator/src/bin/generate-example-screenshots.rs
+++ b/simulator/src/bin/generate-example-screenshots.rs
@@ -117,7 +117,7 @@ some display drivers implement accelerated drawing of iterators."#,
                 pixelcolor::Rgb888, prelude::*, primitives::Rectangle, style::PrimitiveStyleBuilder,
             };
             {}
-            Rectangle::new(Point::new(16, 24), Point::new(48, 40))
+            Rectangle::new(Point::new(16, 24), Size::new(32, 16))
                 .into_styled(
                     PrimitiveStyleBuilder::new()
                         .stroke_width(2)
@@ -138,7 +138,7 @@ some display drivers implement accelerated drawing of iterators."#,
                 pixelcolor::Rgb888, prelude::*, primitives::Circle, style::PrimitiveStyle,
             };
             {}
-            Circle::new(Point::new(32, 32), 20)
+            Circle::new(Point::new(16, 16), 40)
                 .into_styled(PrimitiveStyle::with_fill(Rgb888::BLUE))
                 .draw(&mut display)?;
         }

--- a/simulator/src/framebuffer.rs
+++ b/simulator/src/framebuffer.rs
@@ -1,7 +1,7 @@
 use crate::{display::SimulatorDisplay, output_settings::OutputSettings};
 use embedded_graphics::{
     drawable::{Drawable, Pixel},
-    geometry::{Point, Size},
+    geometry::{Dimensions, Point, Size},
     pixelcolor::{PixelColor, Rgb888, RgbColor},
     primitives::{Primitive, Rectangle},
     style::{PrimitiveStyle, Styled},
@@ -54,17 +54,14 @@ impl Framebuffer {
         let Size { width, height } = display.size();
 
         let pixel_pitch = (self.output_settings.scale + self.output_settings.pixel_spacing) as i32;
-        let pixel_size = Size::new(
-            self.output_settings.scale - 1,
-            self.output_settings.scale - 1,
-        );
+        let pixel_size = Size::new(self.output_settings.scale, self.output_settings.scale);
 
         for y in 0..height as i32 {
             for x in 0..width as i32 {
                 let color = display.get_pixel(Point::new(x, y)).into();
                 let p = Point::new(x * pixel_pitch, y * pixel_pitch);
 
-                Rectangle::new(p, p + pixel_size)
+                Rectangle::new(p, pixel_size)
                     .into_styled(PrimitiveStyle::with_fill(
                         self.output_settings.theme.convert(color),
                     ))
@@ -116,7 +113,7 @@ impl DrawTarget<Rgb888> for Framebuffer {
             let color = &[fill_color.r(), fill_color.g(), fill_color.b()];
 
             let tl = item.primitive.top_left;
-            let br = item.primitive.bottom_right;
+            let br = item.primitive.bottom_right();
             for y in tl.y..=br.y {
                 for x in tl.x..=br.x {
                     let p = Point::new(x, y);


### PR DESCRIPTION
Hi! Thank you for helping out with Embedded Graphics development! Please:

- [x] Check that you've added passing tests and documentation
- [x] Add a simulator example(s) where applicable
- [x] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) and appropriate crate (`embedded-graphics`, `simulator`, `tinytga`, `tinybmp`) if your changes affect the **public API**
- [x] Run `rustfmt` on the project
- [x] Run `./build.sh` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

Continuation of PR #286.

The original comment for the old PR:

This PR changes Rectangle to use top_left and size instead of top_left and bottom_right. A similar change for Circles was recently implemented in #147.

As a part of the changes for #182 some of the code in this PR isn't final. Some problems like the bottom right corner problem mentioned in #182 will need to be addressed, but this will require changes in the Dimensions trait and is outside the scope of this PR IMO.