### PR TITLE
Fix text-custom-font example name in a comment

### DIFF
--- a/embedded-graphics/src/fonts/mod.rs
+++ b/embedded-graphics/src/fonts/mod.rs
@@ -4,7 +4,7 @@
 //! several [built-in fonts].
 //!
 //! Additional custom fonts can be added by the application or other crates. This
-//! is demonstrated in the `custom-font` example in the simulator crate.
+//! is demonstrated in the `text-custom-font` example in the simulator crate.
 //!
 //! # Examples
 //!


### PR DESCRIPTION
Hi! Thank you for helping out with Embedded Graphics development! Please:

- [ ] Check that you've added passing tests and documentation
- [ ] Add a simulator example(s) where applicable
- [ ] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) and appropriate crate (`embedded-graphics`, `simulator`, `tinytga`, `tinybmp`) if your changes affect the **public API**
- [X] Run `rustfmt` on the project
- [X] Run `./build.sh` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

Fix text-custom-font example name in a comment
