### PR TITLE
Add egpolyline macro

### DIFF
--- a/embedded-graphics/CHANGELOG.md
+++ b/embedded-graphics/CHANGELOG.md
@@ -21,6 +21,7 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 - [#337](https://github.com/jamwaffles/embedded-graphics/pull/337) Add `Point::x_axis`, `Point::y_axis`, `Size::x_axis` and `Size::y_axis`.
 - [#337](https://github.com/jamwaffles/embedded-graphics/pull/337) Add `Point::new_equal` and `Size::new_equal`.
 - [#336](https://github.com/jamwaffles/embedded-graphics/pull/336) Add `RoundedRectangle` primitive and `egroundedrectangle!` macro.
+- [#349](https://github.com/jamwaffles/embedded-graphics/pull/349) Added the `egpolyline!` macro.
 
 ### Changed
 

--- a/embedded-graphics/src/primitives/mod.rs
+++ b/embedded-graphics/src/primitives/mod.rs
@@ -308,6 +308,51 @@ macro_rules! egline {
     }};
 }
 
+/// Create a [`Polyline`](./primitives/polyline/struct.Polyline.html) with optional styling using a
+/// convenient macro.
+///
+/// Note that styled polylines currently only support the `stroke_color` and `stroke_width` style
+/// properties. The `stroke_width` property is currently clamped at 1px. All other style properties
+/// are ignored.
+///
+/// # Examples
+///
+/// ```rust
+/// use embedded_graphics::{
+///     egpolyline,
+///     pixelcolor::Rgb565,
+///     prelude::*,
+///     primitive_style,
+///     primitives::Polyline,
+///     style::{PrimitiveStyle, Styled},
+/// };
+///
+/// let points: [Point; 5] = [
+///     Point::new(8, 8),
+///     Point::new(48, 16),
+///     Point::new(32, 48),
+///     Point::new(16, 32),
+///     Point::new(32, 32),
+/// ];
+///
+/// let line: Styled<Polyline, PrimitiveStyle<Rgb565>> = egpolyline!(points = &points);
+///
+/// let stroke_line: Styled<Polyline, PrimitiveStyle<Rgb565>> = egpolyline!(
+///     points = &points,
+///     style = primitive_style!(stroke_width = 1, stroke_color = Rgb565::BLUE)
+/// );
+/// ```
+#[macro_export]
+macro_rules! egpolyline {
+    (points = $points:expr $(,)?) => {
+        $crate::primitives::Polyline::new($points)
+            .into_styled($crate::style::PrimitiveStyle::default())
+    };
+    (points = $points:expr, style = $style:expr $(,)?) => {
+        $crate::primitives::Polyline::new($points).into_styled($style)
+    };
+}
+
 /// Create a [`Rectangle`](./primitives/rectangle/struct.Rectangle.html) with optional styling using a
 /// convenient macro.
 ///

--- a/simulator/examples/primitives-polyline.rs
+++ b/simulator/examples/primitives-polyline.rs
@@ -3,7 +3,8 @@
 //! This example draws a crude "heartbeat" shape using the `Polyline` primitive
 
 use embedded_graphics::{
-    pixelcolor::Rgb888, prelude::*, primitives::Polyline, style::PrimitiveStyle,
+    egpolyline, pixelcolor::Rgb888, prelude::*, primitive_style, primitives::Polyline,
+    style::PrimitiveStyle,
 };
 use embedded_graphics_simulator::{OutputSettings, SimulatorDisplay, Window};
 
@@ -13,7 +14,7 @@ fn main() -> Result<(), core::convert::Infallible> {
     let (w, h) = (320i32, 256i32);
 
     let mut display: SimulatorDisplay<Rgb888> =
-        SimulatorDisplay::new(Size::new(w as u32, h as u32));
+        SimulatorDisplay::new(Size::new(w as u32, h as u32 * 2));
 
     let line_style = PrimitiveStyle::with_stroke(Rgb888::GREEN, 1);
 
@@ -33,6 +34,14 @@ fn main() -> Result<(), core::convert::Infallible> {
     Polyline::new(&points)
         .into_styled(line_style)
         .draw(&mut display)?;
+
+    // Draw an orange heartbeat below the green one using macros
+    egpolyline!(
+        points = &points,
+        style = primitive_style!(stroke_width = 1, stroke_color = Rgb888::new(247, 151, 17))
+    )
+    .translate(Point::new(0, h))
+    .draw(&mut display)?;
 
     Window::new("Polyline", &OutputSettings::default()).show_static(&display);
 


### PR DESCRIPTION
Hi! Thank you for helping out with Embedded Graphics development! Please:

- [x] Check that you've added passing tests and documentation
- [x] Add a simulator example(s) where applicable
- [x] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) and appropriate crate (`embedded-graphics`, `simulator`, `tinytga`, `tinybmp`) if your changes affect the **public API**
- [x] Run `rustfmt` on the project
- [x] Run `./build.sh` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

Adds the `egpolyline!` macro.

Closes #344.

The reference `&` is left at the call site of the macro, i.e. `egpolyline!(points = &points)` as opposed to letting the macro add the reference internally with `egpolyline!(points = points)`. The latter is a little cleaner but hides some of the behaviour which isn't great.

I also wanted to add a variant where the following is possible:

```rust
let stroke_line: Styled<Polyline, PrimitiveStyle<Rgb888>> = egpolyline!(
    points = [(10, 20), (30, 40)],
    style = primitive_style!(stroke_color = Rgb888::BLUE)
);
```

where `points` would be converted into a list of `Point` by the macro, however `Polyline::new` takes a reference which means this isn't possible in the macro due to lifetime issues.
