### PR TITLE
Add note about new linkchecker version for 20.04

### DIFF
--- a/embedded-graphics/README.md
+++ b/embedded-graphics/README.md
@@ -255,8 +255,16 @@ rustup update
 # Ensure rustfmt is installed
 rustup component add rustfmt
 
-# Install SDL2 for simulator and PIP to install linkchecker
+# Install SDL2 for simulator and linkchecker for build script
+
+# Python 2 systems (Ubuntu older than 20.04, Linux Mint 19, etc)
 sudo apt install libsdl2-dev linkchecker
+
+# OR
+
+# Python 3 systems (Ubuntu 20.04+, Linux Mint 20, etc)
+sudo apt install python3-pip
+sudo pip3 install git+https://github.com/linkchecker/linkchecker.git
 ```
 
 ## Attribution


### PR DESCRIPTION
Adds a quick note to the dev env setup to support Ubuntu 20.04 and other systems that only provide Python 3 now.
