### PR TITLE
Add points iterators for primitives

### DIFF
--- a/embedded-graphics/CHANGELOG.md
+++ b/embedded-graphics/CHANGELOG.md
@@ -6,6 +6,10 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+- [#307](https://github.com/jamwaffles/embedded-graphics/pull/307) Added `Primitive::points` to get an iterator over all points inside a primitive.
+
 ### Changed
 
 - **(breaking)** [#274](https://github.com/jamwaffles/embedded-graphics/pull/274) The `Circle` is now defined by its bounding box top-left corner and its diameter instead of its center and its radius. To convert your code, you can replace `Circle::new(point, radius)` by `Circle::with_center(point, 2 * radius + 1)`.

--- a/embedded-graphics/src/primitives/line.rs
+++ b/embedded-graphics/src/primitives/line.rs
@@ -49,7 +49,14 @@ pub struct Line {
     /// End point
     pub end: Point,
 }
-impl Primitive for Line {}
+
+impl Primitive for Line {
+    type PointsIter = Points;
+
+    fn points(&self) -> Self::PointsIter {
+        Points::new(self)
+    }
+}
 
 impl Dimensions for Line {
     fn top_left(&self) -> Point {
@@ -125,6 +132,28 @@ where
 
             line_iter: ThickLineIterator::new(&self.primitive, self.style.stroke_width_i32()),
         }
+    }
+}
+
+/// Iterator over all points on the line.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+pub struct Points {
+    line_iter: ThickLineIterator,
+}
+
+impl Points {
+    fn new(line: &Line) -> Self {
+        Self {
+            line_iter: ThickLineIterator::new(line, 1),
+        }
+    }
+}
+
+impl Iterator for Points {
+    type Item = Point;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.line_iter.next()
     }
 }
 
@@ -450,5 +479,18 @@ mod tests {
                 "  #####     ",
             ])
         );
+    }
+
+    #[test]
+    fn points_iter() {
+        let line = Line::new(Point::new(10, 10), Point::new(20, 30));
+
+        let styled_points = line
+            .clone()
+            .into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 1))
+            .into_iter()
+            .map(|Pixel(p, _)| p);
+
+        assert!(line.points().eq(styled_points));
     }
 }

--- a/embedded-graphics/src/primitives/mod.rs
+++ b/embedded-graphics/src/primitives/mod.rs
@@ -8,7 +8,7 @@ pub mod triangle;
 
 pub use self::{circle::Circle, line::Line, rectangle::Rectangle, triangle::Triangle};
 use crate::{
-    geometry::Dimensions,
+    geometry::{Dimensions, Point},
     pixelcolor::PixelColor,
     style::{PrimitiveStyle, Styled},
 };
@@ -16,6 +16,9 @@ pub(crate) use thick_line_iterator::ThickLineIterator;
 
 /// Primitive trait
 pub trait Primitive: Dimensions {
+    /// Iterator over all points inside the primitive.
+    type PointsIter: Iterator<Item = Point>;
+
     /// Converts this primitive into a `Styled`.
     fn into_styled<C>(self, style: PrimitiveStyle<C>) -> Styled<Self, PrimitiveStyle<C>>
     where
@@ -24,6 +27,9 @@ pub trait Primitive: Dimensions {
     {
         Styled::new(self, style)
     }
+
+    /// Returns an iterator over all points inside the primitive.
+    fn points(&self) -> Self::PointsIter;
 }
 
 /// Create a [`Circle`](./primitives/circle/struct.Circle.html) with optional styling using a

--- a/embedded-graphics/src/primitives/rectangle.rs
+++ b/embedded-graphics/src/primitives/rectangle.rs
@@ -53,7 +53,13 @@ pub struct Rectangle {
     pub size: Size,
 }
 
-impl Primitive for Rectangle {}
+impl Primitive for Rectangle {
+    type PointsIter = Points;
+
+    fn points(&self) -> Self::PointsIter {
+        Points::new(self)
+    }
+}
 
 impl Dimensions for Rectangle {
     fn top_left(&self) -> Point {
@@ -146,6 +152,47 @@ where
             style: self.style,
             p: self.primitive.top_left,
         }
+    }
+}
+
+/// Iterator over all points inside the rectangle.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+pub struct Points {
+    top_left: Point,
+    bottom_right: Point,
+    current_point: Point,
+}
+
+impl Points {
+    fn new(rectangle: &Rectangle) -> Self {
+        Self {
+            top_left: rectangle.top_left,
+            bottom_right: rectangle.top_left + rectangle.size - Point::new(1, 1),
+            current_point: rectangle.top_left,
+        }
+    }
+}
+
+impl Iterator for Points {
+    type Item = Point;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // Finished, i.e. we're below the rect
+        if self.current_point.y > self.bottom_right.y {
+            return None;
+        }
+
+        let ret = self.current_point;
+
+        self.current_point.x += 1;
+
+        // Reached end of row? Jump down one line
+        if self.current_point.x > self.bottom_right.x {
+            self.current_point.x = self.top_left.x;
+            self.current_point.y += 1;
+        }
+
+        Some(ret)
     }
 }
 
@@ -288,5 +335,18 @@ mod tests {
             .into_iter();
 
         assert!(negative.eq(positive.map(|Pixel(p, c)| Pixel(p - Point::new(4, 4), c))));
+    }
+
+    #[test]
+    fn points_iter() {
+        let rectangle = Rectangle::new(Point::new(10, 10), Size::new(20, 30));
+
+        let styled_points = rectangle
+            .clone()
+            .into_styled(PrimitiveStyle::with_fill(Rgb565::WHITE))
+            .into_iter()
+            .map(|Pixel(p, _)| p);
+
+        assert!(rectangle.points().eq(styled_points));
     }
 }


### PR DESCRIPTION
Hi! Thank you for helping out with Embedded Graphics development! Please:

- [x] Check that you've added passing tests and documentation
- [x] Add a simulator example(s) where applicable
- [x] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) and appropriate crate (`embedded-graphics`, `simulator`, `tinytga`, `tinybmp`) if your changes affect the **public API**
- [x] Run `rustfmt` on the project
- [x] Run `./build.sh` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

This PR adds `Primitive::points` which returns an iterator over all points inside a closed shape or on a line.

To keep the changes in this PR small the new iterators are mostly copies of the existing ones without the styling features. Future PRs can reduce the code duplication, but some of these changes depend on other features that aren't implemented yet.