### PR TITLE
Add ContainsPoint trait

### DIFF
--- a/embedded-graphics/CHANGELOG.md
+++ b/embedded-graphics/CHANGELOG.md
@@ -10,6 +10,7 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 
 - [#307](https://github.com/jamwaffles/embedded-graphics/pull/307) Added `Primitive::points` to get an iterator over all points inside a primitive.
 - [#317](https://github.com/jamwaffles/embedded-graphics/pull/317) Added `Rectangle::center` to get the center point of a rectangle.
+- [#318](https://github.com/jamwaffles/embedded-graphics/pull/317) Added `ContainsPoint` trait to check if a point is inside a closed shape.
 
 ### Changed
 

--- a/embedded-graphics/src/primitives/mod.rs
+++ b/embedded-graphics/src/primitives/mod.rs
@@ -32,6 +32,12 @@ pub trait Primitive: Dimensions {
     fn points(&self) -> Self::PointsIter;
 }
 
+/// Trait to check if a point is inside a closed shape.
+pub trait ContainsPoint {
+    /// Returns `true` is the given point is inside the shape.
+    fn contains(&self, point: Point) -> bool;
+}
+
 /// Create a [`Circle`](./primitives/circle/struct.Circle.html) with optional styling using a
 /// convenient macro.
 ///

--- a/embedded-graphics/src/primitives/rectangle.rs
+++ b/embedded-graphics/src/primitives/rectangle.rs
@@ -4,7 +4,7 @@ use crate::{
     drawable::{Drawable, Pixel},
     geometry::{Dimensions, Point, Size},
     pixelcolor::PixelColor,
-    primitives::Primitive,
+    primitives::{ContainsPoint, Primitive},
     style::{PrimitiveStyle, Styled},
     transform::Transform,
     DrawTarget,
@@ -58,6 +58,19 @@ impl Primitive for Rectangle {
 
     fn points(&self) -> Self::PointsIter {
         Points::new(self)
+    }
+}
+
+impl ContainsPoint for Rectangle {
+    fn contains(&self, point: Point) -> bool {
+        if point.x >= self.top_left.x && point.y >= self.top_left.y {
+            // FIXME: use Rectangle::bottom_right
+            let delta = Size::from_bounding_box(self.top_left, point);
+
+            delta.width <= self.size.width && delta.height <= self.size.height
+        } else {
+            false
+        }
     }
 }
 
@@ -361,6 +374,18 @@ mod tests {
         assert_eq!(points.next(), Some(Point::new(10, 22)));
         assert_eq!(points.next(), Some(Point::new(11, 22)));
         assert_eq!(points.next(), None);
+    }
+
+    #[test]
+    fn contains() {
+        let outer = Rectangle::new(Point::zero(), Size::new(10, 10));
+        let inner = Rectangle::new(Point::new(2, 4), Size::new(3, 5));
+
+        for p in outer.points() {
+            let expected = p.x >= 2 && p.x < 2 + 3 && p.y >= 4 && p.y < 4 + 5;
+
+            assert_eq!(inner.contains(p), expected, "{:?}", p);
+        }
     }
 
     #[test]


### PR DESCRIPTION
Hi! Thank you for helping out with Embedded Graphics development! Please:

- [x] Check that you've added passing tests and documentation
- [x] Add a simulator example(s) where applicable
- [x] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) and appropriate crate (`embedded-graphics`, `simulator`, `tinytga`, `tinybmp`) if your changes affect the **public API**
- [x] Run `rustfmt` on the project
- [x] Run `./build.sh` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

This PR adds a `contains(point: Point)` methods to all primitives that are closed shapes. The added `Shape` trait can be extended in the future to contain additional functions that don't make sense on line like primitives.

@jamwaffles Any suggestions for a better name, or do you think `Shape` is OK?