### PR TITLE
Use Rectangle for Dimensions trait

### DIFF
--- a/embedded-graphics/CHANGELOG.md
+++ b/embedded-graphics/CHANGELOG.md
@@ -14,6 +14,7 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 
 - **(breaking)** [#274](https://github.com/jamwaffles/embedded-graphics/pull/274) The `Circle` is now defined by its bounding box top-left corner and its diameter instead of its center and its radius. To convert your code, you can replace `Circle::new(point, radius)` by `Circle::with_center(point, 2 * radius + 1)`.
 - **(breaking)** [#306](https://github.com/jamwaffles/embedded-graphics/pull/306) The `Rectangle` is now defined by its top-left corner and its size instead of the top-left and bottom-right corner. To convert your code, you can replace `Rectangle::new` by `Rectangle::with_corners`.
+- **(breaking)** [#312](https://github.com/jamwaffles/embedded-graphics/pull/312) The methods in the `Dimension` trait are replaced by a single `bounding_box` method that returns a `Rectangle`.
 
 ### Fixed
 

--- a/embedded-graphics/src/fonts/font12x16.rs
+++ b/embedded-graphics/src/fonts/font12x16.rs
@@ -41,6 +41,7 @@ mod tests {
         geometry::{Dimensions, Point, Size},
         mock_display::MockDisplay,
         pixelcolor::BinaryColor,
+        primitives::Rectangle,
         style::TextStyle,
         transform::Transform,
     };
@@ -56,10 +57,10 @@ mod tests {
         let empty = Text::new("", Point::zero()).into_styled(style);
 
         assert_eq!(
-            hello.size(),
+            hello.bounding_box().size,
             Size::new((HELLO_WORLD.len() * WIDTH) as u32, HEIGHT as u32)
         );
-        assert_eq!(empty.size(), Size::new(0, 0));
+        assert_eq!(empty.bounding_box().size, Size::zero());
     }
 
     #[test]
@@ -72,16 +73,17 @@ mod tests {
             .into_styled(style)
             .translate(Point::new(10, 20));
 
-        assert_eq!(hello.top_left(), Point::new(5, -20));
         assert_eq!(
-            hello.bottom_right(),
-            Point::new(
-                ((HELLO_WORLD.len() * WIDTH) as i32) + 5,
-                (HEIGHT as i32) - 20
+            hello.bounding_box(),
+            Rectangle::new(
+                Point::new(5, -20),
+                Size::new((HELLO_WORLD.len() * WIDTH) as u32, HEIGHT as u32)
             )
         );
-        assert_eq!(empty.top_left(), Point::new(10, 20));
-        assert_eq!(empty.bottom_right(), Point::new(10, 20));
+        assert_eq!(
+            empty.bounding_box(),
+            Rectangle::new(Point::new(10, 20), Size::zero())
+        );
     }
 
     #[test]

--- a/embedded-graphics/src/fonts/font24x32.rs
+++ b/embedded-graphics/src/fonts/font24x32.rs
@@ -46,6 +46,7 @@ mod tests {
         geometry::{Dimensions, Point, Size},
         mock_display::MockDisplay,
         pixelcolor::BinaryColor,
+        primitives::Rectangle,
         style::TextStyle,
         transform::Transform,
     };
@@ -61,10 +62,10 @@ mod tests {
         let empty = Text::new("", Point::zero()).into_styled(style);
 
         assert_eq!(
-            hello.size(),
+            hello.bounding_box().size,
             Size::new((HELLO_WORLD.len() * WIDTH) as u32, HEIGHT as u32)
         );
-        assert_eq!(empty.size(), Size::new(0, 0));
+        assert_eq!(empty.bounding_box().size, Size::zero());
     }
 
     #[test]
@@ -77,16 +78,17 @@ mod tests {
             .into_styled(style)
             .translate(Point::new(10, 20));
 
-        assert_eq!(hello.top_left(), Point::new(5, -20));
         assert_eq!(
-            hello.bottom_right(),
-            Point::new(
-                ((HELLO_WORLD.len() * WIDTH) as i32) + 5,
-                (HEIGHT as i32) - 20
+            hello.bounding_box(),
+            Rectangle::new(
+                Point::new(5, -20),
+                Size::new((HELLO_WORLD.len() * WIDTH) as u32, HEIGHT as u32)
             )
         );
-        assert_eq!(empty.top_left(), Point::new(10, 20));
-        assert_eq!(empty.bottom_right(), Point::new(10, 20));
+        assert_eq!(
+            empty.bounding_box(),
+            Rectangle::new(Point::new(10, 20), Size::zero())
+        );
     }
 
     #[test]

--- a/embedded-graphics/src/fonts/font6x12.rs
+++ b/embedded-graphics/src/fonts/font6x12.rs
@@ -37,6 +37,7 @@ mod tests {
         geometry::{Dimensions, Point, Size},
         mock_display::MockDisplay,
         pixelcolor::BinaryColor,
+        primitives::Rectangle,
         style::TextStyle,
         transform::Transform,
     };
@@ -52,10 +53,10 @@ mod tests {
         let empty = Text::new("", Point::zero()).into_styled(style);
 
         assert_eq!(
-            hello.size(),
+            hello.bounding_box().size,
             Size::new((HELLO_WORLD.len() * WIDTH) as u32, HEIGHT as u32)
         );
-        assert_eq!(empty.size(), Size::new(0, 0));
+        assert_eq!(empty.bounding_box().size, Size::zero());
     }
 
     #[test]
@@ -68,16 +69,17 @@ mod tests {
             .into_styled(style)
             .translate(Point::new(10, 20));
 
-        assert_eq!(hello.top_left(), Point::new(5, -20));
         assert_eq!(
-            hello.bottom_right(),
-            Point::new(
-                ((HELLO_WORLD.len() * WIDTH) as i32) + 5,
-                (HEIGHT as i32) - 20
+            hello.bounding_box(),
+            Rectangle::new(
+                Point::new(5, -20),
+                Size::new((HELLO_WORLD.len() * WIDTH) as u32, HEIGHT as u32)
             )
         );
-        assert_eq!(empty.top_left(), Point::new(10, 20));
-        assert_eq!(empty.bottom_right(), Point::new(10, 20));
+        assert_eq!(
+            empty.bounding_box(),
+            Rectangle::new(Point::new(10, 20), Size::zero())
+        );
     }
 
     #[test]

--- a/embedded-graphics/src/fonts/font6x6.rs
+++ b/embedded-graphics/src/fonts/font6x6.rs
@@ -45,6 +45,7 @@ mod tests {
         geometry::{Dimensions, Point, Size},
         mock_display::MockDisplay,
         pixelcolor::BinaryColor,
+        primitives::Rectangle,
         style::TextStyle,
         transform::Transform,
     };
@@ -59,8 +60,11 @@ mod tests {
         let hello = Text::new(HELLO_WORLD, Point::zero()).into_styled(style);
         let empty = Text::new("", Point::zero()).into_styled(style);
 
-        assert_eq!(hello.size(), Size::new(HELLO_WORLD_WIDTH, HEIGHT as u32));
-        assert_eq!(empty.size(), Size::new(0, 0));
+        assert_eq!(
+            hello.bounding_box().size,
+            Size::new(HELLO_WORLD_WIDTH, HEIGHT as u32)
+        );
+        assert_eq!(empty.bounding_box().size, Size::zero());
     }
 
     #[test]
@@ -73,13 +77,17 @@ mod tests {
             .into_styled(style)
             .translate(Point::new(10, 20));
 
-        assert_eq!(hello.top_left(), Point::new(5, -20));
         assert_eq!(
-            hello.bottom_right(),
-            Point::new((HELLO_WORLD_WIDTH as i32) + 5, (HEIGHT as i32) - 20)
+            hello.bounding_box(),
+            Rectangle::new(
+                Point::new(5, -20),
+                Size::new(HELLO_WORLD_WIDTH, HEIGHT as u32)
+            )
         );
-        assert_eq!(empty.top_left(), Point::new(10, 20));
-        assert_eq!(empty.bottom_right(), Point::new(10, 20));
+        assert_eq!(
+            empty.bounding_box(),
+            Rectangle::new(Point::new(10, 20), Size::zero())
+        );
     }
 
     #[test]

--- a/embedded-graphics/src/fonts/font6x8.rs
+++ b/embedded-graphics/src/fonts/font6x8.rs
@@ -40,6 +40,7 @@ mod tests {
         geometry::{Dimensions, Point, Size},
         mock_display::MockDisplay,
         pixelcolor::BinaryColor,
+        primitives::Rectangle,
         style::TextStyle,
         transform::Transform,
     };
@@ -55,10 +56,10 @@ mod tests {
         let empty = Text::new("", Point::zero()).into_styled(style);
 
         assert_eq!(
-            hello.size(),
+            hello.bounding_box().size,
             Size::new((HELLO_WORLD.len() * WIDTH) as u32, HEIGHT as u32)
         );
-        assert_eq!(empty.size(), Size::new(0, 0));
+        assert_eq!(empty.bounding_box().size, Size::zero());
     }
 
     #[test]
@@ -71,16 +72,17 @@ mod tests {
             .into_styled(style)
             .translate(Point::new(10, 20));
 
-        assert_eq!(hello.top_left(), Point::new(5, -20));
         assert_eq!(
-            hello.bottom_right(),
-            Point::new(
-                ((HELLO_WORLD.len() * WIDTH) as i32) + 5,
-                (HEIGHT as i32) - 20
+            hello.bounding_box(),
+            Rectangle::new(
+                Point::new(5, -20),
+                Size::new((HELLO_WORLD.len() * WIDTH) as u32, HEIGHT as u32)
             )
         );
-        assert_eq!(empty.top_left(), Point::new(10, 20));
-        assert_eq!(empty.bottom_right(), Point::new(10, 20));
+        assert_eq!(
+            empty.bounding_box(),
+            Rectangle::new(Point::new(10, 20), Size::zero())
+        );
     }
 
     #[test]

--- a/embedded-graphics/src/fonts/font8x16.rs
+++ b/embedded-graphics/src/fonts/font8x16.rs
@@ -40,6 +40,7 @@ mod tests {
         geometry::{Dimensions, Point, Size},
         mock_display::MockDisplay,
         pixelcolor::BinaryColor,
+        primitives::Rectangle,
         style::TextStyle,
         transform::Transform,
     };
@@ -55,10 +56,10 @@ mod tests {
         let empty = Text::new("", Point::zero()).into_styled(style);
 
         assert_eq!(
-            hello.size(),
+            hello.bounding_box().size,
             Size::new((HELLO_WORLD.len() * WIDTH) as u32, HEIGHT as u32)
         );
-        assert_eq!(empty.size(), Size::new(0, 0));
+        assert_eq!(empty.bounding_box().size, Size::zero());
     }
 
     #[test]
@@ -71,16 +72,17 @@ mod tests {
             .into_styled(style)
             .translate(Point::new(10, 20));
 
-        assert_eq!(hello.top_left(), Point::new(5, -20));
         assert_eq!(
-            hello.bottom_right(),
-            Point::new(
-                ((HELLO_WORLD.len() * WIDTH) as i32) + 5,
-                (HEIGHT as i32) - 20
+            hello.bounding_box(),
+            Rectangle::new(
+                Point::new(5, -20),
+                Size::new((HELLO_WORLD.len() * WIDTH) as u32, HEIGHT as u32)
             )
         );
-        assert_eq!(empty.top_left(), Point::new(10, 20));
-        assert_eq!(empty.bottom_right(), Point::new(10, 20));
+        assert_eq!(
+            empty.bounding_box(),
+            Rectangle::new(Point::new(10, 20), Size::zero())
+        );
     }
 
     #[test]

--- a/embedded-graphics/src/fonts/text.rs
+++ b/embedded-graphics/src/fonts/text.rs
@@ -3,6 +3,7 @@ use crate::{
     fonts::Font,
     geometry::{Dimensions, Point, Size},
     pixelcolor::PixelColor,
+    primitives::Rectangle,
     style::{Styled, TextStyle},
     transform::Transform,
     DrawTarget,
@@ -101,21 +102,7 @@ where
     C: PixelColor,
     F: Font,
 {
-    fn top_left(&self) -> Point {
-        self.primitive.position
-    }
-
-    fn bottom_right(&self) -> Point {
-        self.top_left() + self.size()
-    }
-
-    /// Returns the size of the bounding box of a styled text.
-    ///
-    /// Currently does not handle newlines (but neither does the rasteriser).
-    /// It will return [`Size::zero()`] if the string to render is empty.
-    ///
-    /// [`Size::zero()`]: ../geometry/struct.Size.html#method.zero
-    fn size(&self) -> Size {
+    fn bounding_box(&self) -> Rectangle {
         let width = if !self.primitive.text.is_empty() {
             self.primitive
                 .text
@@ -138,7 +125,9 @@ where
             0
         };
 
-        Size::new(width, height)
+        let size = Size::new(width, height);
+
+        Rectangle::new(self.primitive.position, size)
     }
 }
 
@@ -286,19 +275,22 @@ mod tests {
         assert_eq!(
             Text::new("#", Point::zero())
                 .into_styled(TextStyle::new(SpacedFont, BinaryColor::On))
-                .size(),
+                .bounding_box()
+                .size,
             Size::new(4, 4)
         );
         assert_eq!(
             Text::new("##", Point::zero())
                 .into_styled(TextStyle::new(SpacedFont, BinaryColor::On))
-                .size(),
+                .bounding_box()
+                .size,
             Size::new(4 * 2 + 5, 4)
         );
         assert_eq!(
             Text::new("###", Point::zero())
                 .into_styled(TextStyle::new(SpacedFont, BinaryColor::On))
-                .size(),
+                .bounding_box()
+                .size,
             Size::new(4 * 3 + 5 * 2, 4)
         );
 
@@ -338,7 +330,8 @@ mod tests {
         assert_eq!(
             Text::new("AB\nC", Point::zero())
                 .into_styled(TextStyle::new(Font6x8, BinaryColor::On))
-                .size(),
+                .bounding_box()
+                .size,
             Size::new(2 * 6, 2 * 8)
         );
 

--- a/embedded-graphics/src/geometry/mod.rs
+++ b/embedded-graphics/src/geometry/mod.rs
@@ -6,18 +6,14 @@ mod size;
 pub use point::Point;
 pub use size::Size;
 
+use crate::primitives::Rectangle;
+
 /// Adds the ability to get the dimensions/position of a graphics object
 ///
 /// This **should** be implemented for all builtin embedded-graphics primitives and fonts. Third party
 /// implementations do not have to implement this trait as an object may not have a known size. If
 /// the object _does_ have a known size, this trait **should** be implemented.
 pub trait Dimensions {
-    /// Get the top left corner of the bounding box for an object
-    fn top_left(&self) -> Point;
-
-    /// Get the bottom right corner of the bounding box for an object
-    fn bottom_right(&self) -> Point;
-
-    /// Get the width and height for an object
-    fn size(&self) -> Size;
+    /// Returns the bounding box.
+    fn bounding_box(&self) -> Rectangle;
 }

--- a/embedded-graphics/src/image/image_raw.rs
+++ b/embedded-graphics/src/image/image_raw.rs
@@ -247,6 +247,7 @@ mod tests {
         geometry::Dimensions,
         image::Image,
         pixelcolor::{raw::RawU32, *},
+        primitives::Rectangle,
         transform::Transform,
     };
 
@@ -278,9 +279,10 @@ mod tests {
 
         let image = Image::new(&image, Point::zero()).translate(Point::new(-1, -1));
 
-        assert_eq!(image.top_left(), Point::new(-1, -1));
-        assert_eq!(image.bottom_right(), Point::new(3, 3));
-        assert_eq!(image.size(), Size::new(4, 4));
+        assert_eq!(
+            image.bounding_box(),
+            Rectangle::new(Point::new(-1, -1), Size::new(4, 4))
+        );
     }
 
     #[test]
@@ -289,9 +291,10 @@ mod tests {
 
         let image = Image::new(&image, Point::zero()).translate(Point::new(100, 200));
 
-        assert_eq!(image.top_left(), Point::new(100, 200));
-        assert_eq!(image.bottom_right(), Point::new(104, 204));
-        assert_eq!(image.size(), Size::new(4, 4));
+        assert_eq!(
+            image.bounding_box(),
+            Rectangle::new(Point::new(100, 200), Size::new(4, 4))
+        );
     }
 
     #[test]

--- a/embedded-graphics/src/image/mod.rs
+++ b/embedded-graphics/src/image/mod.rs
@@ -47,6 +47,7 @@ use crate::{
     drawable::{Drawable, Pixel},
     geometry::{Dimensions, Point, Size},
     pixelcolor::PixelColor,
+    primitives::Rectangle,
     transform::Transform,
 };
 use core::fmt::Debug;
@@ -142,8 +143,8 @@ impl<I, C> Transform for Image<'_, I, C> {
     ///
     /// let image_moved = image.translate(Point::new(10, 20));
     ///
-    /// assert_eq!(image.top_left(), Point::zero());
-    /// assert_eq!(image_moved.top_left(), Point::new(10, 20));
+    /// assert_eq!(image.bounding_box().top_left, Point::zero());
+    /// assert_eq!(image_moved.bounding_box().top_left, Point::new(10, 20));
     /// ```
     fn translate(&self, by: Point) -> Self {
         Self {
@@ -176,7 +177,7 @@ impl<I, C> Transform for Image<'_, I, C> {
     ///
     /// image.translate_mut(Point::new(10, 20));
     ///
-    /// assert_eq!(image.top_left(), Point::new(10, 20));
+    /// assert_eq!(image.bounding_box().top_left, Point::new(10, 20));
     /// ```
     fn translate_mut(&mut self, by: Point) -> &mut Self {
         self.offset += by;
@@ -201,16 +202,10 @@ where
     I: ImageDimensions,
     C: PixelColor + From<<C as PixelColor>::Raw>,
 {
-    fn top_left(&self) -> Point {
-        self.offset
-    }
+    fn bounding_box(&self) -> Rectangle {
+        let size = Size::new(self.image_data.width(), self.image_data.height());
 
-    fn bottom_right(&self) -> Point {
-        self.top_left() + self.size()
-    }
-
-    fn size(&self) -> Size {
-        Size::new(self.image_data.width(), self.image_data.height())
+        Rectangle::new(self.offset, size)
     }
 }
 

--- a/embedded-graphics/src/primitives/line.rs
+++ b/embedded-graphics/src/primitives/line.rs
@@ -6,9 +6,8 @@ use crate::{
     drawable::Pixel,
     geometry::Dimensions,
     geometry::Point,
-    geometry::Size,
     pixelcolor::PixelColor,
-    primitives::{Primitive, ThickLineIterator},
+    primitives::{Primitive, Rectangle, ThickLineIterator},
     style::PrimitiveStyle,
     style::Styled,
     transform::Transform,
@@ -59,16 +58,8 @@ impl Primitive for Line {
 }
 
 impl Dimensions for Line {
-    fn top_left(&self) -> Point {
-        Point::new(self.start.x.min(self.end.x), self.start.y.min(self.end.y))
-    }
-
-    fn bottom_right(&self) -> Point {
-        self.top_left() + (self.size() - Size::new(1, 1))
-    }
-
-    fn size(&self) -> Size {
-        Size::from_bounding_box(self.start, self.end)
+    fn bounding_box(&self) -> Rectangle {
+        Rectangle::with_corners(self.start, self.end)
     }
 }
 
@@ -199,7 +190,9 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{drawable::Pixel, mock_display::MockDisplay, pixelcolor::BinaryColor};
+    use crate::{
+        drawable::Pixel, geometry::Size, mock_display::MockDisplay, pixelcolor::BinaryColor,
+    };
 
     fn test_expected_line(start: Point, end: Point, expected: &[(i32, i32)]) {
         let line =
@@ -224,13 +217,14 @@ mod tests {
         let line: Line = Line::new(start, end);
         let backwards_line: Line = Line::new(end, start);
 
-        assert_eq!(line.top_left(), start);
-        assert_eq!(line.bottom_right(), end);
-        assert_eq!(line.size(), Size::new(10, 20));
-
-        assert_eq!(backwards_line.top_left(), start);
-        assert_eq!(backwards_line.bottom_right(), end);
-        assert_eq!(backwards_line.size(), Size::new(10, 20));
+        assert_eq!(
+            line.bounding_box(),
+            Rectangle::new(start, Size::new(10, 20))
+        );
+        assert_eq!(
+            backwards_line.bounding_box(),
+            Rectangle::new(start, Size::new(10, 20))
+        );
     }
 
     #[test]

--- a/embedded-graphics/src/primitives/rectangle.rs
+++ b/embedded-graphics/src/primitives/rectangle.rs
@@ -62,23 +62,8 @@ impl Primitive for Rectangle {
 }
 
 impl Dimensions for Rectangle {
-    fn top_left(&self) -> Point {
-        self.top_left
-    }
-
-    fn bottom_right(&self) -> Point {
-        if self.size == Size::zero() {
-            // FIXME: The bottom right corner isn't valid if the size of the rectangle is zero,
-            //        because creating a rectangle from two corner points creates a rectangle that
-            //        is at least 1x1 pixels large.
-            self.top_left
-        } else {
-            self.top_left + self.size - Point::new(1, 1)
-        }
-    }
-
-    fn size(&self) -> Size {
-        self.size
+    fn bounding_box(&self) -> Rectangle {
+        *self
     }
 }
 
@@ -288,13 +273,15 @@ mod tests {
         let rect = Rectangle::new(Point::new(5, 10), Size::new(10, 20));
         let moved = rect.translate(Point::new(-10, -20));
 
-        assert_eq!(rect.top_left(), Point::new(5, 10));
-        assert_eq!(rect.bottom_right(), Point::new(14, 29));
-        assert_eq!(rect.size(), Size::new(10, 20));
+        assert_eq!(
+            rect.bounding_box(),
+            Rectangle::new(Point::new(5, 10), Size::new(10, 20))
+        );
 
-        assert_eq!(moved.top_left(), Point::new(-5, -10));
-        assert_eq!(moved.bottom_right(), Point::new(4, 9));
-        assert_eq!(moved.size(), Size::new(10, 20));
+        assert_eq!(
+            moved.bounding_box(),
+            Rectangle::new(Point::new(-5, -10), Size::new(10, 20))
+        );
     }
 
     #[test]
@@ -302,8 +289,9 @@ mod tests {
         let rect = Rectangle::new(Point::new(5, 10), Size::new(10, 20));
         let moved = rect.translate(Point::new(10, 15));
 
-        assert_eq!(moved.top_left, Point::new(15, 25));
-        assert_eq!(moved.size, Size::new(10, 20));
+        let bounding_box = moved.bounding_box();
+        assert_eq!(bounding_box.top_left, Point::new(15, 25));
+        assert_eq!(bounding_box.size, Size::new(10, 20));
     }
 
     #[test]

--- a/embedded-graphics/src/primitives/triangle.rs
+++ b/embedded-graphics/src/primitives/triangle.rs
@@ -2,9 +2,9 @@
 
 use crate::{
     drawable::{Drawable, Pixel},
-    geometry::{Dimensions, Point, Size},
+    geometry::{Dimensions, Point},
     pixelcolor::PixelColor,
-    primitives::{line::Line, Primitive, ThickLineIterator},
+    primitives::{line::Line, Primitive, Rectangle, ThickLineIterator},
     style::{PrimitiveStyle, Styled},
     transform::Transform,
     DrawTarget,
@@ -81,22 +81,14 @@ impl Primitive for Triangle {
 }
 
 impl Dimensions for Triangle {
-    fn top_left(&self) -> Point {
-        let x = min(min(self.p1.x, self.p2.x), self.p3.x);
-        let y = min(min(self.p1.y, self.p2.y), self.p3.y);
+    fn bounding_box(&self) -> Rectangle {
+        let x_min = min(min(self.p1.x, self.p2.x), self.p3.x);
+        let y_min = min(min(self.p1.y, self.p2.y), self.p3.y);
 
-        Point::new(x, y)
-    }
+        let x_max = max(max(self.p1.x, self.p2.x), self.p3.x);
+        let y_max = max(max(self.p1.y, self.p2.y), self.p3.y);
 
-    fn bottom_right(&self) -> Point {
-        let x = max(max(self.p1.x, self.p2.x), self.p3.x);
-        let y = max(max(self.p1.y, self.p2.y), self.p3.y);
-
-        Point::new(x, y)
-    }
-
-    fn size(&self) -> Size {
-        Size::from_bounding_box(self.top_left(), self.bottom_right())
+        Rectangle::with_corners(Point::new(x_min, y_min), Point::new(x_max, y_max))
     }
 }
 
@@ -492,6 +484,7 @@ where
 mod tests {
     use super::*;
     use crate::{
+        geometry::Size,
         mock_display::MockDisplay,
         pixelcolor::{BinaryColor, Rgb888, RgbColor},
         style::PrimitiveStyleBuilder,
@@ -505,12 +498,12 @@ mod tests {
         assert_eq!(tri.p1, Point::new(5, 10));
         assert_eq!(tri.p2, Point::new(15, 25));
         assert_eq!(tri.p3, Point::new(5, 25));
-        assert_eq!(tri.size(), Size::new(11, 16));
+        assert_eq!(tri.bounding_box().size, Size::new(11, 16));
 
         assert_eq!(moved.p1, Point::new(-5, -1));
         assert_eq!(moved.p2, Point::new(5, 14));
         assert_eq!(moved.p3, Point::new(-5, 14));
-        assert_eq!(moved.size(), Size::new(11, 16));
+        assert_eq!(moved.bounding_box().size, Size::new(11, 16));
     }
 
     #[test]

--- a/embedded-graphics/src/style/styled.rs
+++ b/embedded-graphics/src/style/styled.rs
@@ -1,5 +1,6 @@
 use crate::{
-    geometry::{Dimensions, Point, Size},
+    geometry::{Dimensions, Point},
+    primitives::Rectangle,
     transform::Transform,
 };
 
@@ -42,15 +43,8 @@ impl<T, S> Dimensions for Styled<T, S>
 where
     T: Dimensions,
 {
-    fn top_left(&self) -> Point {
-        self.primitive.top_left()
-    }
-
-    fn bottom_right(&self) -> Point {
-        self.primitive.bottom_right()
-    }
-
-    fn size(&self) -> Size {
-        self.primitive.size()
+    //FIXME: The bounding box for a styled primitive should use the stroke width and alignment.
+    fn bounding_box(&self) -> Rectangle {
+        self.primitive.bounding_box()
     }
 }

--- a/simulator/examples/analog-clock.rs
+++ b/simulator/examples/analog-clock.rs
@@ -133,9 +133,12 @@ fn draw_digital_clock<'a>(time_str: &'a str) -> impl Iterator<Item = Pixel<Binar
 
     // Add a background around the time digits. Note that there is no bottom-right padding as this
     // is added by the font renderer itself
-    let background =
-        Rectangle::with_corners(text.top_left() - Point::new(3, 3), text.bottom_right())
-            .into_styled(PrimitiveStyle::with_fill(BinaryColor::On));
+    let text_dimensions = text.bounding_box();
+    let background = Rectangle::new(
+        text_dimensions.top_left - Point::new(3, 3),
+        text_dimensions.size + Size::new(3, 3),
+    )
+    .into_styled(PrimitiveStyle::with_fill(BinaryColor::On));
 
     // Draw the white background first, then the black text. Order matters here
     background.into_iter().chain(&text)

--- a/simulator/src/framebuffer.rs
+++ b/simulator/src/framebuffer.rs
@@ -112,14 +112,9 @@ impl DrawTarget<Rgb888> for Framebuffer {
         if let Some(fill_color) = item.style.fill_color {
             let color = &[fill_color.r(), fill_color.g(), fill_color.b()];
 
-            let tl = item.primitive.top_left;
-            let br = item.primitive.bottom_right();
-            for y in tl.y..=br.y {
-                for x in tl.x..=br.x {
-                    let p = Point::new(x, y);
-                    if let Some(pixel) = self.get_pixel_mut(p) {
-                        pixel.copy_from_slice(color);
-                    }
+            for p in item.primitive.bounding_box().points() {
+                if let Some(pixel) = self.get_pixel_mut(p) {
+                    pixel.copy_from_slice(color);
                 }
             }
         }

--- a/tinybmp/tests/embedded_graphics.rs
+++ b/tinybmp/tests/embedded_graphics.rs
@@ -4,6 +4,7 @@ use embedded_graphics::{
     image::Image,
     mock_display::MockDisplay,
     pixelcolor::{BinaryColor, Gray8, GrayColor, Rgb555, Rgb565, Rgb888, RgbColor},
+    primitives::Rectangle,
     transform::Transform,
 };
 use tinybmp::Bmp;
@@ -13,9 +14,10 @@ fn negative_top_left() {
     let image = Bmp::from_slice(include_bytes!("./chessboard-4px-color-16bit.bmp")).unwrap();
     let image: Image<_, Rgb565> = Image::new(&image, Point::zero()).translate(Point::new(-1, -1));
 
-    assert_eq!(image.top_left(), Point::new(-1, -1));
-    assert_eq!(image.bottom_right(), Point::new(3, 3));
-    assert_eq!(image.size(), Size::new(4, 4));
+    assert_eq!(
+        image.bounding_box(),
+        Rectangle::new(Point::new(-1, -1), Size::new(4, 4))
+    );
 }
 
 #[test]
@@ -23,9 +25,10 @@ fn dimensions() {
     let image = Bmp::from_slice(include_bytes!("./chessboard-4px-color-16bit.bmp")).unwrap();
     let image: Image<_, Rgb565> = Image::new(&image, Point::zero()).translate(Point::new(100, 200));
 
-    assert_eq!(image.top_left(), Point::new(100, 200));
-    assert_eq!(image.bottom_right(), Point::new(104, 204));
-    assert_eq!(image.size(), Size::new(4, 4));
+    assert_eq!(
+        image.bounding_box(),
+        Rectangle::new(Point::new(100, 200), Size::new(4, 4))
+    );
 }
 
 #[test]
@@ -74,7 +77,7 @@ macro_rules! test_pattern {
 
         let pattern = create_color_pattern();
 
-        assert_eq!(image.size(), Size::new(4, 2));
+        assert_eq!(image.bounding_box().size, Size::new(4, 2));
 
         let mut iter = image.into_iter();
         for (y, row) in pattern.iter().enumerate() {
@@ -116,7 +119,7 @@ fn colors_grey8() {
     let image = Bmp::from_slice(include_bytes!("./colors_grey8.bmp")).unwrap();
     let image: Image<_, Gray8> = Image::new(&image, Point::zero());
 
-    assert_eq!(image.size(), Size::new(3, 1));
+    assert_eq!(image.bounding_box().size, Size::new(3, 1));
 
     let mut iter = image.into_iter();
 


### PR DESCRIPTION
Hi! Thank you for helping out with Embedded Graphics development! Please:

- [x] Check that you've added passing tests and documentation
- [x] Add a simulator example(s) where applicable
- [x] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) and appropriate crate (`embedded-graphics`, `simulator`, `tinytga`, `tinybmp`) if your changes affect the **public API**
- [x] Run `rustfmt` on the project
- [x] Run `./build.sh` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

This PR changes the `Dimensions` trait to return a `Rectangle` instead of providing separate methods for getting the corners and size.  This reduces code duplication and makes it easier to get consistent behavior that should match #182.

One example of how this PR can simplify code is the change in `simulator/src/framebuffer.rs`. It uses the new `Points` iterator to iterate over all pixels inside the bounding box.

The `Dimension` implementation for `Circle` was broken before this PR and wasn't fixed in the PR to keep the scope of this PR smaller. I'll open another PR after this one is merged.
