### PR TITLE
Add Rectangle::bottom_right()

### DIFF
--- a/embedded-graphics/CHANGELOG.md
+++ b/embedded-graphics/CHANGELOG.md
@@ -13,6 +13,7 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 - [#318](https://github.com/jamwaffles/embedded-graphics/pull/317) Added `ContainsPoint` trait to check if a point is inside a closed shape.
 - [#320](https://github.com/jamwaffles/embedded-graphics/pull/320) Added the `Ellipse` primitive.
 - [#320](https://github.com/jamwaffles/embedded-graphics/pull/320) Added `DrawTarget::draw_ellipse`
+- [#333](https://github.com/jamwaffles/embedded-graphics/pull/333) Added `Rectangle::bottom_right` to get the bottom right corner of a rectangle.
 
 ### Changed
 

--- a/embedded-graphics/src/primitives/rectangle.rs
+++ b/embedded-graphics/src/primitives/rectangle.rs
@@ -110,7 +110,7 @@ impl Rectangle {
     /// Returns the bottom right corner of this rectangle.
     ///
     /// Because the smallest rectangle that can be represented by its corners
-    /// has a size of 1 x 1 pixel this functions returns `None` if the width or
+    /// has a size of 1 x 1 pixels, this function returns `None` if the width or
     /// height of the rectangle is zero.
     pub fn bottom_right(&self) -> Option<Point> {
         if self.size.width > 0 && self.size.height > 0 {


### PR DESCRIPTION
Hi! Thank you for helping out with Embedded Graphics development! Please:

- [x] Check that you've added passing tests and documentation
- [x] Add a simulator example(s) where applicable
- [x] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) and appropriate crate (`embedded-graphics`, `simulator`, `tinytga`, `tinybmp`) if your changes affect the **public API**
- [x] Run `rustfmt` on the project
- [x] Run `./build.sh` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

This PR adds a `bottom_right` method to `Rectangle`.
