### PR TITLE
Infinite triangle

### DIFF
--- a/embedded-graphics/CHANGELOG.md
+++ b/embedded-graphics/CHANGELOG.md
@@ -13,8 +13,11 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 ### Changed
 
 - **(breaking)** [#274](https://github.com/jamwaffles/embedded-graphics/pull/274) The `Circle` is now defined by its bounding box top-left corner and its diameter instead of its center and its radius. To convert your code, you can replace `Circle::new(point, radius)` by `Circle::with_center(point, 2 * radius + 1)`.
-
 - **(breaking)** [#306](https://github.com/jamwaffles/embedded-graphics/pull/306) The `Rectangle` is now defined by its top-left corner and its size instead of the top-left and bottom-right corner. To convert your code, you can replace `Rectangle::new` by `Rectangle::with_corners`.
+
+### Fixed
+
+- [#309](https://github.com/jamwaffles/embedded-graphics/pull/309) Prevent triangles with off-screen vertices from infinitely looping.
 
 ## [0.6.1] - 2020-04-01
 

--- a/embedded-graphics/src/primitives/triangle.rs
+++ b/embedded-graphics/src/primitives/triangle.rs
@@ -458,7 +458,7 @@ where
                 IterState::LeftRight(l, r) => {
                     // Fill the space between the left and right points
                     if let Some(color) = self.style.fill_color {
-                        if l.x >= 0 && l.y >= 0 && r.x >= 0 && r.y >= 0 && l.x + self.x < r.x {
+                        if l.x + self.x < r.x {
                             let point = Point::new(l.x + self.x, l.y);
                             self.x += 1;
                             return Some(Pixel(point, color));
@@ -643,5 +643,46 @@ mod tests {
             .map(|Pixel(p, _)| p);
 
         assert!(triangle.points().eq(styled_points));
+    }
+
+    fn issue_308_infinite() {
+        let mut display: MockDisplay<BinaryColor> = MockDisplay::new();
+
+        Triangle::new(Point::new(10, 10), Point::new(20, 30), Point::new(30, -10))
+            .into_styled(PrimitiveStyle::with_fill(BinaryColor::On))
+            .draw(&mut display)
+            .unwrap();
+    }
+
+    #[test]
+    fn off_screen() {
+        let mut display: MockDisplay<BinaryColor> = MockDisplay::new();
+
+        Triangle::new(Point::new(5, 5), Point::new(10, 15), Point::new(15, -5))
+            .into_styled(PrimitiveStyle::with_fill(BinaryColor::On))
+            .draw(&mut display)
+            .unwrap();
+
+        assert_eq!(
+            display,
+            MockDisplay::from_pattern(&[
+                "          #####",
+                "         ######",
+                "        ###### ",
+                "       ####### ",
+                "      ######## ",
+                "     ######### ",
+                "     ########  ",
+                "      #######  ",
+                "      #######  ",
+                "       ######  ",
+                "       #####   ",
+                "        ####   ",
+                "        ####   ",
+                "         ###   ",
+                "         ##    ",
+                "          #    ",
+            ])
+        );
     }
 }

--- a/embedded-graphics/src/primitives/triangle.rs
+++ b/embedded-graphics/src/primitives/triangle.rs
@@ -335,7 +335,7 @@ impl Iterator for Points {
                 }
                 IterState::LeftRight(l, r) => {
                     // Fill the space between the left and right points
-                    if l.x >= 0 && l.y >= 0 && r.x >= 0 && r.y >= 0 && l.x + self.x < r.x {
+                    if l.x + self.x < r.x {
                         let point = Point::new(l.x + self.x, l.y);
                         self.x += 1;
                         return Some(point);


### PR DESCRIPTION
Hi! Thank you for helping out with Embedded Graphics development! Please:

- [x] Check that you've added passing tests and documentation
- [x] Add a simulator example(s) where applicable
- [x] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) and appropriate crate (`embedded-graphics`, `simulator`, `tinytga`, `tinybmp`) if your changes affect the **public API**
- [x] Run `rustfmt` on the project
- [x] Run `./build.sh` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

Triangles were doing the off-screen check back from 0.4/0.5. This PR removes that check, aligning `Triangle` behaviour with other primitives.

Closes #308 

As an aside, this is a candidate for a 0.6 bugfix release at some point. Do you have any suggestions on keeping track of this stuff? I could:

1. Create a tracking issue with each PR to cherry pick tagged in it
2. Add a `v0.6` label and tag PRs with that
3. Both
4. Something else that's smarter.