### PR TITLE
Add methods to get points with axes

### DIFF
--- a/embedded-graphics/CHANGELOG.md
+++ b/embedded-graphics/CHANGELOG.md
@@ -19,6 +19,7 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 - [#331](https://github.com/jamwaffles/embedded-graphics/pull/331) Added `From<&PrimitiveStyle>` for `PrimitiveStyleBuilder`.
 - [#292](https://github.com/jamwaffles/embedded-graphics/pull/292) Added the `Polyline` primitive.
 - [#337](https://github.com/jamwaffles/embedded-graphics/pull/337) Add `Point::x_axis`, `Point::y_axis`, `Size::x_axis` and `Size::y_axis`.
+- [#337](https://github.com/jamwaffles/embedded-graphics/pull/337) Add `Point::new_equal` and `Size::new_equal`.
 
 ### Changed
 

--- a/embedded-graphics/CHANGELOG.md
+++ b/embedded-graphics/CHANGELOG.md
@@ -18,6 +18,7 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 - [#331](https://github.com/jamwaffles/embedded-graphics/pull/331) Added `Rectangle::with_center`.
 - [#331](https://github.com/jamwaffles/embedded-graphics/pull/331) Added `From<&PrimitiveStyle>` for `PrimitiveStyleBuilder`.
 - [#292](https://github.com/jamwaffles/embedded-graphics/pull/292) Added the `Polyline` primitive.
+- [#337](https://github.com/jamwaffles/embedded-graphics/pull/337) Add `Point::x_axis`, `Point::y_axis`, `Size::x_axis` and `Size::y_axis`.
 
 ### Changed
 

--- a/embedded-graphics/src/geometry/point.rs
+++ b/embedded-graphics/src/geometry/point.rs
@@ -78,6 +78,19 @@ impl Point {
         Point { x, y }
     }
 
+    /// Creates a point with X and Y values set to an equal value.
+    ///
+    /// ```rust
+    /// use embedded_graphics::geometry::Point;
+    ///
+    /// let point = Point::new_equal(11);
+    ///
+    /// assert_eq!(point, Point { x: 11, y: 11 });
+    /// ```
+    pub const fn new_equal(value: i32) -> Self {
+        Point { x: value, y: value }
+    }
+
     /// Creates a point with X and Y equal to zero.
     pub const fn zero() -> Self {
         Point { x: 0, y: 0 }

--- a/embedded-graphics/src/geometry/point.rs
+++ b/embedded-graphics/src/geometry/point.rs
@@ -83,6 +83,48 @@ impl Point {
         Point { x: 0, y: 0 }
     }
 
+    /// Returns a point with equal `x` value and `y` set to `0`.
+    ///
+    /// # Examples
+    ///
+    /// ## Move a `Point` along the X axis.
+    ///
+    /// ```rust
+    /// use embedded_graphics::geometry::Point;
+    ///
+    /// let translate = Point::new(20, 30);
+    ///
+    /// let point = Point::new(10, 15);
+    ///
+    /// let moved_x = point + translate.x_axis();
+    ///
+    /// assert_eq!(moved_x, Point::new(30, 15));
+    /// ```
+    pub const fn x_axis(self) -> Self {
+        Self { x: self.x, y: 0 }
+    }
+
+    /// Returns a point with equal `y` value and `x` set to `0`.
+    ///
+    /// # Examples
+    ///
+    /// ## Move a `Point` along the Y axis.
+    ///
+    /// ```rust
+    /// use embedded_graphics::geometry::Point;
+    ///
+    /// let translate = Point::new(20, 30);
+    ///
+    /// let point = Point::new(10, 15);
+    ///
+    /// let moved_y = point + translate.y_axis();
+    ///
+    /// assert_eq!(moved_y, Point::new(10, 45));
+    /// ```
+    pub const fn y_axis(self) -> Self {
+        Self { x: 0, y: self.y }
+    }
+
     /// Remove the sign from a coordinate
     ///
     /// ```

--- a/embedded-graphics/src/geometry/size.rs
+++ b/embedded-graphics/src/geometry/size.rs
@@ -72,6 +72,22 @@ impl Size {
         Size { width, height }
     }
 
+    /// Creates a size with width and height set to an equal value.
+    ///
+    /// ```rust
+    /// use embedded_graphics::geometry::Size;
+    ///
+    /// let size = Size::new_equal(11);
+    ///
+    /// assert_eq!(size, Size { width: 11, height: 11 });
+    /// ```
+    pub const fn new_equal(value: u32) -> Self {
+        Size {
+            width: value,
+            height: value,
+        }
+    }
+
     /// Creates a size with width and height equal to zero.
     pub const fn zero() -> Self {
         Size {

--- a/embedded-graphics/src/geometry/size.rs
+++ b/embedded-graphics/src/geometry/size.rs
@@ -80,6 +80,54 @@ impl Size {
         }
     }
 
+    /// Returns a size with equal `width` value and `height` set to `0`.
+    ///
+    /// # Examples
+    ///
+    /// ## Move a `Point` along the X axis.
+    ///
+    /// ```rust
+    /// use embedded_graphics::geometry::{Point, Size};
+    ///
+    /// let size = Size::new(20, 30);
+    ///
+    /// let point = Point::new(10, 15);
+    ///
+    /// let moved_x = point + size.x_axis();
+    ///
+    /// assert_eq!(moved_x, Point::new(30, 15));
+    /// ```
+    pub const fn x_axis(self) -> Self {
+        Self {
+            width: self.width,
+            height: 0,
+        }
+    }
+
+    /// Returns a size with equal `height` value and `width` set to `0`.
+    ///
+    /// # Examples
+    ///
+    /// ## Move a `Point` along the Y axis.
+    ///
+    /// ```rust
+    /// use embedded_graphics::geometry::{Point, Size};
+    ///
+    /// let size = Size::new(20, 30);
+    ///
+    /// let point = Point::new(10, 15);
+    ///
+    /// let moved_y = point + size.y_axis();
+    ///
+    /// assert_eq!(moved_y, Point::new(10, 45));
+    /// ```
+    pub const fn y_axis(self) -> Self {
+        Self {
+            width: 0,
+            height: self.height,
+        }
+    }
+
     /// Saturating addition.
     ///
     /// Returns `u32::max_value()` for `width` and/or `height` instead of overflowing.

--- a/embedded-graphics/src/primitives/thick_line_iterator.rs
+++ b/embedded-graphics/src/primitives/thick_line_iterator.rs
@@ -222,17 +222,17 @@ impl ThickLineParameters {
             core::mem::swap(&mut dx, &mut dy);
 
             (
-                Point::new(0, direction.y),
-                Point::new(direction.x, 0),
-                Point::new(0, perp_direction.y),
-                Point::new(perp_direction.x, 0),
+                direction.y_axis(),
+                direction.x_axis(),
+                perp_direction.y_axis(),
+                perp_direction.x_axis(),
             )
         } else {
             (
-                Point::new(direction.x, 0),
-                Point::new(0, direction.y),
-                Point::new(perp_direction.x, 0),
-                Point::new(0, perp_direction.y),
+                direction.x_axis(),
+                direction.y_axis(),
+                perp_direction.x_axis(),
+                perp_direction.y_axis(),
             )
         };
 


### PR DESCRIPTION
Hi! Thank you for helping out with Embedded Graphics development! Please:

- [x] Check that you've added passing tests and documentation
- [x] Add a simulator example(s) where applicable
- [x] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) and appropriate crate (`embedded-graphics`, `simulator`, `tinytga`, `tinybmp`) if your changes affect the **public API**
- [x] Run `rustfmt` on the project
- [x] Run `./build.sh` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

Adds `x_axis` and `y_axis` methods to get a `Point` or `Size` with one dimension set to zero. Some places can already use these, but they would be particularly useful in the `RoundedRectangle` PR. Also adds `Point::fill` and `Size::fill` which will be less useful but there are a couple of places they can be used. If these are really useless I don't mind removing them.
