### PR TITLE
Add ellipse to primitives-fill-macros demo

### DIFF
--- a/simulator/examples/primitives-fill-macros.rs
+++ b/simulator/examples/primitives-fill-macros.rs
@@ -4,14 +4,16 @@
 //! same as the `primitives-fill` example.
 
 use embedded_graphics::{
-    egcircle, egrectangle, egtriangle, pixelcolor::BinaryColor, prelude::*, primitive_style,
+    egcircle, egellipse, egrectangle, egtriangle, pixelcolor::BinaryColor, prelude::*,
+    primitive_style,
 };
 use embedded_graphics_simulator::{OutputSettingsBuilder, SimulatorDisplay, Window};
 
 static CIRCLE_SIZE: i32 = 65;
+static ELLIPSE_SIZE: Size = Size::new(90, 65);
 
 fn main() -> Result<(), core::convert::Infallible> {
-    let mut display: SimulatorDisplay<BinaryColor> = SimulatorDisplay::new(Size::new(384, 128));
+    let mut display: SimulatorDisplay<BinaryColor> = SimulatorDisplay::new(Size::new(404, 128));
 
     egcircle!(
         top_left = (0, 0),
@@ -103,6 +105,38 @@ fn main() -> Result<(), core::convert::Infallible> {
         )
     )
     .translate(Point::new(96 * 2 + 32, 32))
+    .draw(&mut display)?;
+
+    egellipse!(
+        top_left = Point::new(0, 0),
+        size = ELLIPSE_SIZE,
+        style = primitive_style!(stroke_color = BinaryColor::On, stroke_width = 1)
+    )
+    .translate(Point::new(96 * 3, 0))
+    .draw(&mut display)?;
+
+    egellipse!(
+        top_left = Point::new(0, 0),
+        size = ELLIPSE_SIZE,
+        style = primitive_style!(
+            stroke_color = BinaryColor::Off,
+            stroke_width = 1,
+            fill_color = BinaryColor::On,
+        )
+    )
+    .translate(Point::new(96 * 3 + 16, 16))
+    .draw(&mut display)?;
+
+    egellipse!(
+        top_left = Point::new(0, 0),
+        size = ELLIPSE_SIZE,
+        style = primitive_style!(
+            stroke_color = BinaryColor::Off,
+            stroke_width = 1,
+            fill_color = BinaryColor::Off,
+        )
+    )
+    .translate(Point::new(96 * 3 + 32, 32))
     .draw(&mut display)?;
 
     let output_settings = OutputSettingsBuilder::new().scale(2).build();


### PR DESCRIPTION
Hi! Thank you for helping out with Embedded Graphics development! Please:

- [x] Check that you've added passing tests and documentation
- [x] Add a simulator example(s) where applicable
- [x] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) and appropriate crate (`embedded-graphics`, `simulator`, `tinytga`, `tinybmp`) if your changes affect the **public API**
- [x] Run `rustfmt` on the project
- [x] Run `./build.sh` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

Adds `egellipse` usage to mirror the `primitives-fill` output.

I considered moving the style definitions into variables like `primitives-fill` to reduce duplication, but it might be useful to leave them inline to demonstrate `style = ` usage in the macros.

Closes #345 
