### PR TITLE
Add support for Arc and Sector primitive

### DIFF
--- a/embedded-graphics/CHANGELOG.md
+++ b/embedded-graphics/CHANGELOG.md
@@ -27,6 +27,8 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 - [#366](https://github.com/jamwaffles/embedded-graphics/pull/366) Allow usage of all grayscale color types in `MockDisplay` patterns.
 - [#342](https://github.com/jamwaffles/embedded-graphics/pull/342) Added `Rectangle::intersection` method.
 - [#363](https://github.com/jamwaffles/embedded-graphics/pull/363) Export `primitives::ContainsPoint` trait in prelude.
+- [#310](https://github.com/jamwaffles/embedded-graphics/pull/320) Added the `Arc` primitive.
+- [#310](https://github.com/jamwaffles/embedded-graphics/pull/320) Added the `Sector` primitive.
 
 ### Changed
 

--- a/embedded-graphics/Cargo.toml
+++ b/embedded-graphics/Cargo.toml
@@ -25,11 +25,15 @@ circle-ci = { repository = "jamwaffles/embedded-graphics", branch = "master" }
 
 [dependencies]
 byteorder = { version = "1.3.2", default-features = false }
+fixed = { version = "0.5.5", optional = true, default-features = false }
+float-cmp = { version = "0.8.0" }
+micromath = { version = "1.0.0", default-features = false }
 nalgebra = { version = "0.19.0", optional = true, default-features = false }
 
 [features]
 default = []
 nalgebra_support = [ "nalgebra" ]
+fixed_point = [ "fixed" ]
 
 [dev-dependencies]
 arrayvec = { version = "0.5.1", default-features = false }

--- a/embedded-graphics/README.md
+++ b/embedded-graphics/README.md
@@ -19,6 +19,7 @@ It contains built in items that make it easy to draw 2D graphics primitives:
   - Circles
   - Ellipses
   - Arcs
+  - Sectors
   - Triangles
   - Polylines
   - Rounded rectangles

--- a/embedded-graphics/README.md
+++ b/embedded-graphics/README.md
@@ -18,6 +18,7 @@ It contains built in items that make it easy to draw 2D graphics primitives:
   - Rectangles
   - Circles
   - Ellipses
+  - Arcs
   - Triangles
   - Polylines
   - Rounded rectangles

--- a/embedded-graphics/README.md
+++ b/embedded-graphics/README.md
@@ -176,6 +176,9 @@ Additional examples can be found in the [simulator](./simulator/examples) crate.
 - `nalgebra_support` - use the [Nalgebra](https://crates.io/crates/nalgebra) crate with `no_std`
   support to enable conversions from `nalgebra::Vector2` to `Coord` and `UnsignedCoord`.
 
+- `fixed_point` - use fixed point arithmetic instead of floating point for all trigonometric
+  calculation.
+
 ## Migrating from 0.5 to 0.6
 
 Please read [the migration guide](embedded-graphics/MIGRATING-0.5-0.6.md).

--- a/embedded-graphics/src/geometry/angle.rs
+++ b/embedded-graphics/src/geometry/angle.rs
@@ -1,0 +1,486 @@
+use super::real;
+use crate::geometry::Real;
+use core::f32::consts::PI;
+use core::ops::{Add, AddAssign, Neg, Sub, SubAssign};
+use float_cmp::{ApproxEq, F32Margin};
+#[cfg(not(feature = "fixed_point"))]
+#[allow(unused_imports)]
+use micromath::F32Ext;
+
+pub(crate) mod angle_consts {
+    use super::{real, Angle};
+
+    pub(crate) const ANGLE_90DEG: Angle = Angle(real::FRAC_PI_2);
+    pub(crate) const ANGLE_180DEG: Angle = Angle(real::PI);
+    pub(crate) const ANGLE_360DEG: Angle = Angle(real::TAU);
+}
+
+/// Angle.
+///
+/// `Angle` is used to define the value of an angle.
+///
+/// # Examples
+///
+/// ## Create an `Angle` from a value
+///
+/// ```rust
+/// use embedded_graphics::geometry::{Angle, AngleUnit};
+/// use core::f32::consts::PI;
+///
+/// // Create an angle using the `from_degrees` constructor method
+/// let angle_a = Angle::from_degrees(10.0);
+/// let angle_b = Angle::from_radians(PI);
+///
+/// // Angles can also be created using the [AngleUnit](./trait.AngleUnit.html) trait
+/// let angle_c = 30.0.deg();
+/// let angle_d = PI.rad();
+/// ```
+#[derive(Copy, Clone, PartialEq, PartialOrd, Debug)]
+pub struct Angle(Real);
+
+impl Angle {
+    /// Creates an angle defined in degrees.
+    pub fn from_degrees(angle: f32) -> Self {
+        Angle((angle * PI / 180.0).into())
+    }
+
+    /// Creates an angle defined in radians.
+    pub fn from_radians(angle: f32) -> Self {
+        Angle(angle.into())
+    }
+
+    /// Creates a zero degree angle.
+    pub fn zero() -> Self {
+        Angle(0.into())
+    }
+
+    /// Compute the absolute value of the angle.
+    pub fn abs(self) -> Self {
+        Angle(self.0.abs())
+    }
+
+    /// Normalize the angle to less than one full rotation (ie. in the range 0..360).
+    pub fn normalize(self) -> Self {
+        Angle(self.0.rem_euclid((2.0 * PI).into()))
+    }
+
+    /// Normalize the angle to less than one full rotation, starting from angle.
+    /// (ie. in the range angle..(angle+360)).
+    pub(crate) fn normalize_from(self, angle: Self) -> Self {
+        Angle((self.0 - angle.0).rem_euclid((2.0 * PI).into()) + angle.0)
+    }
+
+    /// Return numerical value of the angle in degree
+    pub fn to_degrees(self) -> f32 {
+        let angle: f32 = self.0.into();
+        180.0 * angle / PI
+    }
+
+    /// Return numerical value of the angle in radian
+    pub fn to_radians(self) -> f32 {
+        self.0.into()
+    }
+}
+
+/// AngleUnit trait.
+///
+/// `AngleUnit` is a trait to convert numbers into angle by appending .deg() or .rad()
+/// to the number as if it was a unit.
+///
+/// # Examples
+///
+/// ## Create an `Angle` from a value using `AngleUnit`
+///
+/// ```rust
+/// use embedded_graphics::geometry::AngleUnit;
+/// use core::f32::consts::PI;
+///
+/// // Create an angle using the `AngleUnit` methods
+/// let angle_a = 30.0.deg();
+/// let angle_b = PI.rad();
+/// ```
+pub trait AngleUnit {
+    /// Convert a number (interpreted as degrees) to an `Angle`.
+    fn deg(self) -> Angle;
+
+    /// Convert a number (interpreted as radians) to an `Angle`.
+    fn rad(self) -> Angle;
+}
+
+impl AngleUnit for f32 {
+    fn deg(self) -> Angle {
+        Angle::from_degrees(self)
+    }
+
+    fn rad(self) -> Angle {
+        Angle::from_radians(self)
+    }
+}
+
+pub(crate) trait Trigonometry {
+    /// Get the sine of the angle.
+    fn sin(self) -> Real;
+
+    /// Get the cosine of the angle.
+    fn cos(self) -> Real;
+
+    /// Get the tangent of the angle.
+    fn tan(self) -> Option<Real>;
+}
+
+#[cfg(not(feature = "fixed_point"))]
+impl Trigonometry for Angle {
+    fn sin(self) -> Real {
+        let angle: f32 = self.0.into();
+        angle.sin().into()
+    }
+
+    fn cos(self) -> Real {
+        let angle: f32 = self.0.into();
+        angle.cos().into()
+    }
+
+    fn tan(self) -> Option<Real> {
+        let angle: f32 = self.0.into();
+        let tan = angle.tan();
+        // FRAC_PI_2.tan() has no value, but the approximate method used by micromath actually return a huge
+        // value which is > 20000000.0, so we check for this to decide that the angle was approximately
+        // FRAC_PI_2 and that tan() has actually no value.
+        if tan.is_nan() || tan.abs() > 20000000.0 {
+            None
+        } else {
+            Some(tan.into())
+        }
+    }
+}
+
+#[cfg(feature = "fixed_point")]
+impl Trigonometry for Angle {
+    fn sin(self) -> Real {
+        use fixed::types::I16F16;
+        const SIN: [I16F16; 91] = [
+            // Ideally we could make the compiler generate those values, but for now sin() is not a const fn,
+            // so it can't be used here. Here is how it would look like:
+            //   I16F16::from_bits((0f64.sin() * (1 << 16) as f64).round()))),
+            I16F16::from_bits(0),
+            I16F16::from_bits(1144),
+            I16F16::from_bits(2287),
+            I16F16::from_bits(3430),
+            I16F16::from_bits(4572),
+            I16F16::from_bits(5712),
+            I16F16::from_bits(6850),
+            I16F16::from_bits(7987),
+            I16F16::from_bits(9121),
+            I16F16::from_bits(10252),
+            I16F16::from_bits(11380),
+            I16F16::from_bits(12505),
+            I16F16::from_bits(13626),
+            I16F16::from_bits(14742),
+            I16F16::from_bits(15855),
+            I16F16::from_bits(16962),
+            I16F16::from_bits(18064),
+            I16F16::from_bits(19161),
+            I16F16::from_bits(20252),
+            I16F16::from_bits(21336),
+            I16F16::from_bits(22415),
+            I16F16::from_bits(23486),
+            I16F16::from_bits(24550),
+            I16F16::from_bits(25607),
+            I16F16::from_bits(26656),
+            I16F16::from_bits(27697),
+            I16F16::from_bits(28729),
+            I16F16::from_bits(29753),
+            I16F16::from_bits(30767),
+            I16F16::from_bits(31772),
+            I16F16::from_bits(32768),
+            I16F16::from_bits(33754),
+            I16F16::from_bits(34729),
+            I16F16::from_bits(35693),
+            I16F16::from_bits(36647),
+            I16F16::from_bits(37590),
+            I16F16::from_bits(38521),
+            I16F16::from_bits(39441),
+            I16F16::from_bits(40348),
+            I16F16::from_bits(41243),
+            I16F16::from_bits(42126),
+            I16F16::from_bits(42995),
+            I16F16::from_bits(43852),
+            I16F16::from_bits(44695),
+            I16F16::from_bits(45525),
+            I16F16::from_bits(46341),
+            I16F16::from_bits(47143),
+            I16F16::from_bits(47930),
+            I16F16::from_bits(48703),
+            I16F16::from_bits(49461),
+            I16F16::from_bits(50203),
+            I16F16::from_bits(50931),
+            I16F16::from_bits(51643),
+            I16F16::from_bits(52339),
+            I16F16::from_bits(53020),
+            I16F16::from_bits(53684),
+            I16F16::from_bits(54332),
+            I16F16::from_bits(54963),
+            I16F16::from_bits(55578),
+            I16F16::from_bits(56175),
+            I16F16::from_bits(56756),
+            I16F16::from_bits(57319),
+            I16F16::from_bits(57865),
+            I16F16::from_bits(58393),
+            I16F16::from_bits(58903),
+            I16F16::from_bits(59396),
+            I16F16::from_bits(59870),
+            I16F16::from_bits(60326),
+            I16F16::from_bits(60764),
+            I16F16::from_bits(61183),
+            I16F16::from_bits(61584),
+            I16F16::from_bits(61966),
+            I16F16::from_bits(62328),
+            I16F16::from_bits(62672),
+            I16F16::from_bits(62997),
+            I16F16::from_bits(63303),
+            I16F16::from_bits(63589),
+            I16F16::from_bits(63856),
+            I16F16::from_bits(64104),
+            I16F16::from_bits(64332),
+            I16F16::from_bits(64540),
+            I16F16::from_bits(64729),
+            I16F16::from_bits(64898),
+            I16F16::from_bits(65048),
+            I16F16::from_bits(65177),
+            I16F16::from_bits(65287),
+            I16F16::from_bits(65376),
+            I16F16::from_bits(65446),
+            I16F16::from_bits(65496),
+            I16F16::from_bits(65526),
+            I16F16::from_bits(65536),
+        ];
+        let degree: i32 = (Real::from(180) * self.0 / real::PI).round().into();
+        let degree = degree.rem_euclid(360) as usize;
+        let sin = if degree <= 90 {
+            SIN[degree]
+        } else if degree <= 180 {
+            SIN[180 - degree]
+        } else if degree <= 270 {
+            -SIN[degree - 180]
+        } else {
+            -SIN[360 - degree]
+        };
+        sin.into()
+    }
+
+    fn cos(self) -> Real {
+        (self + angle_consts::ANGLE_90DEG).sin()
+    }
+
+    fn tan(self) -> Option<Real> {
+        let cos = self.cos();
+        if cos != Real::zero() {
+            Some(self.sin() / cos)
+        } else {
+            None
+        }
+    }
+}
+
+impl Add for Angle {
+    type Output = Angle;
+
+    fn add(self, other: Angle) -> Angle {
+        Angle(self.0 + other.0)
+    }
+}
+
+impl AddAssign for Angle {
+    fn add_assign(&mut self, other: Angle) {
+        self.0 += other.0;
+    }
+}
+
+impl Sub for Angle {
+    type Output = Angle;
+
+    fn sub(self, other: Angle) -> Angle {
+        Angle(self.0 - other.0)
+    }
+}
+
+impl SubAssign for Angle {
+    fn sub_assign(&mut self, other: Angle) {
+        self.0 -= other.0;
+    }
+}
+
+impl Neg for Angle {
+    type Output = Angle;
+
+    fn neg(self) -> Angle {
+        Angle(-self.0)
+    }
+}
+
+impl ApproxEq for Angle {
+    type Margin = F32Margin;
+
+    fn approx_eq<M: Into<Self::Margin>>(self, other: Self, margin: M) -> bool {
+        self.0.approx_eq(other.0, margin.into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use float_cmp::approx_eq;
+
+    #[test]
+    fn angles_can_be_added() {
+        let left = Angle::from_degrees(10.0);
+        let right = Angle::from_degrees(30.0);
+
+        assert!(approx_eq!(
+            Angle,
+            left + right,
+            Angle::from_degrees(40.0),
+            epsilon = 0.0001
+        ));
+    }
+
+    #[test]
+    fn angles_can_be_subtracted() {
+        let left = Angle::from_degrees(30.0);
+        let right = Angle::from_degrees(10.0);
+
+        assert!(approx_eq!(
+            Angle,
+            left - right,
+            Angle::from_degrees(20.0),
+            epsilon = 0.0001
+        ));
+    }
+
+    #[test]
+    fn angles_can_be_absoluted() {
+        let angle = Angle::from_degrees(30.0).abs();
+        assert_eq!(angle, Angle::from_degrees(30.0));
+
+        let angle = Angle::from_degrees(-30.0).abs();
+        assert_eq!(angle, Angle::from_degrees(30.0));
+    }
+
+    #[test]
+    fn angle_unit() {
+        assert_eq!(180.0.deg(), Angle::from_degrees(180.0));
+        assert_eq!(PI.rad(), Angle::from_radians(PI));
+    }
+
+    #[test]
+    fn from_radians() {
+        assert_eq!(Angle(PI.into()), Angle::from_radians(PI));
+    }
+
+    #[test]
+    fn to_radians() {
+        let angle = Angle(PI.into()).to_radians();
+        assert!(approx_eq!(f32, angle, PI, epsilon = 0.0001));
+    }
+
+    #[test]
+    fn from_degrees() {
+        let angle = Angle::from_degrees(180.0);
+        assert!(approx_eq!(f32, angle.0.into(), PI, epsilon = 0.0001));
+    }
+
+    #[test]
+    fn to_degrees() {
+        let angle = Angle(PI.into()).to_degrees();
+        assert!(approx_eq!(f32, angle, 180.0, epsilon = 0.001));
+    }
+
+    #[test]
+    fn sin_correct() {
+        let degree_sin_pairs = [
+            (-90.0, -1.0),
+            (-60.0, -0.86602540),
+            (-45.0, -0.70710678),
+            (-30.0, -0.5),
+            (0.0, 0.0),
+            (30.0, 0.5),
+            (45.0, 0.70710678),
+            (60.0, 0.86602540),
+            (90.0, 1.0),
+            (120.0, 0.86602540),
+            (135.0, 0.70710678),
+            (150.0, 0.5),
+            (180.0, 0.0),
+            (210.0, -0.5),
+            (225.0, -0.70710678),
+            (240.0, -0.86602540),
+            (270.0, -1.0),
+        ];
+
+        for (angle, sin) in &degree_sin_pairs {
+            assert!(approx_eq!(
+                Real,
+                angle.deg().sin(),
+                (*sin).into(),
+                epsilon = 0.0001
+            ));
+        }
+    }
+
+    #[test]
+    fn cos_correct() {
+        let degree_cos_pairs = [
+            (-90.0, 0.0),
+            (-60.0, 0.5),
+            (-45.0, 0.70710678),
+            (-30.0, 0.86602540),
+            (0.0, 1.0),
+            (30.0, 0.86602540),
+            (45.0, 0.70710678),
+            (60.0, 0.5),
+            (90.0, 0.0),
+            (120.0, -0.5),
+            (135.0, -0.70710678),
+            (150.0, -0.86602540),
+            (180.0, -1.0),
+            (210.0, -0.86602540),
+            (225.0, -0.70710678),
+            (240.0, -0.5),
+            (270.0, -0.0),
+        ];
+
+        for (angle, cos) in &degree_cos_pairs {
+            assert!(approx_eq!(
+                Real,
+                angle.deg().cos(),
+                (*cos).into(),
+                epsilon = 0.0001
+            ));
+        }
+    }
+
+    #[test]
+    fn tan_correct() {
+        let degree_tan_pairs = [
+            (-60.0, -1.73205080),
+            (-45.0, -1.0),
+            (-30.0, -0.57735026),
+            (0.0, 0.0),
+            (30.0, 0.57735026),
+            (45.0, 1.0),
+            (60.0, 1.73205080),
+        ];
+
+        for (angle, tan) in &degree_tan_pairs {
+            assert!(approx_eq!(
+                Real,
+                angle.deg().tan().unwrap(),
+                (*tan).into(),
+                epsilon = 0.0001
+            ));
+        }
+
+        assert_eq!((-90.0.deg()).tan(), None);
+        assert_eq!(90.0.deg().tan(), None);
+    }
+}

--- a/embedded-graphics/src/geometry/mod.rs
+++ b/embedded-graphics/src/geometry/mod.rs
@@ -1,9 +1,15 @@
 //! Geometry module.
 
+mod angle;
 mod point;
+mod real;
 mod size;
 
+pub(crate) use angle::angle_consts;
+pub(crate) use angle::Trigonometry;
+pub use angle::{Angle, AngleUnit};
 pub use point::Point;
+pub(crate) use real::Real;
 pub use size::Size;
 
 use crate::primitives::Rectangle;

--- a/embedded-graphics/src/geometry/real.rs
+++ b/embedded-graphics/src/geometry/real.rs
@@ -1,0 +1,214 @@
+use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
+use float_cmp::{ApproxEq, F32Margin};
+#[cfg(not(feature = "fixed_point"))]
+#[allow(unused_imports)]
+use micromath::F32Ext;
+
+/// Real.
+///
+/// `Real` is used to store real numbers as either floating point or 32 bit fixed point if the
+/// `fixed_point` cargo feature is enabled.
+/// ```
+pub(crate) use real_impl::{Real, FRAC_PI_2, PI, TAU};
+
+#[cfg(not(feature = "fixed_point"))]
+mod real_impl {
+    use core::f32;
+
+    pub(crate) const FRAC_PI_2: Real = Real(f32::consts::FRAC_PI_2);
+    pub(crate) const PI: Real = Real(f32::consts::PI);
+    pub(crate) const TAU: Real = Real(2.0 * f32::consts::PI);
+
+    #[derive(Copy, Clone, PartialEq, PartialOrd, Debug)]
+    pub(crate) struct Real(pub(super) f32);
+
+    impl From<f32> for Real {
+        fn from(src: f32) -> Self {
+            Self(src)
+        }
+    }
+
+    impl From<i32> for Real {
+        fn from(src: i32) -> Self {
+            Self(src as f32)
+        }
+    }
+
+    impl From<u32> for Real {
+        fn from(src: u32) -> Self {
+            Self(src as f32)
+        }
+    }
+
+    impl From<Real> for f32 {
+        fn from(src: Real) -> Self {
+            src.0
+        }
+    }
+
+    impl From<Real> for i32 {
+        fn from(src: Real) -> Self {
+            src.0 as i32
+        }
+    }
+
+    impl From<Real> for u32 {
+        fn from(src: Real) -> Self {
+            src.0 as u32
+        }
+    }
+}
+
+#[cfg(feature = "fixed_point")]
+mod real_impl {
+    use fixed::types::I16F16;
+
+    pub(crate) const FRAC_PI_2: Real = Real(I16F16::from_bits(102944));
+    pub(crate) const PI: Real = Real(I16F16::from_bits(205887));
+    pub(crate) const TAU: Real = Real(I16F16::from_bits(411775));
+
+    #[derive(Copy, Clone, PartialEq, PartialOrd, Debug)]
+    pub(crate) struct Real(pub(super) I16F16);
+
+    impl Real {
+        pub(crate) const fn zero() -> Self {
+            Self(I16F16::from_bits(0))
+        }
+    }
+
+    impl From<I16F16> for Real {
+        fn from(src: I16F16) -> Self {
+            Self(src)
+        }
+    }
+
+    impl From<f32> for Real {
+        fn from(src: f32) -> Self {
+            Self(I16F16::from_num(src))
+        }
+    }
+
+    impl From<i32> for Real {
+        fn from(src: i32) -> Self {
+            Self(I16F16::from_num(src))
+        }
+    }
+
+    impl From<u32> for Real {
+        fn from(src: u32) -> Self {
+            Self(I16F16::from_num(src))
+        }
+    }
+
+    impl From<Real> for f32 {
+        fn from(src: Real) -> Self {
+            src.0.to_num::<f32>()
+        }
+    }
+
+    impl From<Real> for i32 {
+        fn from(src: Real) -> Self {
+            src.0.round_to_zero().to_num::<i32>()
+        }
+    }
+
+    impl From<Real> for u32 {
+        fn from(src: Real) -> Self {
+            src.0.to_num::<u32>()
+        }
+    }
+}
+
+impl Add for Real {
+    type Output = Real;
+
+    fn add(self, other: Real) -> Real {
+        Self(self.0 + other.0)
+    }
+}
+
+impl AddAssign for Real {
+    fn add_assign(&mut self, other: Real) {
+        self.0 += other.0;
+    }
+}
+
+impl Sub for Real {
+    type Output = Real;
+
+    fn sub(self, other: Real) -> Real {
+        Self(self.0 - other.0)
+    }
+}
+
+impl SubAssign for Real {
+    fn sub_assign(&mut self, other: Real) {
+        self.0 -= other.0;
+    }
+}
+
+impl Neg for Real {
+    type Output = Real;
+
+    fn neg(self) -> Real {
+        Self(-self.0)
+    }
+}
+
+impl Mul for Real {
+    type Output = Real;
+
+    fn mul(self, other: Real) -> Real {
+        Self(self.0 * other.0)
+    }
+}
+
+impl MulAssign for Real {
+    fn mul_assign(&mut self, other: Real) {
+        self.0 *= other.0
+    }
+}
+
+impl Div for Real {
+    type Output = Real;
+
+    fn div(self, other: Real) -> Real {
+        Self(self.0 / other.0)
+    }
+}
+
+impl DivAssign for Real {
+    fn div_assign(&mut self, other: Real) {
+        self.0 /= other.0
+    }
+}
+
+impl ApproxEq for Real {
+    type Margin = F32Margin;
+
+    fn approx_eq<M: Into<Self::Margin>>(self, other: Self, margin: M) -> bool {
+        let a: f32 = self.into();
+        let b: f32 = other.into();
+        a.approx_eq(b, margin.into())
+    }
+}
+
+impl Real {
+    pub(crate) fn abs(self) -> Self {
+        Self(self.0.abs())
+    }
+
+    pub(crate) fn rem_euclid(self, rhs: Real) -> Self {
+        let r = self.0 % rhs.0;
+        if r < 0.0 {
+            Real(r) + rhs.abs()
+        } else {
+            Real(r)
+        }
+    }
+
+    #[allow(unused)]
+    pub(crate) fn round(self) -> Self {
+        Self(self.0.round())
+    }
+}

--- a/embedded-graphics/src/lib.rs
+++ b/embedded-graphics/src/lib.rs
@@ -8,6 +8,7 @@
 //!     * [Circles](./primitives/circle/struct.Circle.html)
 //!     * [Ellipses](./primitives/ellipse/struct.Ellipse.html)
 //!     * [Arcs](./primitives/arc/struct.Arc.html)
+//!     * [Sectors](./primitives/sector/struct.Sector.html)
 //!     * [Triangles](./primitives/triangle/struct.Triangle.html)
 //!     * [Polylines](./primitives/polyline/struct.Polyline.html)
 //!     * [Rounded rectangles](./primitives/rounded_rectangle/struct.RoundedRectangle.html)
@@ -320,6 +321,29 @@
 //!
 //! Arc::new(Point::new(12, 12), 40, -30.0.deg(), 150.0.deg())
 //!     .into_styled(PrimitiveStyle::with_stroke(Rgb888::GREEN, 2))
+//!     .draw(&mut display)?;
+//! # Ok::<(), core::convert::Infallible>(())
+//! ```
+//!
+//! </div>
+//! </div>
+//!
+//! ## Draw a sector
+//!
+//! This example draws a sector with no stroke and a solid blue fill.
+//!
+//! <div style="display: flex">
+//! <img style="width: 128px; height: 128px; margin-right: 8px;" alt="Draw a sector example screenshot" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAYAAADDPmHLAAABbElEQVR42u3dgYkCQRBE0W4x/5TbCISFXcHpei8D9V85I+h1VU0R6+UpEAACQAAIAAEgAASAABAAAkAACAABIAAEgAAQAAJAAAgAASAATvbe/xDvfu2hLQB7dR3/zaD5g6fQAmABUv7idy2CBXAN5PmFGgHgDBB+FjjjbGABnAFIPhsIwBnAJ4HJZwILYAG2/EqYJbAACAABkHkGcBawAAjg7OUaASCAB95L2ytrARCAs4AAiA3AWcACIABLYAEQAALg6xtk2P8N9H0CC4AAEACZAfhcwAIgAARARfxO4NX79VgALECwzEWwABaA5EWwAK6BXF+EFgD7sh5Pwx3zw5fGAuAW4LZgAbAAFsECIIBTF6EFgM8BuHQ2aAuAW4DbggXAGQALgAAQAAJAAAgAASAABIAAEAACQAAIAAEgAASAABAAAkAACAABIAAEgAAQAAJAAAgAASAABCAABIAAEAACQAAIAAEgAATAfh9WESP9yc4uqgAAAABJRU5ErkJggg==" />
+//! <div style="flex-grow: 1;">
+//!
+//! ```rust
+//! # let mut display = embedded_graphics::mock_display::MockDisplay::default();
+//! use embedded_graphics::{
+//!     pixelcolor::Rgb888, prelude::*, primitives::Sector, style::PrimitiveStyle,
+//! };
+//!
+//! Sector::new(Point::new(12, 12), 40, -30.0.deg(), 150.0.deg())
+//!     .into_styled(PrimitiveStyle::with_fill(Rgb888::BLUE))
 //!     .draw(&mut display)?;
 //! # Ok::<(), core::convert::Infallible>(())
 //! ```

--- a/embedded-graphics/src/lib.rs
+++ b/embedded-graphics/src/lib.rs
@@ -88,6 +88,9 @@
 //! * `nalgebra_support` - use the [Nalgebra](https://crates.io/crates/nalgebra) crate with `no_std`
 //! support to enable conversions from `nalgebra::Vector2` to [`Point`] and [`Size`].
 //!
+//! * `fixed_point` - use fixed point arithmetic instead of floating point for all trigonometric
+//! calculation.
+//!
 //! # Implementing `embedded_graphics` in a driver
 //!
 //! To add support for embedded_graphics to a display driver, [`DrawTarget`] should be implemented.

--- a/embedded-graphics/src/lib.rs
+++ b/embedded-graphics/src/lib.rs
@@ -7,6 +7,7 @@
 //!     * [Rectangles (and squares)](./primitives/rectangle/struct.Rectangle.html)
 //!     * [Circles](./primitives/circle/struct.Circle.html)
 //!     * [Ellipses](./primitives/ellipse/struct.Ellipse.html)
+//!     * [Arcs](./primitives/arc/struct.Arc.html)
 //!     * [Triangles](./primitives/triangle/struct.Triangle.html)
 //!     * [Polylines](./primitives/polyline/struct.Polyline.html)
 //!     * [Rounded rectangles](./primitives/rounded_rectangle/struct.RoundedRectangle.html)
@@ -295,6 +296,29 @@
 //! };
 //!
 //! Ellipse::new(Point::new(8, 16), Size::new(48, 32))
+//!     .into_styled(PrimitiveStyle::with_stroke(Rgb888::GREEN, 2))
+//!     .draw(&mut display)?;
+//! # Ok::<(), core::convert::Infallible>(())
+//! ```
+//!
+//! </div>
+//! </div>
+//!
+//! ## Draw an arc
+//!
+//! This example draws an arc with a 2px green stroke.
+//!
+//! <div style="display: flex">
+//! <img style="width: 128px; height: 128px; margin-right: 8px;" alt="Draw an arc example screenshot" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAYAAADDPmHLAAABTUlEQVR42u3cQQ6DMAxFQRvl/lcOOzaIDYqEHWYu0Ba9/gapbUbEDH7rcAkEgAAQAAJAAAgAASAABIAAEAACQAAIAAEgAASAABAAAqC/se0rW/1d57QAbCij++8CZoEraAGwAFXf8dns8SwAFuDNOzKLPI9mi2ABLEDTBciiz6vZElgAC+D/AbY+q1gALIAlsABYAEtgAbAAlsACYAEsgQVAAF9vbwoAAXA7G0wBIABnAQEgAGcBASAAZwEBIAAEgADcDQgAAbgbEAACQAAIAAEgAASAABAAAkAACAABIAAEwKPhEhQzLQAWgEtaAASAAHAGcPq3AFgAp38LgAAQAIs+afxXsAVAAAgAASAABIAAEAACQAAIAAEgAASAABAAAkAACAABIAAEgAAQAAJAAAgAASAABIAAEAACQAAIAAEgAASAABAAAkAACIDvnG3zIPeb6boNAAAAAElFTkSuQmCC" />
+//! <div style="flex-grow: 1;">
+//!
+//! ```rust
+//! # let mut display = embedded_graphics::mock_display::MockDisplay::default();
+//! use embedded_graphics::{
+//!     pixelcolor::Rgb888, prelude::*, primitives::Arc, style::PrimitiveStyle,
+//! };
+//!
+//! Arc::new(Point::new(12, 12), 40, -30.0.deg(), 150.0.deg())
 //!     .into_styled(PrimitiveStyle::with_stroke(Rgb888::GREEN, 2))
 //!     .draw(&mut display)?;
 //! # Ok::<(), core::convert::Infallible>(())

--- a/embedded-graphics/src/prelude.rs
+++ b/embedded-graphics/src/prelude.rs
@@ -3,7 +3,7 @@
 #[doc(no_inline)]
 pub use crate::{
     fonts::Font,
-    geometry::{Dimensions, Point, Size},
+    geometry::{Angle, AngleUnit, Dimensions, Point, Size},
     image::{ImageDimensions, IntoPixelIter},
     pixelcolor::{raw::RawData, GrayColor, IntoStorage, PixelColor, RgbColor},
     primitives::{ContainsPoint, Primitive},

--- a/embedded-graphics/src/primitives/arc.rs
+++ b/embedded-graphics/src/primitives/arc.rs
@@ -1,0 +1,618 @@
+//! The arc primitive
+
+use crate::{
+    drawable::{Drawable, Pixel},
+    geometry::{angle_consts::*, Angle, Dimensions, Point, Real, Size, Trigonometry},
+    pixelcolor::PixelColor,
+    primitives::{circle, circle::DistanceIterator, Primitive, Rectangle, Styled},
+    style::PrimitiveStyle,
+    transform::Transform,
+    DrawTarget,
+};
+
+/// Arc primitive
+///
+/// # Examples
+///
+/// ## Create some arcs with different styles
+///
+/// ```rust
+/// use embedded_graphics::{
+///     pixelcolor::Rgb565,
+///     prelude::*,
+///     primitives::Arc,
+///     style::{PrimitiveStyle, PrimitiveStyleBuilder},
+/// };
+/// # use embedded_graphics::mock_display::MockDisplay;
+/// # let mut display = MockDisplay::default();
+///
+/// // Arc with 1 pixel wide white stroke with top-left point at (10, 20) with a diameter of 30
+/// Arc::new(Point::new(10, 20), 30, 0.0.deg(), 90.0.deg())
+///     .into_styled(PrimitiveStyle::with_stroke(Rgb565::WHITE, 1))
+///     .draw(&mut display)?;
+///
+/// // Arc with styled stroke with top-left point at (15, 25) with a diameter of 20
+/// let style = PrimitiveStyleBuilder::new()
+///     .stroke_color(Rgb565::RED)
+///     .stroke_width(3)
+///     .build();
+///
+/// Arc::new(Point::new(15, 25), 20, 180.0.deg(), -90.0.deg())
+///     .into_styled(style)
+///     .draw(&mut display)?;
+/// # Ok::<(), core::convert::Infallible>(())
+/// ```
+#[derive(Copy, Clone, PartialEq, PartialOrd, Debug)]
+pub struct Arc {
+    /// Top-left point of the bounding-box of the circle supporting the arc
+    pub top_left: Point,
+
+    /// Diameter of the circle supporting the arc
+    pub diameter: u32,
+
+    /// Angle at which the arc starts
+    pub angle_start: Angle,
+
+    /// Angle defining the arc sweep starting at angle_start
+    pub angle_sweep: Angle,
+}
+
+impl Arc {
+    /// Create a new arc delimited with a top-left point with a specific diameter and start and sweep angles
+    pub const fn new(
+        top_left: Point,
+        diameter: u32,
+        angle_start: Angle,
+        angle_sweep: Angle,
+    ) -> Self {
+        Arc {
+            top_left,
+            diameter,
+            angle_start,
+            angle_sweep,
+        }
+    }
+
+    /// Create a new arc centered around a given point with a specific diameter and start and sweep angles
+    pub fn with_center(
+        center: Point,
+        diameter: u32,
+        angle_start: Angle,
+        angle_sweep: Angle,
+    ) -> Self {
+        let top_left = center - Size::new_equal(diameter).center_offset();
+
+        Arc {
+            top_left,
+            diameter,
+            angle_start,
+            angle_sweep,
+        }
+    }
+
+    /// Return the center point of the arc
+    pub fn center(&self) -> Point {
+        self.bounding_box().center()
+    }
+
+    /// Return the center point of the arc scaled by a factor of 2
+    ///
+    /// This method is used to accurately calculate the outside edge of the arc.
+    /// The result is not equivalent to `self.center() * 2` because of rounding.
+    fn center_2x(&self) -> Point {
+        // The radius scaled up by a factor of 2 is equal to the diameter
+        let radius = self.diameter.saturating_sub(1);
+
+        self.top_left * 2 + Size::new(radius, radius)
+    }
+
+    pub(crate) fn expand(&self, offset: u32) -> Self {
+        let diameter = self.diameter.saturating_add(2 * offset);
+
+        Self::with_center(self.center(), diameter, self.angle_start, self.angle_sweep)
+    }
+
+    pub(crate) fn shrink(&self, offset: u32) -> Self {
+        let diameter = self.diameter.saturating_sub(2 * offset);
+
+        Self::with_center(self.center(), diameter, self.angle_start, self.angle_sweep)
+    }
+}
+
+impl Primitive for Arc {
+    type PointsIter = Points;
+
+    fn points(&self) -> Self::PointsIter {
+        Points::new(self)
+    }
+}
+
+impl Dimensions for Arc {
+    fn bounding_box(&self) -> Rectangle {
+        Rectangle::new(self.top_left, Size::new(self.diameter, self.diameter))
+    }
+}
+
+impl Transform for Arc {
+    /// Translate the arc from its current position to a new position by (x, y) pixels,
+    /// returning a new `Arc`. For a mutating transform, see `translate_mut`.
+    ///
+    /// ```
+    /// # use embedded_graphics::primitives::Arc;
+    /// # use embedded_graphics::prelude::*;
+    /// let arc = Arc::new(Point::new(5, 10), 10, 0.0.deg(), 90.0.deg());
+    /// let moved = arc.translate(Point::new(10, 10));
+    ///
+    /// assert_eq!(moved.top_left, Point::new(15, 20));
+    /// ```
+    fn translate(&self, by: Point) -> Self {
+        Self {
+            top_left: self.top_left + by,
+            ..*self
+        }
+    }
+
+    /// Translate the arc from its current position to a new position by (x, y) pixels.
+    ///
+    /// ```
+    /// # use embedded_graphics::primitives::Arc;
+    /// # use embedded_graphics::prelude::*;
+    /// let mut arc = Arc::new(Point::new(5, 10), 10, 0.0.deg(), 90.0.deg());
+    /// arc.translate_mut(Point::new(10, 10));
+    ///
+    /// assert_eq!(arc.top_left, Point::new(15, 20));
+    /// ```
+    fn translate_mut(&mut self, by: Point) -> &mut Self {
+        self.top_left += by;
+
+        self
+    }
+}
+
+/// Iterator over all points on the arc line.
+#[derive(Copy, Clone, PartialEq, PartialOrd, Debug)]
+pub struct Points {
+    iter: DistanceIterator<PlaneSectorIterator>,
+
+    outer_threshold: u32,
+    inner_threshold: u32,
+}
+
+impl Points {
+    fn new(arc: &Arc) -> Self {
+        let outer_diameter = arc.diameter;
+        let inner_diameter = outer_diameter.saturating_sub(2);
+
+        let inner_threshold = circle::diameter_to_threshold(inner_diameter);
+        let outer_threshold = circle::diameter_to_threshold(outer_diameter);
+
+        let iter = DistanceIterator::new(
+            arc.center_2x(),
+            PlaneSectorIterator::new(arc, arc.center(), arc.angle_start, arc.angle_sweep),
+        );
+
+        Self {
+            iter,
+            outer_threshold,
+            inner_threshold,
+        }
+    }
+}
+
+impl Iterator for Points {
+    type Item = Point;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let outer_threshold = self.outer_threshold;
+        let inner_threshold = self.inner_threshold;
+
+        self.iter
+            .find(|(_, distance)| *distance < outer_threshold && *distance >= inner_threshold)
+            .map(|(point, _)| point)
+    }
+}
+
+/// Pixel iterator for each pixel in the arc border
+#[derive(Copy, Clone, PartialEq, PartialOrd, Debug)]
+pub struct StyledArcIterator<C>
+where
+    C: PixelColor,
+{
+    iter: DistanceIterator<PlaneSectorIterator>,
+
+    outer_threshold: u32,
+    inner_threshold: u32,
+
+    stroke_color: Option<C>,
+}
+
+impl<C> StyledArcIterator<C>
+where
+    C: PixelColor,
+{
+    fn new(styled: &Styled<Arc, PrimitiveStyle<C>>) -> Self {
+        let Styled { primitive, style } = styled;
+
+        let stroke_area = primitive.expand(style.outside_stroke_width());
+        let fill_area = primitive.shrink(style.inside_stroke_width());
+
+        let inner_threshold = circle::diameter_to_threshold(fill_area.diameter);
+        let outer_threshold = circle::diameter_to_threshold(stroke_area.diameter);
+
+        let iter = if !styled.style.is_transparent() {
+            DistanceIterator::new(
+                stroke_area.center_2x(),
+                PlaneSectorIterator::new(
+                    &stroke_area,
+                    stroke_area.center(),
+                    stroke_area.angle_start,
+                    stroke_area.angle_sweep,
+                ),
+            )
+        } else {
+            DistanceIterator::new(Point::zero(), PlaneSectorIterator::empty())
+        };
+
+        Self {
+            iter,
+            outer_threshold,
+            inner_threshold,
+            stroke_color: styled.style.stroke_color,
+        }
+    }
+}
+
+impl<C> Iterator for StyledArcIterator<C>
+where
+    C: PixelColor,
+{
+    type Item = Pixel<C>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let stroke_color = self.stroke_color?;
+        let outer_threshold = self.outer_threshold;
+        let inner_threshold = self.inner_threshold;
+
+        self.iter
+            .find(|(_, distance)| *distance < outer_threshold && *distance >= inner_threshold)
+            .map(|(point, _)| Pixel(point, stroke_color))
+    }
+}
+
+impl<'a, C: 'a> Drawable<C> for &Styled<Arc, PrimitiveStyle<C>>
+where
+    C: PixelColor,
+{
+    fn draw<D: DrawTarget<Color = C>>(self, display: &mut D) -> Result<(), D::Error> {
+        display.draw_iter(self)
+    }
+}
+
+impl<'a, C> IntoIterator for &'a Styled<Arc, PrimitiveStyle<C>>
+where
+    C: PixelColor,
+{
+    type Item = Pixel<C>;
+    type IntoIter = StyledArcIterator<C>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        StyledArcIterator::new(self)
+    }
+}
+
+#[derive(Copy, Clone, PartialEq, PartialOrd, Debug)]
+pub(in crate::primitives) struct PlaneSector {
+    line_a: LinearEquation,
+    line_b: LinearEquation,
+    draw_above_a: bool,
+    draw_above_b: bool,
+    sweep: Angle,
+}
+
+impl PlaneSector {
+    pub(in crate::primitives) fn new(
+        center: Point,
+        angle_start: Angle,
+        angle_sweep: Angle,
+    ) -> Self {
+        let angle_end = angle_start + angle_sweep;
+
+        let angle_start_norm = angle_start.normalize_from(-ANGLE_90DEG);
+        let angle_end_norm = angle_end.normalize_from(-ANGLE_90DEG);
+        let negative_sweep = angle_sweep < Angle::zero();
+
+        Self {
+            line_a: LinearEquation::from_point_angle(center, angle_start),
+            line_b: LinearEquation::from_point_angle(center, angle_end),
+            draw_above_a: (angle_start_norm < ANGLE_90DEG) ^ negative_sweep,
+            draw_above_b: (angle_end_norm >= ANGLE_90DEG) ^ negative_sweep,
+            sweep: angle_sweep.abs(),
+        }
+    }
+
+    fn empty() -> Self {
+        Self {
+            line_a: LinearEquation::flat(),
+            line_b: LinearEquation::flat(),
+            draw_above_a: true,
+            draw_above_b: true,
+            sweep: Angle::zero(),
+        }
+    }
+
+    pub(in crate::primitives) fn contains(&self, point: &Point) -> bool {
+        let side_a = self.line_a.side(point);
+        let side_b = self.line_b.side(point);
+
+        let correct_a_side = self.draw_above_a ^ (side_a == LineSide::Below);
+        let correct_b_side = self.draw_above_b ^ (side_b == LineSide::Below);
+
+        if self.sweep < ANGLE_180DEG {
+            correct_a_side && correct_b_side
+        } else if self.sweep < ANGLE_360DEG {
+            correct_a_side || correct_b_side
+        } else {
+            true
+        }
+    }
+}
+
+/// Iterator that returns only the points which are inside a plane sector defined by two lines.
+#[derive(Copy, Clone, PartialEq, PartialOrd, Debug)]
+pub(in crate::primitives) struct PlaneSectorIterator {
+    plane_sector: PlaneSector,
+    points: super::rectangle::Points,
+}
+
+impl PlaneSectorIterator {
+    pub(in crate::primitives) fn new<D: Dimensions>(
+        primitive: &D,
+        center: Point,
+        angle_start: Angle,
+        angle_sweep: Angle,
+    ) -> Self {
+        Self {
+            plane_sector: PlaneSector::new(center, angle_start, angle_sweep),
+            points: primitive.bounding_box().points(),
+        }
+    }
+
+    pub(in crate::primitives) fn empty() -> Self {
+        Self {
+            plane_sector: PlaneSector::empty(),
+            points: Rectangle::new(Point::zero(), Size::zero()).points(),
+        }
+    }
+}
+
+impl Iterator for PlaneSectorIterator {
+    type Item = Point;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let plane_sector = self.plane_sector;
+        self.points.find(|p| plane_sector.contains(p))
+    }
+}
+
+/// Define one side of a line
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+enum LineSide {
+    Above,
+    Below,
+}
+
+/// Linear equation representation
+///
+/// The equation is stored as the a, b and c coefficients of the ax + by + c = 0 equation
+#[derive(Copy, Clone, PartialEq, PartialOrd, Debug)]
+struct LinearEquation {
+    a: Real,
+    b: Real,
+    c: Real,
+}
+
+impl LinearEquation {
+    /// Create a new linear equation based on one point and one angle
+    fn from_point_angle(point: Point, angle: Angle) -> Self {
+        let (a, b) = match angle.tan() {
+            None => (Real::from(1.0), Real::from(0.0)),
+            Some(a) => (-a, Real::from(-1.0)),
+        };
+        let c = -(a * point.x.into() + b * point.y.into());
+        LinearEquation { a, b, c }
+    }
+
+    /// Create a flat line equation
+    fn flat() -> Self {
+        LinearEquation {
+            a: Real::from(0.0),
+            b: Real::from(1.0),
+            c: Real::from(0.0),
+        }
+    }
+
+    /// Check on which side of the line a point is
+    fn side(&self, point: &Point) -> LineSide {
+        if self.a * point.x.into() + self.b * point.y.into() + self.c < Real::from(0.0) {
+            LineSide::Below
+        } else {
+            LineSide::Above
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        geometry::AngleUnit,
+        mock_display::MockDisplay,
+        pixelcolor::BinaryColor,
+        style::{PrimitiveStyleBuilder, StrokeAlignment},
+    };
+
+    // Check the rendering of a simple arc
+    #[test]
+    fn tiny_arc() -> Result<(), core::convert::Infallible> {
+        let mut display = MockDisplay::new();
+
+        Arc::new(Point::zero(), 7, 30.0.deg(), 120.0.deg())
+            .into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 1))
+            .draw(&mut display)?;
+
+        #[rustfmt::skip]
+        assert_eq!(
+            display,
+            MockDisplay::from_pattern(&[
+                "  ###  ",
+                " #   # ",
+            ])
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn negative_dimensions() {
+        let arc = Arc::new(Point::new(-15, -15), 10, 0.0.deg(), 90.0.deg());
+
+        assert_eq!(
+            arc.bounding_box(),
+            Rectangle::new(Point::new(-15, -15), Size::new(10, 10))
+        );
+    }
+
+    #[test]
+    fn dimensions() {
+        let arc = Arc::new(Point::new(5, 15), 10, 0.0.deg(), 90.0.deg());
+
+        assert_eq!(
+            arc.bounding_box(),
+            Rectangle::new(Point::new(5, 15), Size::new(10, 10))
+        );
+    }
+
+    #[test]
+    fn it_handles_negative_coordinates() {
+        let positive = Arc::new(Point::new(10, 10), 5, 0.0.deg(), 90.0.deg())
+            .into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 1))
+            .into_iter();
+
+        let negative = Arc::new(Point::new(-10, -10), 5, 0.0.deg(), 90.0.deg())
+            .into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 1))
+            .into_iter();
+
+        assert!(negative.into_iter().eq(positive
+            .into_iter()
+            .map(|Pixel(p, c)| Pixel(p - Point::new(20, 20), c))));
+    }
+
+    #[test]
+    fn center_is_correct() {
+        // odd diameter
+        let arc = Arc::new(Point::new(10, 10), 5, 0.0.deg(), 90.0.deg());
+        assert_eq!(arc.center(), Point::new(12, 12));
+
+        // even diameter
+        let arc = Arc::new(Point::new(10, 10), 6, 0.0.deg(), 90.0.deg());
+        assert_eq!(arc.center(), Point::new(12, 12));
+
+        // odd diameter
+        let arc = Arc::with_center(Point::new(10, 10), 5, 0.0.deg(), 90.0.deg());
+        assert_eq!(arc.center(), Point::new(10, 10));
+
+        // even diameter
+        let arc = Arc::with_center(Point::new(10, 10), 6, 0.0.deg(), 90.0.deg());
+        assert_eq!(arc.center(), Point::new(10, 10));
+    }
+
+    #[test]
+    fn points_iter() {
+        let arc = Arc::with_center(Point::new(10, 10), 5, 0.0.deg(), 90.0.deg());
+
+        let styled_points = arc
+            .clone()
+            .into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 1))
+            .into_iter()
+            .map(|Pixel(p, _)| p);
+
+        assert!(arc.points().eq(styled_points));
+    }
+
+    #[test]
+    fn plane_arc_iter() {
+        let arc = Arc::new(Point::zero(), 3, 0.0.deg(), 90.0.deg());
+
+        let mut iter =
+            PlaneSectorIterator::new(&arc, arc.center(), arc.angle_start, arc.angle_sweep);
+        assert_eq!(iter.next(), Some(Point::new(1, 0)));
+        assert_eq!(iter.next(), Some(Point::new(2, 0)));
+        assert_eq!(iter.next(), Some(Point::new(1, 1)));
+        assert_eq!(iter.next(), Some(Point::new(2, 1)));
+        assert_eq!(iter.next(), None);
+    }
+
+    #[test]
+    fn plane_sector_iter_empty() {
+        let mut iter = PlaneSectorIterator::empty();
+        assert_eq!(iter.next(), None);
+    }
+
+    #[test]
+    fn distance_iter() {
+        let arc = Arc::new(Point::zero(), 3, 0.0.deg(), 90.0.deg());
+
+        let mut iter = DistanceIterator::new(
+            arc.center_2x(),
+            PlaneSectorIterator::new(&arc, arc.center(), arc.angle_start, arc.angle_sweep),
+        );
+        assert_eq!(iter.next(), Some((Point::new(1, 0), 4)));
+        assert_eq!(iter.next(), Some((Point::new(2, 0), 8)));
+        assert_eq!(iter.next(), Some((Point::new(1, 1), 0)));
+        assert_eq!(iter.next(), Some((Point::new(2, 1), 4)));
+        assert_eq!(iter.next(), None);
+    }
+
+    #[test]
+    fn distance_iter_empty() {
+        let mut iter = DistanceIterator::new(Point::zero(), PlaneSectorIterator::empty());
+        assert_eq!(iter.next(), None);
+    }
+
+    #[test]
+    fn stroke_alignment() {
+        const CENTER: Point = Point::new(15, 15);
+        const SIZE: u32 = 10;
+
+        let style = PrimitiveStyle::with_stroke(BinaryColor::On, 3);
+
+        let mut display_center = MockDisplay::new();
+        Arc::with_center(CENTER, SIZE, 0.0.deg(), 90.0.deg())
+            .into_styled(style)
+            .draw(&mut display_center)
+            .unwrap();
+
+        let mut display_inside = MockDisplay::new();
+        Arc::with_center(CENTER, SIZE + 2, 0.0.deg(), 90.0.deg())
+            .into_styled(
+                PrimitiveStyleBuilder::from(&style)
+                    .stroke_alignment(StrokeAlignment::Inside)
+                    .build(),
+            )
+            .draw(&mut display_inside)
+            .unwrap();
+
+        let mut display_outside = MockDisplay::new();
+        Arc::with_center(CENTER, SIZE - 4, 0.0.deg(), 90.0.deg())
+            .into_styled(
+                PrimitiveStyleBuilder::from(&style)
+                    .stroke_alignment(StrokeAlignment::Outside)
+                    .build(),
+            )
+            .draw(&mut display_outside)
+            .unwrap();
+
+        assert_eq!(display_center, display_inside);
+        assert_eq!(display_center, display_outside);
+    }
+}

--- a/embedded-graphics/src/primitives/circle/mod.rs
+++ b/embedded-graphics/src/primitives/circle/mod.rs
@@ -9,6 +9,7 @@ use crate::{
     primitives::{ContainsPoint, Primitive, Rectangle},
     transform::Transform,
 };
+pub use distance_iterator::DistanceIterator;
 pub use points::Points;
 pub use styled::StyledPixels;
 

--- a/embedded-graphics/src/primitives/circle/points.rs
+++ b/embedded-graphics/src/primitives/circle/points.rs
@@ -1,12 +1,14 @@
 use crate::{
-    geometry::Point,
+    geometry::{Dimensions, Point},
     primitives::circle::{diameter_to_threshold, distance_iterator::DistanceIterator, Circle},
+    primitives::rectangle,
+    primitives::Primitive,
 };
 
 /// Iterator over all points inside the circle.
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub struct Points {
-    iter: DistanceIterator,
+    iter: DistanceIterator<rectangle::Points>,
     threshold: u32,
 }
 
@@ -15,7 +17,7 @@ impl Points {
         let threshold = diameter_to_threshold(circle.diameter);
 
         Self {
-            iter: DistanceIterator::new(&circle),
+            iter: DistanceIterator::new(circle.center_2x(), circle.bounding_box().points()),
             threshold,
         }
     }

--- a/embedded-graphics/src/primitives/circle/styled.rs
+++ b/embedded-graphics/src/primitives/circle/styled.rs
@@ -1,8 +1,11 @@
 use crate::{
     draw_target::DrawTarget,
     drawable::{Drawable, Pixel},
+    geometry::{Dimensions, Point, Size},
     pixelcolor::PixelColor,
     primitives::circle::{diameter_to_threshold, distance_iterator::DistanceIterator, Circle},
+    primitives::rectangle::{self, Rectangle},
+    primitives::Primitive,
     style::{PrimitiveStyle, Styled},
 };
 
@@ -12,7 +15,7 @@ pub struct StyledPixels<C>
 where
     C: PixelColor,
 {
-    iter: DistanceIterator,
+    iter: DistanceIterator<rectangle::Points>,
 
     outer_threshold: u32,
     outer_color: Option<C>,
@@ -35,9 +38,12 @@ where
         let outer_threshold = diameter_to_threshold(stroke_area.diameter);
 
         let iter = if !styled.style.is_transparent() {
-            DistanceIterator::new(&stroke_area)
+            DistanceIterator::new(stroke_area.center_2x(), stroke_area.bounding_box().points())
         } else {
-            DistanceIterator::empty()
+            DistanceIterator::new(
+                Point::zero(),
+                Rectangle::new(Point::zero(), Size::zero()).points(),
+            )
         };
 
         Self {
@@ -101,7 +107,7 @@ mod tests {
     use super::*;
     use crate::{
         drawable::Drawable,
-        geometry::{Dimensions, Point},
+        geometry::Dimensions,
         mock_display::MockDisplay,
         pixelcolor::BinaryColor,
         primitives::Primitive,

--- a/embedded-graphics/src/primitives/line/mod.rs
+++ b/embedded-graphics/src/primitives/line/mod.rs
@@ -12,6 +12,7 @@ use crate::{
 };
 pub use points::Points;
 pub use styled::StyledPixels;
+pub use thick_points::ThickPoints;
 
 /// Line primitive
 ///

--- a/embedded-graphics/src/primitives/line/thick_points.rs
+++ b/embedded-graphics/src/primitives/line/thick_points.rs
@@ -190,7 +190,7 @@ impl Iterator for ParallelsIterator {
 }
 
 /// Iterator over all pixels in the stroke of a thick line.
-#[derive(Clone, Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub struct ThickPoints {
     parallel: Bresenham,
     parallel_length: u32,
@@ -201,7 +201,7 @@ pub struct ThickPoints {
 
 impl ThickPoints {
     /// Creates a new iterator over the points in the stroke of a thick line.
-    pub(in crate::primitives::line) fn new(line: &Line, thickness: i32) -> Self {
+    pub(in crate::primitives) fn new(line: &Line, thickness: i32) -> Self {
         Self {
             parallel: Bresenham::new(line.start),
             parallel_length: bresenham::major_length(line),

--- a/embedded-graphics/src/primitives/mod.rs
+++ b/embedded-graphics/src/primitives/mod.rs
@@ -7,6 +7,7 @@ pub mod line;
 pub mod polyline;
 pub mod rectangle;
 pub mod rounded_rectangle;
+pub mod sector;
 pub mod triangle;
 
 pub use self::{
@@ -17,6 +18,7 @@ pub use self::{
     polyline::Polyline,
     rectangle::Rectangle,
     rounded_rectangle::{CornerRadii, CornerRadiiBuilder, RoundedRectangle},
+    sector::Sector,
     triangle::Triangle,
 };
 use crate::{

--- a/embedded-graphics/src/primitives/mod.rs
+++ b/embedded-graphics/src/primitives/mod.rs
@@ -1,5 +1,6 @@
 //! Graphics primitives
 
+pub mod arc;
 pub mod circle;
 pub mod ellipse;
 pub mod line;
@@ -9,6 +10,7 @@ pub mod rounded_rectangle;
 pub mod triangle;
 
 pub use self::{
+    arc::Arc,
     circle::Circle,
     ellipse::Ellipse,
     line::Line,

--- a/embedded-graphics/src/primitives/sector.rs
+++ b/embedded-graphics/src/primitives/sector.rs
@@ -1,0 +1,646 @@
+//! The sector primitive
+
+use crate::{
+    drawable::{Drawable, Pixel},
+    geometry::{Angle, Dimensions, Point, Real, Size, Trigonometry},
+    pixelcolor::PixelColor,
+    primitives::{
+        arc::PlaneSector, arc::PlaneSectorIterator, circle, circle::DistanceIterator, line::Line,
+        line::ThickPoints, ContainsPoint, Primitive, Rectangle, Styled,
+    },
+    style::PrimitiveStyle,
+    transform::Transform,
+    DrawTarget,
+};
+
+/// Sector primitive
+///
+/// # Examples
+///
+/// ## Create some sectors with different styles
+///
+/// ```rust
+/// use embedded_graphics::{
+///     pixelcolor::Rgb565,
+///     prelude::*,
+///     primitives::Sector,
+///     style::{PrimitiveStyle, PrimitiveStyleBuilder},
+/// };
+/// # use embedded_graphics::mock_display::MockDisplay;
+/// # let mut display = MockDisplay::default();
+/// # display.set_allow_overdraw(true);
+///
+/// // Sector with 1 pixel wide white stroke with top-left point at (10, 20) with a diameter of 30
+/// Sector::new(Point::new(10, 20), 30, 0.0.deg(), 90.0.deg())
+///     .into_styled(PrimitiveStyle::with_stroke(Rgb565::WHITE, 1))
+///     .draw(&mut display)?;
+///
+/// // Sector with styled stroke and fill with top-left point at (10, 20) with a diameter of 30
+/// let style = PrimitiveStyleBuilder::new()
+///     .stroke_color(Rgb565::RED)
+///     .stroke_width(3)
+///     .fill_color(Rgb565::GREEN)
+///     .build();
+///
+/// Sector::new(Point::new(10, 20), 30, 180.0.deg(), -90.0.deg())
+///     .into_styled(style)
+///     .draw(&mut display)?;
+///
+/// // Sector with blue fill and no stroke with a translation applied
+/// Sector::new(Point::new(10, 20), 30, 0.0.deg(), 90.0.deg())
+///     .translate(Point::new(15, 5))
+///     .into_styled(PrimitiveStyle::with_fill(Rgb565::BLUE))
+///     .draw(&mut display)?;
+/// # Ok::<(), core::convert::Infallible>(())
+/// ```
+#[derive(Copy, Clone, PartialEq, PartialOrd, Debug)]
+pub struct Sector {
+    /// Top-left point of the bounding-box of the circle supporting the sector
+    pub top_left: Point,
+
+    /// Diameter of the circle supporting the sector
+    pub diameter: u32,
+
+    /// Angle at which the sector starts
+    pub angle_start: Angle,
+
+    /// Angle defining the sector sweep starting at angle_start
+    pub angle_sweep: Angle,
+}
+
+impl Sector {
+    /// Create a new sector delimited with a top-left point with a specific diameter and start and sweep angles
+    pub const fn new(
+        top_left: Point,
+        diameter: u32,
+        angle_start: Angle,
+        angle_sweep: Angle,
+    ) -> Self {
+        Sector {
+            top_left,
+            diameter,
+            angle_start,
+            angle_sweep,
+        }
+    }
+
+    /// Create a new sector centered around a given point with a specific diameter and start and sweep angles
+    pub fn with_center(
+        center: Point,
+        diameter: u32,
+        angle_start: Angle,
+        angle_sweep: Angle,
+    ) -> Self {
+        let top_left = center - Size::new(diameter, diameter).center_offset();
+
+        Sector {
+            top_left,
+            diameter,
+            angle_start,
+            angle_sweep,
+        }
+    }
+
+    /// Return the center point of the sector
+    pub fn center(&self) -> Point {
+        self.bounding_box().center()
+    }
+
+    /// Return the center point of the sector scaled by a factor of 2
+    ///
+    /// This method is used to accurately calculate the outside edge of the sector.
+    /// The result is not equivalent to `self.center() * 2` because of rounding.
+    fn center_2x(&self) -> Point {
+        // The radius scaled up by a factor of 2 is equal to the diameter
+        let radius = self.diameter.saturating_sub(1);
+
+        self.top_left * 2 + Size::new(radius, radius)
+    }
+
+    /// Return the end angle of the sector
+    fn angle_end(&self) -> Angle {
+        self.angle_start + self.angle_sweep
+    }
+
+    /// Return a `Line` between the sector center and a point on the circumference following a given angle
+    fn line_from_angle(&self, angle: Angle) -> Line {
+        let center = self.center();
+        let radius = Real::from(self.diameter.saturating_sub(1)) / 2.into();
+
+        let point = Point::new(
+            center.x + i32::from(angle.cos() * radius),
+            center.y - i32::from(angle.sin() * radius),
+        );
+
+        Line::new(center, point)
+    }
+
+    pub(crate) fn expand(&self, offset: u32) -> Self {
+        let diameter = self.diameter.saturating_add(2 * offset);
+
+        Self::with_center(self.center(), diameter, self.angle_start, self.angle_sweep)
+    }
+
+    pub(crate) fn shrink(&self, offset: u32) -> Self {
+        let diameter = self.diameter.saturating_sub(2 * offset);
+
+        Self::with_center(self.center(), diameter, self.angle_start, self.angle_sweep)
+    }
+}
+
+impl Primitive for Sector {
+    type PointsIter = Points;
+
+    fn points(&self) -> Self::PointsIter {
+        Points::new(self)
+    }
+}
+
+impl ContainsPoint for Sector {
+    fn contains(&self, point: Point) -> bool {
+        let delta = self.center_2x() - point * 2;
+        let distance = delta.length_squared() as u32;
+
+        let threshold = circle::diameter_to_threshold(self.diameter);
+
+        if distance >= threshold {
+            return false;
+        }
+
+        PlaneSector::new(self.center(), self.angle_start, self.angle_sweep).contains(&point)
+    }
+}
+
+impl Dimensions for Sector {
+    fn bounding_box(&self) -> Rectangle {
+        Rectangle::new(self.top_left, Size::new_equal(self.diameter))
+    }
+}
+
+impl Transform for Sector {
+    /// Translate the sector from its current position to a new position by (x, y) pixels,
+    /// returning a new `Sector`. For a mutating transform, see `translate_mut`.
+    ///
+    /// ```
+    /// # use embedded_graphics::primitives::Sector;
+    /// # use embedded_graphics::prelude::*;
+    /// let sector = Sector::new(Point::new(5, 10), 10, 0.0.deg(), 90.0.deg());
+    /// let moved = sector.translate(Point::new(10, 10));
+    ///
+    /// assert_eq!(moved.top_left, Point::new(15, 20));
+    /// ```
+    fn translate(&self, by: Point) -> Self {
+        Self {
+            top_left: self.top_left + by,
+            ..*self
+        }
+    }
+
+    /// Translate the sector from its current position to a new position by (x, y) pixels.
+    ///
+    /// ```
+    /// # use embedded_graphics::primitives::Sector;
+    /// # use embedded_graphics::prelude::*;
+    /// let mut sector = Sector::new(Point::new(5, 10), 10, 0.0.deg(), 90.0.deg());
+    /// sector.translate_mut(Point::new(10, 10));
+    ///
+    /// assert_eq!(sector.top_left, Point::new(15, 20));
+    /// ```
+    fn translate_mut(&mut self, by: Point) -> &mut Self {
+        self.top_left += by;
+
+        self
+    }
+}
+
+/// Iterator over all points inside the sector.
+#[derive(Copy, Clone, PartialEq, PartialOrd, Debug)]
+pub struct Points {
+    iter: DistanceIterator<PlaneSectorIterator>,
+    threshold: u32,
+}
+
+impl Points {
+    fn new(sector: &Sector) -> Self {
+        let threshold = circle::diameter_to_threshold(sector.diameter);
+
+        Self {
+            iter: DistanceIterator::new(
+                sector.center_2x(),
+                PlaneSectorIterator::new(
+                    sector,
+                    sector.center(),
+                    sector.angle_start,
+                    sector.angle_sweep,
+                ),
+            ),
+            threshold,
+        }
+    }
+}
+
+impl Iterator for Points {
+    type Item = Point;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let threshold = self.threshold;
+        self.iter
+            .find(|(_, distance)| *distance < threshold)
+            .map(|(point, _)| point)
+    }
+}
+
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+enum IterState {
+    Arc,
+    Lines,
+    Done,
+}
+
+/// Pixel iterator for each pixel in the sector border
+#[derive(Copy, Clone, PartialEq, PartialOrd, Debug)]
+pub struct StyledSectorIterator<C>
+where
+    C: PixelColor,
+{
+    iter: DistanceIterator<PlaneSectorIterator>,
+
+    outer_threshold: u32,
+    outer_color: Option<C>,
+
+    inner_threshold: u32,
+    inner_color: Option<C>,
+
+    line_a_iter: ThickPoints,
+    line_b_iter: ThickPoints,
+
+    state: IterState,
+}
+
+impl<C> StyledSectorIterator<C>
+where
+    C: PixelColor,
+{
+    fn new(styled: &Styled<Sector, PrimitiveStyle<C>>) -> Self {
+        let Styled { primitive, style } = styled;
+
+        let stroke_area = primitive.expand(style.outside_stroke_width());
+        let fill_area = primitive.shrink(style.inside_stroke_width());
+
+        let inner_threshold = circle::diameter_to_threshold(fill_area.diameter);
+        let outer_threshold = circle::diameter_to_threshold(stroke_area.diameter);
+
+        let line_a = stroke_area.line_from_angle(styled.primitive.angle_start);
+        let line_b = stroke_area.line_from_angle(styled.primitive.angle_end());
+
+        let line_a_iter = ThickPoints::new(&line_a, styled.style.stroke_width_i32());
+        let line_b_iter = ThickPoints::new(&line_b, styled.style.stroke_width_i32());
+
+        let iter = if !styled.style.is_transparent() {
+            DistanceIterator::new(
+                stroke_area.center_2x(),
+                PlaneSectorIterator::new(
+                    &stroke_area,
+                    stroke_area.center(),
+                    stroke_area.angle_start,
+                    stroke_area.angle_sweep,
+                ),
+            )
+        } else {
+            DistanceIterator::new(Point::zero(), PlaneSectorIterator::empty())
+        };
+
+        Self {
+            iter,
+            outer_threshold,
+            outer_color: styled.style.stroke_color,
+            inner_threshold,
+            inner_color: styled.style.fill_color,
+            line_a_iter,
+            line_b_iter,
+            state: IterState::Arc,
+        }
+    }
+}
+
+impl<C> Iterator for StyledSectorIterator<C>
+where
+    C: PixelColor,
+{
+    type Item = Pixel<C>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            match self.state {
+                IterState::Arc => {
+                    if let Some((point, distance)) = self.iter.next() {
+                        let color = if distance < self.inner_threshold {
+                            self.inner_color
+                        } else if distance < self.outer_threshold {
+                            self.outer_color
+                        } else {
+                            None
+                        };
+
+                        if let Some(color) = color {
+                            return Some(Pixel(point, color));
+                        }
+                    } else {
+                        self.state = IterState::Lines;
+                    }
+                }
+                IterState::Lines => {
+                    if let Some(color) = self.outer_color {
+                        if let Some(point) =
+                            self.line_a_iter.next().or_else(|| self.line_b_iter.next())
+                        {
+                            break Some(Pixel(point, color));
+                        }
+                    }
+                    self.state = IterState::Done;
+                }
+                IterState::Done => {
+                    break None;
+                }
+            }
+        }
+    }
+}
+
+impl<'a, C: 'a> Drawable<C> for &Styled<Sector, PrimitiveStyle<C>>
+where
+    C: PixelColor,
+{
+    fn draw<D: DrawTarget<Color = C>>(self, display: &mut D) -> Result<(), D::Error> {
+        display.draw_iter(self)
+    }
+}
+
+impl<'a, C> IntoIterator for &'a Styled<Sector, PrimitiveStyle<C>>
+where
+    C: PixelColor,
+{
+    type Item = Pixel<C>;
+    type IntoIter = StyledSectorIterator<C>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        StyledSectorIterator::new(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        geometry::AngleUnit,
+        mock_display::MockDisplay,
+        pixelcolor::BinaryColor,
+        style::{PrimitiveStyleBuilder, StrokeAlignment},
+    };
+
+    #[test]
+    fn stroke_width_doesnt_affect_fill() -> Result<(), core::convert::Infallible> {
+        let mut expected = MockDisplay::new();
+        let mut style = PrimitiveStyle::with_fill(BinaryColor::On);
+        Sector::new(Point::new(5, 5), 4, 30.0.deg(), 120.0.deg())
+            .into_styled(style)
+            .draw(&mut expected)?;
+
+        let mut with_stroke_width = MockDisplay::new();
+        style.stroke_width = 1;
+        Sector::new(Point::new(5, 5), 4, 30.0.deg(), 120.0.deg())
+            .into_styled(style)
+            .draw(&mut with_stroke_width)?;
+
+        assert_eq!(expected, with_stroke_width);
+
+        Ok(())
+    }
+
+    // Check the rendering of a simple sector
+    #[test]
+    fn tiny_sector() -> Result<(), core::convert::Infallible> {
+        let mut display = MockDisplay::new();
+        display.set_allow_overdraw(true);
+
+        Sector::new(Point::zero(), 9, 30.0.deg(), 120.0.deg())
+            .into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 1))
+            .draw(&mut display)?;
+
+        #[rustfmt::skip]
+        assert_eq!(
+            display,
+            MockDisplay::from_pattern(&[
+                "  #####  ",
+                " ##   ## ",
+                " #     # ",
+                "  ## ##  ",
+                "    #    ",
+            ])
+        );
+
+        Ok(())
+    }
+
+    // Check the rendering of a filled sector with negative sweep
+    #[test]
+    fn tiny_sector_filled() -> Result<(), core::convert::Infallible> {
+        let mut display = MockDisplay::new();
+
+        Sector::new(Point::zero(), 7, -30.0.deg(), -300.0.deg())
+            .into_styled(PrimitiveStyle::with_fill(BinaryColor::On))
+            .draw(&mut display)?;
+
+        #[rustfmt::skip]
+        assert_eq!(
+            display,
+            MockDisplay::from_pattern(&[
+                "  ###  ",
+                " ##### ",
+                "#####  ",
+                "####   ",
+                "#####  ",
+                " ##### ",
+                "  ###  ",
+            ])
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn negative_dimensions() {
+        let sector = Sector::new(Point::new(-15, -15), 10, 0.0.deg(), 90.0.deg());
+
+        assert_eq!(
+            sector.bounding_box(),
+            Rectangle::new(Point::new(-15, -15), Size::new(10, 10))
+        );
+    }
+
+    #[test]
+    fn dimensions() {
+        let sector = Sector::new(Point::new(5, 15), 10, 0.0.deg(), 90.0.deg());
+
+        assert_eq!(
+            sector.bounding_box(),
+            Rectangle::new(Point::new(5, 15), Size::new(10, 10))
+        );
+    }
+
+    #[test]
+    fn transparent_border() {
+        let sector: Styled<Sector, PrimitiveStyle<BinaryColor>> =
+            Sector::new(Point::new(-5, -5), 21, 0.0.deg(), 90.0.deg())
+                .into_styled(PrimitiveStyle::with_fill(BinaryColor::On));
+
+        assert!(sector.into_iter().count() > 0);
+    }
+
+    #[test]
+    fn it_handles_negative_coordinates() {
+        let positive = Sector::new(Point::new(10, 10), 5, 0.0.deg(), 90.0.deg())
+            .into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 1))
+            .into_iter();
+
+        let negative = Sector::new(Point::new(-10, -10), 5, 0.0.deg(), 90.0.deg())
+            .into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 1))
+            .into_iter();
+
+        assert!(negative.into_iter().eq(positive
+            .into_iter()
+            .map(|Pixel(p, c)| Pixel(p - Point::new(20, 20), c))));
+    }
+
+    #[test]
+    fn center_is_correct() {
+        // odd diameter
+        let sector = Sector::new(Point::new(10, 10), 5, 0.0.deg(), 90.0.deg());
+        assert_eq!(sector.center(), Point::new(12, 12));
+
+        // even diameter
+        let sector = Sector::new(Point::new(10, 10), 6, 0.0.deg(), 90.0.deg());
+        assert_eq!(sector.center(), Point::new(12, 12));
+
+        // odd diameter
+        let sector = Sector::with_center(Point::new(10, 10), 5, 0.0.deg(), 90.0.deg());
+        assert_eq!(sector.center(), Point::new(10, 10));
+
+        // even diameter
+        let sector = Sector::with_center(Point::new(10, 10), 6, 0.0.deg(), 90.0.deg());
+        assert_eq!(sector.center(), Point::new(10, 10));
+    }
+
+    #[test]
+    fn points_iter() {
+        let sector = Sector::with_center(Point::new(10, 10), 5, 0.0.deg(), 90.0.deg());
+
+        let styled_points = sector
+            .clone()
+            .into_styled(PrimitiveStyle::with_fill(BinaryColor::On))
+            .into_iter()
+            .map(|Pixel(p, _)| p);
+
+        assert!(sector.points().eq(styled_points));
+    }
+
+    #[test]
+    fn plane_sector_iter() {
+        let sector = Sector::new(Point::zero(), 3, 0.0.deg(), 90.0.deg());
+
+        let mut iter = PlaneSectorIterator::new(
+            &sector,
+            sector.center(),
+            sector.angle_start,
+            sector.angle_sweep,
+        );
+        assert_eq!(iter.next(), Some(Point::new(1, 0)));
+        assert_eq!(iter.next(), Some(Point::new(2, 0)));
+        assert_eq!(iter.next(), Some(Point::new(1, 1)));
+        assert_eq!(iter.next(), Some(Point::new(2, 1)));
+        assert_eq!(iter.next(), None);
+    }
+
+    #[test]
+    fn plane_sector_iter_empty() {
+        let mut iter = PlaneSectorIterator::empty();
+        assert_eq!(iter.next(), None);
+    }
+
+    #[test]
+    fn distance_iter() {
+        let sector = Sector::new(Point::zero(), 3, 0.0.deg(), 90.0.deg());
+
+        let mut iter = DistanceIterator::new(
+            sector.center_2x(),
+            PlaneSectorIterator::new(
+                &sector,
+                sector.center(),
+                sector.angle_start,
+                sector.angle_sweep,
+            ),
+        );
+        assert_eq!(iter.next(), Some((Point::new(1, 0), 4)));
+        assert_eq!(iter.next(), Some((Point::new(2, 0), 8)));
+        assert_eq!(iter.next(), Some((Point::new(1, 1), 0)));
+        assert_eq!(iter.next(), Some((Point::new(2, 1), 4)));
+        assert_eq!(iter.next(), None);
+    }
+
+    #[test]
+    fn distance_iter_empty() {
+        let mut iter = DistanceIterator::new(Point::zero(), PlaneSectorIterator::empty());
+        assert_eq!(iter.next(), None);
+    }
+
+    #[test]
+    fn contains() {
+        let sector = Sector::new(Point::zero(), 10, 0.0.deg(), 90.0.deg());
+
+        let contained_points = Rectangle::new(Point::new(-10, -10), Size::new(30, 30))
+            .points()
+            .filter(|p| sector.contains(*p));
+
+        assert!(contained_points.eq(sector.points()));
+    }
+
+    #[test]
+    fn stroke_alignment() {
+        const CENTER: Point = Point::new(15, 15);
+        const SIZE: u32 = 10;
+
+        let style = PrimitiveStyle::with_stroke(BinaryColor::On, 3);
+
+        let mut display_center = MockDisplay::new();
+        display_center.set_allow_overdraw(true);
+        Sector::with_center(CENTER, SIZE, 0.0.deg(), 90.0.deg())
+            .into_styled(style)
+            .draw(&mut display_center)
+            .unwrap();
+
+        let mut display_inside = MockDisplay::new();
+        display_inside.set_allow_overdraw(true);
+        Sector::with_center(CENTER, SIZE + 2, 0.0.deg(), 90.0.deg())
+            .into_styled(
+                PrimitiveStyleBuilder::from(&style)
+                    .stroke_alignment(StrokeAlignment::Inside)
+                    .build(),
+            )
+            .draw(&mut display_inside)
+            .unwrap();
+
+        let mut display_outside = MockDisplay::new();
+        display_outside.set_allow_overdraw(true);
+        Sector::with_center(CENTER, SIZE - 4, 0.0.deg(), 90.0.deg())
+            .into_styled(
+                PrimitiveStyleBuilder::from(&style)
+                    .stroke_alignment(StrokeAlignment::Outside)
+                    .build(),
+            )
+            .draw(&mut display_outside)
+            .unwrap();
+
+        assert_eq!(display_center, display_inside);
+        assert_eq!(display_center, display_outside);
+    }
+}

--- a/simulator/Cargo.toml
+++ b/simulator/Cargo.toml
@@ -25,6 +25,10 @@ harness = false
 name = "primitives"
 [[bench]]
 harness = false
+name = "primitives_fixed_point"
+required-features = ["fixed_point"]
+[[bench]]
+harness = false
 name = "fonts"
 [[bench]]
 harness = false
@@ -50,4 +54,5 @@ tinybmp = { version = "0.2.2", features = [ "graphics" ] }
 
 [features]
 default = [ "with-sdl" ]
+fixed_point = [ "embedded-graphics/fixed_point" ]
 with-sdl = [ "sdl2" ]

--- a/simulator/benches/primitives.rs
+++ b/simulator/benches/primitives.rs
@@ -106,6 +106,33 @@ fn filled_ellipse(c: &mut Criterion) {
     });
 }
 
+fn arc(c: &mut Criterion) {
+    c.bench_function("arc", |b| {
+        let object = &Arc::new(Point::new(100, 100), 100, -30.0.deg(), 150.0.deg())
+            .into_styled(PrimitiveStyle::with_stroke(Gray8::new(1), 1));
+
+        b.iter(|| object.into_iter().collect::<Vec<Pixel<Gray8>>>())
+    });
+}
+
+fn sector(c: &mut Criterion) {
+    c.bench_function("sector", |b| {
+        let object = &Sector::new(Point::new(100, 100), 100, -30.0.deg(), 150.0.deg())
+            .into_styled(PrimitiveStyle::with_stroke(Gray8::new(1), 1));
+
+        b.iter(|| object.into_iter().collect::<Vec<Pixel<Gray8>>>())
+    });
+}
+
+fn filled_sector(c: &mut Criterion) {
+    c.bench_function("filled_sector", |b| {
+        let object = &Sector::new(Point::new(100, 100), 100, -30.0.deg(), 150.0.deg())
+            .into_styled(PrimitiveStyle::with_fill(Gray8::new(1)));
+
+        b.iter(|| object.into_iter().collect::<Vec<Pixel<Gray8>>>())
+    });
+}
+
 fn polyline(c: &mut Criterion) {
     c.bench_function("polyline", |b| {
         let points = [
@@ -178,6 +205,9 @@ criterion_group!(
     filled_ellipse,
     polyline,
     rounded_rectangle,
-    rounded_rectangle_corners
+    rounded_rectangle_corners,
+    arc,
+    sector,
+    filled_sector
 );
 criterion_main!(primitives);

--- a/simulator/benches/primitives_fixed_point.rs
+++ b/simulator/benches/primitives_fixed_point.rs
@@ -1,0 +1,38 @@
+use criterion::*;
+use embedded_graphics::{
+    drawable::Pixel,
+    geometry::{AngleUnit, Point},
+    pixelcolor::Gray8,
+    primitives::*,
+    style::PrimitiveStyle,
+};
+
+fn arc(c: &mut Criterion) {
+    c.bench_function("arc", |b| {
+        let object = &Arc::new(Point::new(100, 100), 100, -30.0.deg(), 150.0.deg())
+            .into_styled(PrimitiveStyle::with_stroke(Gray8::new(1), 1));
+
+        b.iter(|| object.into_iter().collect::<Vec<Pixel<Gray8>>>())
+    });
+}
+
+fn sector(c: &mut Criterion) {
+    c.bench_function("sector", |b| {
+        let object = &Sector::new(Point::new(100, 100), 100, -30.0.deg(), 150.0.deg())
+            .into_styled(PrimitiveStyle::with_stroke(Gray8::new(1), 1));
+
+        b.iter(|| object.into_iter().collect::<Vec<Pixel<Gray8>>>())
+    });
+}
+
+fn filled_sector(c: &mut Criterion) {
+    c.bench_function("filled_sector", |b| {
+        let object = &Sector::new(Point::new(100, 100), 100, -30.0.deg(), 150.0.deg())
+            .into_styled(PrimitiveStyle::with_fill(Gray8::new(1)));
+
+        b.iter(|| object.into_iter().collect::<Vec<Pixel<Gray8>>>())
+    });
+}
+
+criterion_group!(primitives_fixed_point, arc, sector, filled_sector);
+criterion_main!(primitives_fixed_point);

--- a/simulator/examples/pacman.rs
+++ b/simulator/examples/pacman.rs
@@ -1,0 +1,68 @@
+//! # Example: Pacman
+//!
+//! An example displaying an animated Pacman.
+
+use embedded_graphics::{
+    pixelcolor::Rgb565, prelude::*, primitives::Circle, primitives::Sector,
+    style::PrimitiveStyleBuilder,
+};
+use embedded_graphics_simulator::{
+    OutputSettingsBuilder, SimulatorDisplay, SimulatorEvent, Window,
+};
+use std::{thread, time::Duration};
+
+// the number of steps of the animation
+const STEPS: i32 = 10;
+
+fn main() -> Result<(), std::convert::Infallible> {
+    // Create a new simulator display with 65x65 pixels.
+    let mut display: SimulatorDisplay<Rgb565> = SimulatorDisplay::new(Size::new(65, 65));
+
+    // Create styles used by the drawing operations.
+    let sector_style = PrimitiveStyleBuilder::new()
+        .stroke_color(Rgb565::BLACK)
+        .stroke_width(2)
+        .fill_color(Rgb565::YELLOW)
+        .build();
+    let eye_style = PrimitiveStyleBuilder::new()
+        .stroke_color(Rgb565::BLACK)
+        .stroke_width(1)
+        .fill_color(Rgb565::BLACK)
+        .build();
+
+    let output_settings = OutputSettingsBuilder::new().scale(4).build();
+    let mut window = Window::new("Pacman", &output_settings);
+
+    // The current progress of the animation
+    let mut progress: i32 = 0;
+
+    'running: loop {
+        display.clear(Rgb565::WHITE)?;
+
+        let p = (progress - STEPS).abs();
+
+        // Draw a Sector as the main Pacman feature.
+        Sector::new(
+            Point::new(2, 2),
+            61,
+            Angle::from_degrees((p * 30 / STEPS) as f32),
+            Angle::from_degrees((360 - 2 * p * 30 / STEPS) as f32),
+        )
+        .into_styled(sector_style)
+        .draw(&mut display)?;
+
+        // Draw a Circle as the eye.
+        Circle::new(Point::new(36, 16), 5)
+            .into_styled(eye_style)
+            .draw(&mut display)?;
+
+        window.update(&display);
+
+        if window.events().any(|e| e == SimulatorEvent::Quit) {
+            break 'running Ok(());
+        }
+        thread::sleep(Duration::from_millis(50));
+
+        progress = (progress + 1) % (2 * STEPS + 1);
+    }
+}

--- a/simulator/examples/progress.rs
+++ b/simulator/examples/progress.rs
@@ -1,0 +1,63 @@
+//! # Example: Progress
+//!
+//! An example displaying a progress circle.
+
+use embedded_graphics::{
+    fonts::{Font12x16, Text},
+    pixelcolor::BinaryColor,
+    prelude::*,
+    primitives::Arc,
+    style::{PrimitiveStyleBuilder, StrokeAlignment, TextStyle},
+};
+use embedded_graphics_simulator::{
+    BinaryColorTheme, OutputSettingsBuilder, SimulatorDisplay, SimulatorEvent, Window,
+};
+use std::{thread, time::Duration};
+
+fn main() -> Result<(), std::convert::Infallible> {
+    // Create a new simulator display with 64x64 pixels.
+    let mut display: SimulatorDisplay<BinaryColor> = SimulatorDisplay::new(Size::new(64, 64));
+
+    // Create styles used by the drawing operations.
+    let arc_stroke = PrimitiveStyleBuilder::new()
+        .stroke_color(BinaryColor::On)
+        .stroke_width(5)
+        .stroke_alignment(StrokeAlignment::Inside)
+        .build();
+    let text_style = TextStyle::new(Font12x16, BinaryColor::On);
+
+    let output_settings = OutputSettingsBuilder::new()
+        .theme(BinaryColorTheme::OledBlue)
+        .build();
+    let mut window = Window::new("Progress", &output_settings);
+
+    // The current progress percentage
+    let mut progress = 0;
+
+    'running: loop {
+        display.clear(BinaryColor::Off)?;
+
+        let sweep = progress as f32 * 360.0 / 100.0;
+
+        // Draw an arc with a 5px wide stroke.
+        Arc::new(Point::new(2, 2), 64 - 4, 90.0.deg(), sweep.deg())
+            .into_styled(arc_stroke)
+            .draw(&mut display)?;
+
+        // Draw centered text.
+        let text = format!("{}%", progress);
+        let width = text.len() as i32 * 12;
+        Text::new(&text, Point::new(32 - width / 2, 32 - 16 / 2))
+            .into_styled(text_style)
+            .draw(&mut display)?;
+
+        window.update(&display);
+
+        if window.events().any(|e| e == SimulatorEvent::Quit) {
+            break 'running Ok(());
+        }
+        thread::sleep(Duration::from_millis(50));
+
+        progress = (progress + 1) % 101;
+    }
+}

--- a/tinytga/src/lib.rs
+++ b/tinytga/src/lib.rs
@@ -289,7 +289,7 @@ impl<'a> Iterator for TgaIterator<'a> {
 
         self.x += 1;
 
-        if self.x >= self.tga.width().into() {
+        if self.x >= u32::from(self.tga.width()) {
             self.x = 0;
             self.y += 1;
         }

--- a/tinytga/src/packet/raw_packet.rs
+++ b/tinytga/src/packet/raw_packet.rs
@@ -61,7 +61,7 @@ mod tests {
 
         let (remaining, packet) = raw_packet(4)(&input).unwrap();
 
-        assert_eq!(remaining, &[]);
+        assert_eq!(remaining.len(), 0);
         assert_eq!(
             packet,
             RawPacket {

--- a/tinytga/src/packet/rle_packet.rs
+++ b/tinytga/src/packet/rle_packet.rs
@@ -56,7 +56,7 @@ mod tests {
 
         let (remaining, packet) = rle_packet(4)(&input).unwrap();
 
-        assert_eq!(remaining, &[]);
+        assert_eq!(remaining.len(), 0);
         assert_eq!(
             packet,
             RlePacket {


### PR DESCRIPTION
Hi! Thank you for helping out with Embedded Graphics development! Please:

- [x] Check that you've added passing tests and documentation
- [x] Add a simulator example(s) where applicable
- [x] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) and appropriate crate (`embedded-graphics`, `simulator`, `tinytga`, `tinybmp`) if your changes affect the **public API**
- [x] Run `rustfmt` on the project
- [x] Run `./build.sh` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

This is a first draft implementation of the Arc primitive.
For now it supports filled Arcs, but I plan to implement Sector and remove fill support from Arc, as described in #284. I think Arc and Sector will use a common `StyledIterator` but I'm not sure yet how to do this cleanly.
There is probably no need for a full detailed review right now, but I would like to know if this is overall going into the right direction.

Here are a few technical details of the current implementation:
- Angles are specified as integer degrees (this is plenty enough for me right now, and it shouldn't be very hard to add support for radiants)
- Center + Angles are converted to linear equation using `tan()`
- `tan()` is implemented with a LUT of `FixedPoint` values
- I introduced a basic implementation of `FixedPoint` numbers