### PR TITLE
Add MockDisplay features and cleanup font tests

### DIFF
--- a/embedded-graphics/CHANGELOG.md
+++ b/embedded-graphics/CHANGELOG.md
@@ -22,6 +22,8 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 - [#337](https://github.com/jamwaffles/embedded-graphics/pull/337) Add `Point::new_equal` and `Size::new_equal`.
 - [#336](https://github.com/jamwaffles/embedded-graphics/pull/336) Add `RoundedRectangle` primitive and `egroundedrectangle!` macro.
 - [#353](https://github.com/jamwaffles/embedded-graphics/pull/353) Add `MockDisplay::swap_xy` method.
+- [#357](https://github.com/jamwaffles/embedded-graphics/pull/357) Add `MockDisplay::map` method.
+- [#357](https://github.com/jamwaffles/embedded-graphics/pull/357) Allow usage of all RGB color types in `MockDisplay` patterns.
 
 ### Changed
 
@@ -30,6 +32,7 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 - **(breaking)** [#312](https://github.com/jamwaffles/embedded-graphics/pull/312) The methods in the `Dimension` trait are replaced by a single `bounding_box` method that returns a `Rectangle`.
 - **(breaking)** [#353](https://github.com/jamwaffles/embedded-graphics/pull/353) Lines with equal start and end points are now drawn by assuming they are oriented horizontally. This means that they are now drawn as a `stroke_width` high and 1px wide rectangle, instead of not being drawn at all.
 - **(breaking)** [#353](https://github.com/jamwaffles/embedded-graphics/pull/353) `primitives::line::StyledLineIterator` was renamed to `primitives::line::StyledIterator`.
+- **(breaking)** [#357](https://github.com/jamwaffles/embedded-graphics/pull/357) Additional checks for overdraw and out of bounds drawing were added to `MockDisplay` which can cause tests to panic. See the `mock_display` module docs for more information.
 
 ### Fixed
 

--- a/embedded-graphics/src/drawable.rs
+++ b/embedded-graphics/src/drawable.rs
@@ -33,7 +33,7 @@ use crate::{geometry::Point, pixelcolor::PixelColor, DrawTarget};
 ///             .into_styled(PrimitiveStyle::with_fill(self.bg_color))
 ///             .draw(display)?;
 ///
-///         Text::new(self.text, Point::new(20, 20))
+///         Text::new(self.text, Point::new(6, 6))
 ///             .into_styled(TextStyle::new(Font6x8, self.fg_color))
 ///             .draw(display)
 ///     }
@@ -41,7 +41,7 @@ use crate::{geometry::Point, pixelcolor::PixelColor, DrawTarget};
 ///
 /// let mut button = Button {
 ///     top_left: Point::zero(),
-///     size: Size::new(100, 50),
+///     size: Size::new(60, 20),
 ///     bg_color: Rgb888::RED,
 ///     fg_color: Rgb888::BLUE,
 ///     text: "Click me!",
@@ -49,6 +49,7 @@ use crate::{geometry::Point, pixelcolor::PixelColor, DrawTarget};
 ///
 /// # use embedded_graphics::mock_display::MockDisplay;
 /// # let mut display = MockDisplay::default();
+/// # display.set_allow_overdraw(true);
 /// button.draw(&mut display)?;
 /// # Ok::<(), core::convert::Infallible>(())
 /// ```
@@ -87,7 +88,7 @@ where
 /// # use embedded_graphics::mock_display::MockDisplay;
 /// # let mut display = MockDisplay::new();
 ///
-/// (0..100)
+/// (0..32)
 ///     .map(|i| Pixel(Point::new(i, i * 2), BinaryColor::On))
 ///     .draw(&mut display)?;
 /// # Ok::<(), core::convert::Infallible>(())

--- a/embedded-graphics/src/fonts/font12x16.rs
+++ b/embedded-graphics/src/fonts/font12x16.rs
@@ -36,14 +36,10 @@ impl Font for Font12x16 {
 mod tests {
     use super::*;
     use crate::{
-        drawable::Drawable,
-        fonts::{Font, Text},
+        fonts::{tests::assert_text_from_pattern, Font, Text},
         geometry::{Dimensions, Point, Size},
-        mock_display::MockDisplay,
         pixelcolor::BinaryColor,
-        primitives::Rectangle,
         style::TextStyle,
-        transform::Transform,
     };
 
     const WIDTH: usize = Font12x16::CHARACTER_SIZE.width as usize;
@@ -64,38 +60,11 @@ mod tests {
     }
 
     #[test]
-    fn text_corners() {
-        let style = TextStyle::new(Font12x16, BinaryColor::On);
-        let hello = Text::new(HELLO_WORLD, Point::zero())
-            .into_styled(style)
-            .translate(Point::new(5, -20));
-        let empty = Text::new("", Point::zero())
-            .into_styled(style)
-            .translate(Point::new(10, 20));
-
-        assert_eq!(
-            hello.bounding_box(),
-            Rectangle::new(
-                Point::new(5, -20),
-                Size::new((HELLO_WORLD.len() * WIDTH) as u32, HEIGHT as u32)
-            )
-        );
-        assert_eq!(
-            empty.bounding_box(),
-            Rectangle::new(Point::new(10, 20), Size::zero())
-        );
-    }
-
-    #[test]
-    fn correct_m() -> Result<(), core::convert::Infallible> {
-        let mut display = MockDisplay::new();
-        Text::new("Mm", Point::zero())
-            .into_styled(TextStyle::new(Font12x16, BinaryColor::On))
-            .draw(&mut display)?;
-
-        assert_eq!(
-            display,
-            MockDisplay::from_pattern(&[
+    fn correct_m() {
+        assert_text_from_pattern(
+            "Mm",
+            Font12x16,
+            &[
                 "##      ##              ",
                 "##      ##              ",
                 "####  ####              ",
@@ -112,22 +81,16 @@ mod tests {
                 "##      ##  ##      ##  ",
                 "                        ",
                 "                        ",
-            ])
+            ],
         );
-
-        Ok(())
     }
 
     #[test]
-    fn correct_ascii_borders() -> Result<(), core::convert::Infallible> {
-        let mut display = MockDisplay::new();
-        Text::new(" ~", Point::zero())
-            .into_styled(TextStyle::new(Font12x16, BinaryColor::On))
-            .draw(&mut display)?;
-
-        assert_eq!(
-            display,
-            MockDisplay::from_pattern(&[
+    fn correct_ascii_borders() {
+        assert_text_from_pattern(
+            " ~",
+            Font12x16,
+            &[
                 "              ####  ##  ",
                 "              ####  ##  ",
                 "            ##    ##    ",
@@ -144,22 +107,16 @@ mod tests {
                 "                        ",
                 "                        ",
                 "                        ",
-            ])
+            ],
         );
-
-        Ok(())
     }
 
     #[test]
-    fn correct_dollar_y() -> Result<(), core::convert::Infallible> {
-        let mut display = MockDisplay::new();
-        Text::new("$y", Point::zero())
-            .into_styled(TextStyle::new(Font12x16, BinaryColor::On))
-            .draw(&mut display)?;
-
-        assert_eq!(
-            display,
-            MockDisplay::from_pattern(&[
+    fn correct_dollar_y() {
+        assert_text_from_pattern(
+            "$y",
+            Font12x16,
+            &[
                 "    ##                  ",
                 "    ##                  ",
                 "  ########              ",
@@ -176,22 +133,16 @@ mod tests {
                 "    ##              ##  ",
                 "              ######    ",
                 "              ######    ",
-            ])
+            ],
         );
-
-        Ok(())
     }
 
     #[test]
-    fn correct_latin1() -> Result<(), core::convert::Infallible> {
-        let mut display = MockDisplay::new();
-        Text::new("¡ÿ", Point::zero())
-            .into_styled(TextStyle::new(Font12x16, BinaryColor::On))
-            .draw(&mut display)?;
-
-        assert_eq!(
-            display,
-            MockDisplay::from_pattern(&[
+    fn correct_latin1() {
+        assert_text_from_pattern(
+            "¡ÿ",
+            Font12x16,
+            &[
                 "    ##        ##  ##    ",
                 "    ##        ##  ##    ",
                 "                        ",
@@ -208,15 +159,13 @@ mod tests {
                 "    ##              ##  ",
                 "              ######    ",
                 "              ######    ",
-            ])
+            ],
         );
-
-        Ok(())
     }
 
     #[test]
-    fn dont_panic() -> Result<(), core::convert::Infallible> {
-        let two_question_marks = MockDisplay::from_pattern(&[
+    fn dont_panic() {
+        let two_question_marks = &[
             "  ######      ######    ",
             "  ######      ######    ",
             "##      ##  ##      ##  ",
@@ -233,28 +182,10 @@ mod tests {
             "    ##          ##      ",
             "                        ",
             "                        ",
-        ]);
+        ];
 
-        let style = TextStyle::new(Font12x16, BinaryColor::On);
-
-        let mut display = MockDisplay::new();
-        Text::new("\0\r", Point::zero())
-            .into_styled(style)
-            .draw(&mut display)?;
-        assert_eq!(display, two_question_marks);
-
-        let mut display = MockDisplay::new();
-        Text::new("\x7F\u{A0}", Point::zero())
-            .into_styled(style)
-            .draw(&mut display)?;
-        assert_eq!(display, two_question_marks);
-
-        let mut display = MockDisplay::new();
-        Text::new("Ā💣", Point::zero())
-            .into_styled(style)
-            .draw(&mut display)?;
-        assert_eq!(display, two_question_marks);
-
-        Ok(())
+        assert_text_from_pattern("\0\r", Font12x16, two_question_marks);
+        assert_text_from_pattern("\x7F\u{A0}", Font12x16, two_question_marks);
+        assert_text_from_pattern("Ā💣", Font12x16, two_question_marks);
     }
 }

--- a/embedded-graphics/src/fonts/font24x32.rs
+++ b/embedded-graphics/src/fonts/font24x32.rs
@@ -41,14 +41,10 @@ impl Font for Font24x32 {
 mod tests {
     use super::*;
     use crate::{
-        drawable::Drawable,
-        fonts::{Font, Text},
+        fonts::{tests::assert_text_from_pattern, Font, Text},
         geometry::{Dimensions, Point, Size},
-        mock_display::MockDisplay,
         pixelcolor::BinaryColor,
-        primitives::Rectangle,
         style::TextStyle,
-        transform::Transform,
     };
 
     const WIDTH: usize = Font24x32::CHARACTER_SIZE.width as usize;
@@ -69,106 +65,67 @@ mod tests {
     }
 
     #[test]
-    fn text_corners() {
-        let style = TextStyle::new(Font24x32, BinaryColor::On);
-        let hello = Text::new(HELLO_WORLD, Point::zero())
-            .into_styled(style)
-            .translate(Point::new(5, -20));
-        let empty = Text::new("", Point::zero())
-            .into_styled(style)
-            .translate(Point::new(10, 20));
-
-        assert_eq!(
-            hello.bounding_box(),
-            Rectangle::new(
-                Point::new(5, -20),
-                Size::new((HELLO_WORLD.len() * WIDTH) as u32, HEIGHT as u32)
-            )
-        );
-        assert_eq!(
-            empty.bounding_box(),
-            Rectangle::new(Point::new(10, 20), Size::zero())
+    fn correct_m() {
+        assert_text_from_pattern(
+            "Mm",
+            Font24x32,
+            &[
+                "####            ####                          ",
+                "####            ####                          ",
+                "####            ####                          ",
+                "####            ####                          ",
+                "########    ########                          ",
+                "########    ########                          ",
+                "########    ########                          ",
+                "########    ########                          ",
+                "####    ####    ####    ########    ####      ",
+                "####    ####    ####    ########    ####      ",
+                "####    ####    ####    ########    ####      ",
+                "####    ####    ####    ########    ####      ",
+                "####    ####    ####    ####    ####    ####  ",
+                "####    ####    ####    ####    ####    ####  ",
+                "####    ####    ####    ####    ####    ####  ",
+                "####    ####    ####    ####    ####    ####  ",
+                "####            ####    ####            ####  ",
+                "####            ####    ####            ####  ",
+                "####            ####    ####            ####  ",
+                "####            ####    ####            ####  ",
+                "####            ####    ####            ####  ",
+                "####            ####    ####            ####  ",
+                "####            ####    ####            ####  ",
+                "####            ####    ####            ####  ",
+                "####            ####    ####            ####  ",
+                "####            ####    ####            ####  ",
+                "####            ####    ####            ####  ",
+                "####            ####    ####            ####  ",
+            ],
         );
     }
 
     #[test]
-    fn correct_m() -> Result<(), core::convert::Infallible> {
-        let mut display = MockDisplay::new();
-        Text::new("Mm", Point::zero())
-            .into_styled(TextStyle::new(Font24x32, BinaryColor::On))
-            .draw(&mut display)?;
-
-        assert_eq!(
-            display,
-            MockDisplay::from_pattern(&[
-                "####            ####                          ",
-                "####            ####                          ",
-                "####            ####                          ",
-                "####            ####                          ",
-                "########    ########                          ",
-                "########    ########                          ",
-                "########    ########                          ",
-                "########    ########                          ",
-                "####    ####    ####    ########    ####      ",
-                "####    ####    ####    ########    ####      ",
-                "####    ####    ####    ########    ####      ",
-                "####    ####    ####    ########    ####      ",
-                "####    ####    ####    ####    ####    ####  ",
-                "####    ####    ####    ####    ####    ####  ",
-                "####    ####    ####    ####    ####    ####  ",
-                "####    ####    ####    ####    ####    ####  ",
-                "####            ####    ####            ####  ",
-                "####            ####    ####            ####  ",
-                "####            ####    ####            ####  ",
-                "####            ####    ####            ####  ",
-                "####            ####    ####            ####  ",
-                "####            ####    ####            ####  ",
-                "####            ####    ####            ####  ",
-                "####            ####    ####            ####  ",
-                "####            ####    ####            ####  ",
-                "####            ####    ####            ####  ",
-                "####            ####    ####            ####  ",
-                "####            ####    ####            ####  ",
-            ])
+    fn correct_ascii_borders() {
+        assert_text_from_pattern(
+            " ~",
+            Font24x32,
+            &[
+                "                            ########    #### ",
+                "                            ########    #### ",
+                "                            ########    #### ",
+                "                            ########    #### ",
+                "                        ####        ####     ",
+                "                        ####        ####     ",
+                "                        ####        ####     ",
+                "                        ####        ####     ",
+            ],
         );
-
-        Ok(())
     }
 
     #[test]
-    fn correct_ascii_borders() -> Result<(), core::convert::Infallible> {
-        let mut display = MockDisplay::new();
-        Text::new(" ~", Point::zero())
-            .into_styled(TextStyle::new(Font24x32, BinaryColor::On))
-            .draw(&mut display)?;
-
-        assert_eq!(
-            display,
-            MockDisplay::from_pattern(&[
-                "                            ########    #### ",
-                "                            ########    #### ",
-                "                            ########    #### ",
-                "                            ########    #### ",
-                "                        ####        ####     ",
-                "                        ####        ####     ",
-                "                        ####        ####     ",
-                "                        ####        ####     ",
-            ])
-        );
-
-        Ok(())
-    }
-
-    #[test]
-    fn correct_dollar_y() -> Result<(), core::convert::Infallible> {
-        let mut display = MockDisplay::new();
-        Text::new("$y", Point::zero())
-            .into_styled(TextStyle::new(Font24x32, BinaryColor::On))
-            .draw(&mut display)?;
-
-        assert_eq!(
-            display,
-            MockDisplay::from_pattern(&[
+    fn correct_dollar_y() {
+        assert_text_from_pattern(
+            "$y",
+            Font24x32,
+            &[
                 "        ####                                 ",
                 "        ####                                 ",
                 "        ####                                 ",
@@ -201,22 +158,16 @@ mod tests {
                 "                            ############     ",
                 "                            ############     ",
                 "                            ############     ",
-            ])
+            ],
         );
-
-        Ok(())
     }
 
     #[test]
-    fn correct_latin1() -> Result<(), core::convert::Infallible> {
-        let mut display = MockDisplay::new();
-        Text::new("¡ÿ", Point::zero())
-            .into_styled(TextStyle::new(Font24x32, BinaryColor::On))
-            .draw(&mut display)?;
-
-        assert_eq!(
-            display,
-            MockDisplay::from_pattern(&[
+    fn correct_latin1() {
+        assert_text_from_pattern(
+            "¡ÿ",
+            Font24x32,
+            &[
                 "        ####                ####    ####         ",
                 "        ####                ####    ####         ",
                 "        ####                ####    ####         ",
@@ -249,15 +200,13 @@ mod tests {
                 "                            ############         ",
                 "                            ############         ",
                 "                            ############         ",
-            ])
+            ],
         );
-
-        Ok(())
     }
 
     #[test]
-    fn dont_panic() -> Result<(), core::convert::Infallible> {
-        let two_question_marks = MockDisplay::from_pattern(&[
+    fn dont_panic() {
+        let two_question_marks = &[
             "    ############            ############     ",
             "    ############            ############     ",
             "    ############            ############     ",
@@ -286,28 +235,10 @@ mod tests {
             "        ####                    ####         ",
             "        ####                    ####         ",
             "        ####                    ####         ",
-        ]);
+        ];
 
-        let style = TextStyle::new(Font24x32, BinaryColor::On);
-
-        let mut display = MockDisplay::new();
-        Text::new("\0\r", Point::zero())
-            .into_styled(style)
-            .draw(&mut display)?;
-        assert_eq!(display, two_question_marks);
-
-        let mut display = MockDisplay::new();
-        Text::new("\x7F\u{A0}", Point::zero())
-            .into_styled(style)
-            .draw(&mut display)?;
-        assert_eq!(display, two_question_marks);
-
-        let mut display = MockDisplay::new();
-        Text::new("Ā💣", Point::zero())
-            .into_styled(style)
-            .draw(&mut display)?;
-        assert_eq!(display, two_question_marks);
-
-        Ok(())
+        assert_text_from_pattern("\0\r", Font24x32, two_question_marks);
+        assert_text_from_pattern("\x7F\u{A0}", Font24x32, two_question_marks);
+        assert_text_from_pattern("Ā💣", Font24x32, two_question_marks);
     }
 }

--- a/embedded-graphics/src/fonts/font6x12.rs
+++ b/embedded-graphics/src/fonts/font6x12.rs
@@ -32,14 +32,10 @@ impl Font for Font6x12 {
 mod tests {
     use super::*;
     use crate::{
-        drawable::Drawable,
-        fonts::{Font, Text},
+        fonts::{tests::assert_text_from_pattern, Font, Text},
         geometry::{Dimensions, Point, Size},
-        mock_display::MockDisplay,
         pixelcolor::BinaryColor,
-        primitives::Rectangle,
         style::TextStyle,
-        transform::Transform,
     };
 
     const WIDTH: usize = Font6x12::CHARACTER_SIZE.width as usize;
@@ -60,38 +56,11 @@ mod tests {
     }
 
     #[test]
-    fn text_corners() {
-        let style = TextStyle::new(Font6x12, BinaryColor::On);
-        let hello = Text::new(HELLO_WORLD, Point::zero())
-            .into_styled(style)
-            .translate(Point::new(5, -20));
-        let empty = Text::new("", Point::zero())
-            .into_styled(style)
-            .translate(Point::new(10, 20));
-
-        assert_eq!(
-            hello.bounding_box(),
-            Rectangle::new(
-                Point::new(5, -20),
-                Size::new((HELLO_WORLD.len() * WIDTH) as u32, HEIGHT as u32)
-            )
-        );
-        assert_eq!(
-            empty.bounding_box(),
-            Rectangle::new(Point::new(10, 20), Size::zero())
-        );
-    }
-
-    #[test]
-    fn correct_m() -> Result<(), core::convert::Infallible> {
-        let mut display = MockDisplay::new();
-        Text::new("Mm", Point::zero())
-            .into_styled(TextStyle::new(Font6x12, BinaryColor::On))
-            .draw(&mut display)?;
-
-        assert_eq!(
-            display,
-            MockDisplay::from_pattern(&[
+    fn correct_m() {
+        assert_text_from_pattern(
+            "Mm",
+            Font6x12,
+            &[
                 "            ",
                 "#   #       ",
                 "## ##       ",
@@ -104,22 +73,16 @@ mod tests {
                 "#   # # # # ",
                 "            ",
                 "            ",
-            ])
+            ],
         );
-
-        Ok(())
     }
 
     #[test]
-    fn correct_ascii_borders() -> Result<(), core::convert::Infallible> {
-        let mut display = MockDisplay::new();
-        Text::new(" ~", Point::zero())
-            .into_styled(TextStyle::new(Font6x12, BinaryColor::On))
-            .draw(&mut display)?;
-
-        assert_eq!(
-            display,
-            MockDisplay::from_pattern(&[
+    fn correct_ascii_borders() {
+        assert_text_from_pattern(
+            " ~",
+            Font6x12,
+            &[
                 "        # # ",
                 "       #### ",
                 "       # #  ",
@@ -132,22 +95,16 @@ mod tests {
                 "            ",
                 "            ",
                 "            ",
-            ])
+            ],
         );
-
-        Ok(())
     }
 
     #[test]
-    fn correct_dollar_y() -> Result<(), core::convert::Infallible> {
-        let mut display = MockDisplay::new();
-        Text::new("$y", Point::zero())
-            .into_styled(TextStyle::new(Font6x12, BinaryColor::On))
-            .draw(&mut display)?;
-
-        assert_eq!(
-            display,
-            MockDisplay::from_pattern(&[
+    fn correct_dollar_y() {
+        assert_text_from_pattern(
+            "$y",
+            Font6x12,
+            &[
                 "            ",
                 "  #         ",
                 " ###        ",
@@ -160,15 +117,13 @@ mod tests {
                 " ###    ### ",
                 "  #       # ",
                 "        ##  ",
-            ])
+            ],
         );
-
-        Ok(())
     }
 
     #[test]
-    fn dont_panic() -> Result<(), core::convert::Infallible> {
-        let two_question_marks = MockDisplay::from_pattern(&[
+    fn dont_panic() {
+        let two_question_marks = &[
             "            ",
             "  ##    ##  ",
             " #  #  #  # ",
@@ -181,62 +136,11 @@ mod tests {
             "  #     #   ",
             "            ",
             "            ",
-        ]);
+        ];
 
-        let style = TextStyle::new(Font6x12, BinaryColor::On);
-
-        let mut display = MockDisplay::new();
-        Text::new("\0\r", Point::zero())
-            .into_styled(style)
-            .draw(&mut display)?;
-        assert_eq!(display, two_question_marks);
-
-        let mut display = MockDisplay::new();
-        Text::new("\x7F\u{A0}", Point::zero())
-            .into_styled(style)
-            .draw(&mut display)?;
-        assert_eq!(display, two_question_marks);
-
-        let mut display = MockDisplay::new();
-        Text::new("¡ÿ", Point::zero())
-            .into_styled(style)
-            .draw(&mut display)?;
-        assert_eq!(display, two_question_marks);
-
-        let mut display = MockDisplay::new();
-        Text::new("Ā💣", Point::zero())
-            .into_styled(style)
-            .draw(&mut display)?;
-        assert_eq!(display, two_question_marks);
-
-        Ok(())
-    }
-
-    #[test]
-    fn negative_y_no_infinite_loop() {
-        let style = TextStyle {
-            font: Font6x12,
-            text_color: Some(BinaryColor::On),
-            background_color: Some(BinaryColor::Off),
-        };
-
-        let mut text = Text::new("Testing string", Point::zero()).into_styled(style);
-        text.translate_mut(Point::new(0, -12));
-
-        assert_eq!(text.into_iter().count(), 6 * 12 * "Testing string".len());
-    }
-
-    #[test]
-    fn negative_x_no_infinite_loop() {
-        let style = TextStyle {
-            font: Font6x12,
-            text_color: Some(BinaryColor::On),
-            background_color: Some(BinaryColor::Off),
-        };
-
-        let mut text = Text::new("A", Point::zero()).into_styled(style);
-        text.translate_mut(Point::new(-6, 0));
-
-        assert_eq!(text.into_iter().count(), 6 * 12);
+        assert_text_from_pattern("\0\r", Font6x12, two_question_marks);
+        assert_text_from_pattern("\x7F\u{A0}", Font6x12, two_question_marks);
+        assert_text_from_pattern("¡ÿ", Font6x12, two_question_marks);
+        assert_text_from_pattern("Ā💣", Font6x12, two_question_marks);
     }
 }

--- a/embedded-graphics/src/fonts/font6x6.rs
+++ b/embedded-graphics/src/fonts/font6x6.rs
@@ -41,13 +41,11 @@ mod tests {
     use super::*;
     use crate::{
         drawable::Drawable,
-        fonts::{Font, Text},
+        fonts::{tests::assert_text_from_pattern, Font, Text},
         geometry::{Dimensions, Point, Size},
         mock_display::MockDisplay,
         pixelcolor::BinaryColor,
-        primitives::Rectangle,
         style::TextStyle,
-        transform::Transform,
     };
 
     const HEIGHT: usize = Font6x6::CHARACTER_SIZE.height as usize;
@@ -68,48 +66,19 @@ mod tests {
     }
 
     #[test]
-    fn text_corners() {
-        let style = TextStyle::new(Font6x6, BinaryColor::On);
-        let hello = Text::new(HELLO_WORLD, Point::zero())
-            .into_styled(style)
-            .translate(Point::new(5, -20));
-        let empty = Text::new("", Point::zero())
-            .into_styled(style)
-            .translate(Point::new(10, 20));
-
-        assert_eq!(
-            hello.bounding_box(),
-            Rectangle::new(
-                Point::new(5, -20),
-                Size::new(HELLO_WORLD_WIDTH, HEIGHT as u32)
-            )
-        );
-        assert_eq!(
-            empty.bounding_box(),
-            Rectangle::new(Point::new(10, 20), Size::zero())
-        );
-    }
-
-    #[test]
-    fn correct_m() -> Result<(), core::convert::Infallible> {
-        let mut display = MockDisplay::new();
-        Text::new("Mm", Point::zero())
-            .into_styled(TextStyle::new(Font6x6, BinaryColor::On))
-            .draw(&mut display)?;
-
-        assert_eq!(
-            display,
-            MockDisplay::from_pattern(&[
+    fn correct_m() {
+        assert_text_from_pattern(
+            "Mm",
+            Font6x6,
+            &[
                 "#   #       ",
                 "## ##  # #  ",
                 "# # # # # # ",
                 "#   # #   # ",
                 "#   # #   # ",
                 "            ",
-            ])
+            ],
         );
-
-        Ok(())
     }
 
     #[test]
@@ -162,62 +131,41 @@ mod tests {
             .into_styled(style_normal)
             .draw(&mut display_normal)?;
 
-        for y in 0..display_inverse.height() {
-            for x in 0..display_inverse.width() {
-                let p = Point::new(x as i32, y as i32);
-
-                let inverse_color = display_inverse.get_pixel(p);
-                let normal_color = display_normal.get_pixel(p);
-
-                assert_eq!(inverse_color, normal_color.map(|c| c.invert()));
-            }
-        }
+        assert_eq!(display_inverse, display_normal.map(|c| c.invert()));
 
         Ok(())
     }
 
     #[test]
-    fn correct_i() -> Result<(), core::convert::Infallible> {
-        let mut display = MockDisplay::new();
-        Text::new("Ii", Point::zero())
-            .into_styled(TextStyle::new(Font6x6, BinaryColor::On))
-            .draw(&mut display)?;
-
-        assert_eq!(
-            display,
-            MockDisplay::from_pattern(&[
+    fn correct_i() {
+        assert_text_from_pattern(
+            "Ii",
+            Font6x6,
+            &[
                 "# #         ",
                 "#           ",
                 "# #         ",
                 "# #         ",
                 "# #         ",
                 "            ",
-            ])
+            ],
         );
-
-        Ok(())
     }
 
     #[test]
-    fn correct_ascii_borders() -> Result<(), core::convert::Infallible> {
-        let mut display = MockDisplay::new();
-        Text::new(" ~", Point::zero())
-            .into_styled(TextStyle::new(Font6x6, BinaryColor::On))
-            .draw(&mut display)?;
-
-        assert_eq!(
-            display,
-            MockDisplay::from_pattern(&[
+    fn correct_ascii_borders() {
+        assert_text_from_pattern(
+            " ~",
+            Font6x6,
+            &[
                 "            ",
                 "   ## #     ",
                 "  #  #      ",
                 "            ",
                 "            ",
                 "            ",
-            ])
+            ],
         );
-
-        Ok(())
     }
 
     #[test]
@@ -233,58 +181,34 @@ mod tests {
     }
 
     #[test]
-    fn correct_dollar_y() -> Result<(), core::convert::Infallible> {
-        let mut display = MockDisplay::new();
-        Text::new("$y", Point::zero())
-            .into_styled(TextStyle::new(Font6x6, BinaryColor::On))
-            .draw(&mut display)?;
-
-        assert_eq!(
-            display,
-            MockDisplay::from_pattern(&[
+    fn correct_dollar_y() {
+        assert_text_from_pattern(
+            "$y",
+            Font6x6,
+            &[
                 " #### #  #  ",
                 "# #   #  #  ",
                 "##### ####  ",
                 "  # #    #  ",
                 "####  ###   ",
                 "            ",
-            ])
+            ],
         );
-
-        Ok(())
     }
 
     #[test]
-    fn dont_panic() -> Result<(), core::convert::Infallible> {
-        let two_question_marks = MockDisplay::from_pattern(&[
+    fn dont_panic() {
+        let two_question_marks = &[
             " ###   ### ",
             "#   # #   #",
             "  ##    ## ",
             "           ",
             "  #     #  ",
             "           ",
-        ]);
+        ];
 
-        let style = TextStyle::new(Font6x6, BinaryColor::On);
-
-        let mut display = MockDisplay::new();
-        Text::new("\0\r", Point::zero())
-            .into_styled(style)
-            .draw(&mut display)?;
-        assert_eq!(display, two_question_marks);
-
-        let mut display = MockDisplay::new();
-        Text::new("\x7F\u{A0}", Point::zero())
-            .into_styled(style)
-            .draw(&mut display)?;
-        assert_eq!(display, two_question_marks);
-
-        let mut display = MockDisplay::new();
-        Text::new("Ā💣", Point::zero())
-            .into_styled(style)
-            .draw(&mut display)?;
-        assert_eq!(display, two_question_marks);
-
-        Ok(())
+        assert_text_from_pattern("\0\r", Font6x6, two_question_marks);
+        assert_text_from_pattern("\x7F\u{A0}", Font6x6, two_question_marks);
+        assert_text_from_pattern("Ā💣", Font6x6, two_question_marks);
     }
 }

--- a/embedded-graphics/src/fonts/font6x8.rs
+++ b/embedded-graphics/src/fonts/font6x8.rs
@@ -35,14 +35,10 @@ impl Font for Font6x8 {
 mod tests {
     use super::*;
     use crate::{
-        drawable::Drawable,
-        fonts::{Font, Text},
+        fonts::{tests::assert_text_from_pattern, Font, Text},
         geometry::{Dimensions, Point, Size},
-        mock_display::MockDisplay,
         pixelcolor::BinaryColor,
-        primitives::Rectangle,
         style::TextStyle,
-        transform::Transform,
     };
 
     const WIDTH: usize = Font6x8::CHARACTER_SIZE.width as usize;
@@ -63,38 +59,11 @@ mod tests {
     }
 
     #[test]
-    fn text_corners() {
-        let style = TextStyle::new(Font6x8, BinaryColor::On);
-        let hello = Text::new(HELLO_WORLD, Point::zero())
-            .into_styled(style)
-            .translate(Point::new(5, -20));
-        let empty = Text::new("", Point::zero())
-            .into_styled(style)
-            .translate(Point::new(10, 20));
-
-        assert_eq!(
-            hello.bounding_box(),
-            Rectangle::new(
-                Point::new(5, -20),
-                Size::new((HELLO_WORLD.len() * WIDTH) as u32, HEIGHT as u32)
-            )
-        );
-        assert_eq!(
-            empty.bounding_box(),
-            Rectangle::new(Point::new(10, 20), Size::zero())
-        );
-    }
-
-    #[test]
-    fn correct_m() -> Result<(), core::convert::Infallible> {
-        let mut display = MockDisplay::new();
-        Text::new("Mm", Point::zero())
-            .into_styled(TextStyle::new(Font6x8, BinaryColor::On))
-            .draw(&mut display)?;
-
-        assert_eq!(
-            display,
-            MockDisplay::from_pattern(&[
+    fn correct_m() {
+        assert_text_from_pattern(
+            "Mm",
+            Font6x8,
+            &[
                 "#   #       ",
                 "## ##       ",
                 "# # # ## #  ",
@@ -103,88 +72,16 @@ mod tests {
                 "#   # #   # ",
                 "#   # #   # ",
                 "            ",
-            ])
+            ],
         );
-
-        Ok(())
     }
 
     #[test]
-    fn correct_inverse_colored_m() -> Result<(), core::convert::Infallible> {
-        let mut display = MockDisplay::new();
-        let style = TextStyle {
-            font: Font6x8,
-            text_color: Some(BinaryColor::Off),
-            background_color: Some(BinaryColor::On),
-        };
-        Text::new("Mm", Point::zero())
-            .into_styled(style)
-            .draw(&mut display)?;
-
-        assert_eq!(
-            display,
-            MockDisplay::from_pattern(&[
-                ".###.#######",
-                "..#..#######",
-                ".#.#.#..#.##",
-                ".#.#.#.#.#.#",
-                ".###.#.###.#",
-                ".###.#.###.#",
-                ".###.#.###.#",
-                "############",
-            ])
-        );
-
-        Ok(())
-    }
-
-    // tests if black on white has really the same behavior as white on black
-    #[test]
-    fn compare_inverse_colored_m() -> Result<(), core::convert::Infallible> {
-        let mut display_inverse = MockDisplay::new();
-        let style_inverse = TextStyle {
-            font: Font6x8,
-            text_color: Some(BinaryColor::Off),
-            background_color: Some(BinaryColor::On),
-        };
-        Text::new("Mm", Point::zero())
-            .into_styled(style_inverse)
-            .draw(&mut display_inverse)?;
-
-        let mut display_normal = MockDisplay::new();
-        let style_normal = TextStyle {
-            font: Font6x8,
-            text_color: Some(BinaryColor::On),
-            background_color: Some(BinaryColor::Off),
-        };
-        Text::new("Mm", Point::zero())
-            .into_styled(style_normal)
-            .draw(&mut display_normal)?;
-
-        for y in 0..display_inverse.height() {
-            for x in 0..display_inverse.width() {
-                let p = Point::new(x as i32, y as i32);
-
-                let inverse_color = display_inverse.get_pixel(p);
-                let normal_color = display_normal.get_pixel(p);
-
-                assert_eq!(inverse_color, normal_color.map(|c| c.invert()));
-            }
-        }
-
-        Ok(())
-    }
-
-    #[test]
-    fn correct_ascii_borders() -> Result<(), core::convert::Infallible> {
-        let mut display = MockDisplay::new();
-        Text::new(" ~", Point::zero())
-            .into_styled(TextStyle::new(Font6x8, BinaryColor::On))
-            .draw(&mut display)?;
-
-        assert_eq!(
-            display,
-            MockDisplay::from_pattern(&[
+    fn correct_ascii_borders() {
+        assert_text_from_pattern(
+            " ~",
+            Font6x8,
+            &[
                 "       ## # ",
                 "      #  #  ",
                 "            ",
@@ -193,34 +90,16 @@ mod tests {
                 "            ",
                 "            ",
                 "            ",
-            ])
+            ],
         );
-
-        Ok(())
     }
 
     #[test]
-    fn no_fill_doesnt_hang() -> Result<(), core::convert::Infallible> {
-        let mut display = MockDisplay::new();
-        Text::new(" ", Point::zero())
-            .into_styled(TextStyle::new(Font6x8, BinaryColor::On))
-            .draw(&mut display)?;
-
-        assert_eq!(display, MockDisplay::new());
-
-        Ok(())
-    }
-
-    #[test]
-    fn correct_dollar_y() -> Result<(), core::convert::Infallible> {
-        let mut display = MockDisplay::new();
-        Text::new("$y", Point::zero())
-            .into_styled(TextStyle::new(Font6x8, BinaryColor::On))
-            .draw(&mut display)?;
-
-        assert_eq!(
-            display,
-            MockDisplay::from_pattern(&[
+    fn correct_dollar_y() {
+        assert_text_from_pattern(
+            "$y",
+            Font6x8,
+            &[
                 "  #         ",
                 " ####       ",
                 "# #   #   # ",
@@ -229,22 +108,16 @@ mod tests {
                 "####   #### ",
                 "  #       # ",
                 "       ###  ",
-            ])
+            ],
         );
-
-        Ok(())
     }
 
     #[test]
-    fn correct_latin1() -> Result<(), core::convert::Infallible> {
-        let mut display = MockDisplay::new();
-        Text::new("¡ÿ", Point::zero())
-            .into_styled(TextStyle::new(Font6x8, BinaryColor::On))
-            .draw(&mut display)?;
-
-        assert_eq!(
-            display,
-            MockDisplay::from_pattern(&[
+    fn correct_latin1() {
+        assert_text_from_pattern(
+            "¡ÿ",
+            Font6x8,
+            &[
                 "  #    # #  ",
                 "            ",
                 "  #   #   # ",
@@ -254,15 +127,13 @@ mod tests {
                 "  #       # ",
                 "       ###  ",
                 "            ",
-            ])
+            ],
         );
-
-        Ok(())
     }
 
     #[test]
-    fn dont_panic() -> Result<(), core::convert::Infallible> {
-        let two_question_marks = MockDisplay::from_pattern(&[
+    fn dont_panic() {
+        let two_question_marks = &[
             " ###   ### ",
             "#   # #   #",
             "    #     #",
@@ -270,28 +141,10 @@ mod tests {
             "  #     #  ",
             "           ",
             "  #     #  ",
-        ]);
+        ];
 
-        let style = TextStyle::new(Font6x8, BinaryColor::On);
-
-        let mut display = MockDisplay::new();
-        Text::new("\0\r", Point::zero())
-            .into_styled(style)
-            .draw(&mut display)?;
-        assert_eq!(display, two_question_marks);
-
-        let mut display = MockDisplay::new();
-        Text::new("\x7F\u{A0}", Point::zero())
-            .into_styled(style)
-            .draw(&mut display)?;
-        assert_eq!(display, two_question_marks);
-
-        let mut display = MockDisplay::new();
-        Text::new("Ā💣", Point::zero())
-            .into_styled(style)
-            .draw(&mut display)?;
-        assert_eq!(display, two_question_marks);
-
-        Ok(())
+        assert_text_from_pattern("\0\r", Font6x8, two_question_marks);
+        assert_text_from_pattern("\x7F\u{A0}", Font6x8, two_question_marks);
+        assert_text_from_pattern("Ā💣", Font6x8, two_question_marks);
     }
 }

--- a/embedded-graphics/src/fonts/font8x16.rs
+++ b/embedded-graphics/src/fonts/font8x16.rs
@@ -35,14 +35,10 @@ impl Font for Font8x16 {
 mod tests {
     use super::*;
     use crate::{
-        drawable::Drawable,
-        fonts::{Font, Text},
+        fonts::{tests::assert_text_from_pattern, Font, Text},
         geometry::{Dimensions, Point, Size},
-        mock_display::MockDisplay,
         pixelcolor::BinaryColor,
-        primitives::Rectangle,
         style::TextStyle,
-        transform::Transform,
     };
 
     const WIDTH: usize = Font8x16::CHARACTER_SIZE.width as usize;
@@ -63,38 +59,11 @@ mod tests {
     }
 
     #[test]
-    fn text_corners() {
-        let style = TextStyle::new(Font8x16, BinaryColor::On);
-        let hello = Text::new(HELLO_WORLD, Point::zero())
-            .into_styled(style)
-            .translate(Point::new(5, -20));
-        let empty = Text::new("", Point::zero())
-            .into_styled(style)
-            .translate(Point::new(10, 20));
-
-        assert_eq!(
-            hello.bounding_box(),
-            Rectangle::new(
-                Point::new(5, -20),
-                Size::new((HELLO_WORLD.len() * WIDTH) as u32, HEIGHT as u32)
-            )
-        );
-        assert_eq!(
-            empty.bounding_box(),
-            Rectangle::new(Point::new(10, 20), Size::zero())
-        );
-    }
-
-    #[test]
-    fn correct_m() -> Result<(), core::convert::Infallible> {
-        let mut display = MockDisplay::new();
-        Text::new("Mm", Point::zero())
-            .into_styled(TextStyle::new(Font8x16, BinaryColor::On))
-            .draw(&mut display)?;
-
-        assert_eq!(
-            display,
-            MockDisplay::from_pattern(&[
+    fn correct_m() {
+        assert_text_from_pattern(
+            "Mm",
+            Font8x16,
+            &[
                 "                ",
                 "                ",
                 "##   ##         ",
@@ -111,22 +80,16 @@ mod tests {
                 "                ",
                 "                ",
                 "                ",
-            ])
+            ],
         );
-
-        Ok(())
     }
 
     #[test]
-    fn correct_ascii_borders() -> Result<(), core::convert::Infallible> {
-        let mut display = MockDisplay::new();
-        Text::new(" ~", Point::zero())
-            .into_styled(TextStyle::new(Font8x16, BinaryColor::On))
-            .draw(&mut display)?;
-
-        assert_eq!(
-            display,
-            MockDisplay::from_pattern(&[
+    fn correct_ascii_borders() {
+        assert_text_from_pattern(
+            " ~",
+            Font8x16,
+            &[
                 "                ",
                 "         ### ## ",
                 "        ## ###  ",
@@ -143,117 +106,85 @@ mod tests {
                 "                ",
                 "                ",
                 "                ",
-            ])
+            ],
         );
-
-        Ok(())
     }
 
     #[test]
-    fn correct_dollar_y() -> Result<(), core::convert::Infallible> {
-        let mut display = MockDisplay::new();
-        Text::new("$y", Point::zero())
-            .into_styled(TextStyle::new(Font8x16, BinaryColor::On))
-            .draw(&mut display)?;
-
-        assert_eq!(
-            display,
-            MockDisplay::from_pattern(&[
-                "   ##                   ",
-                "   ##                   ",
-                " #####                  ",
-                "##   ##                 ",
-                "##    #                 ",
-                "##      ##   ##         ",
-                " #####  ##   ##         ",
-                "     ## ##   ##         ",
-                "     ## ##   ##         ",
-                "#    ## ##   ##         ",
-                "##   ## ##   ##         ",
-                " #####   ######         ",
-                "   ##        ##         ",
-                "   ##       ##          ",
-                "        #####           ",
-                "                        ",
-            ])
+    fn correct_dollar_y() {
+        assert_text_from_pattern(
+            "$y",
+            Font8x16,
+            &[
+                "   ##           ",
+                "   ##           ",
+                " #####          ",
+                "##   ##         ",
+                "##    #         ",
+                "##      ##   ## ",
+                " #####  ##   ## ",
+                "     ## ##   ## ",
+                "     ## ##   ## ",
+                "#    ## ##   ## ",
+                "##   ## ##   ## ",
+                " #####   ###### ",
+                "   ##        ## ",
+                "   ##       ##  ",
+                "        #####   ",
+                "                ",
+            ],
         );
-
-        Ok(())
     }
 
     #[test]
-    fn correct_latin1() -> Result<(), core::convert::Infallible> {
-        let mut display = MockDisplay::new();
-        Text::new("¡ÿ", Point::zero())
-            .into_styled(TextStyle::new(Font8x16, BinaryColor::On))
-            .draw(&mut display)?;
-
-        assert_eq!(
-            display,
-            MockDisplay::from_pattern(&[
-                "                        ",
-                "        ##   ##         ",
-                "   ##   ##   ##         ",
-                "   ##                   ",
-                "                        ",
-                "   ##   ##   ##         ",
-                "   ##   ##   ##         ",
-                "   ##   ##   ##         ",
-                "  ####  ##   ##         ",
-                "  ####  ##   ##         ",
-                "  ####  ##   ##         ",
-                "   ##    ######         ",
-                "             ##         ",
-                "            ##          ",
-                "        #####           ",
-                "                        ",
-            ])
+    fn correct_latin1() {
+        assert_text_from_pattern(
+            "¡ÿ",
+            Font8x16,
+            &[
+                "                ",
+                "        ##   ## ",
+                "   ##   ##   ## ",
+                "   ##           ",
+                "                ",
+                "   ##   ##   ## ",
+                "   ##   ##   ## ",
+                "   ##   ##   ## ",
+                "  ####  ##   ## ",
+                "  ####  ##   ## ",
+                "  ####  ##   ## ",
+                "   ##    ###### ",
+                "             ## ",
+                "            ##  ",
+                "        #####   ",
+                "                ",
+            ],
         );
-
-        Ok(())
     }
 
     #[test]
-    fn dont_panic() -> Result<(), core::convert::Infallible> {
-        let two_question_marks = MockDisplay::from_pattern(&[
-            "                        ",
-            "                        ",
-            " #####   #####          ",
-            "##   ## ##   ##         ",
-            "##   ## ##   ##         ",
-            "    ##      ##          ",
-            "   ##      ##           ",
-            "   ##      ##           ",
-            "   ##      ##           ",
-            "                        ",
-            "   ##      ##           ",
-            "   ##      ##           ",
-            "                        ",
-            "                        ",
-            "                        ",
-            "                        ",
-        ]);
+    fn dont_panic() {
+        let two_question_marks = &[
+            "                ",
+            "                ",
+            " #####   #####  ",
+            "##   ## ##   ## ",
+            "##   ## ##   ## ",
+            "    ##      ##  ",
+            "   ##      ##   ",
+            "   ##      ##   ",
+            "   ##      ##   ",
+            "                ",
+            "   ##      ##   ",
+            "   ##      ##   ",
+            "                ",
+            "                ",
+            "                ",
+            "                ",
+        ];
 
-        let style = TextStyle::new(Font8x16, BinaryColor::On);
-
-        let mut display = MockDisplay::new();
-        Text::new("\0\r", Point::zero())
-            .into_styled(style)
-            .draw(&mut display)?;
-        assert_eq!(display, two_question_marks);
-
-        let mut display = MockDisplay::new();
-        Text::new("\x7F\u{A0}", Point::zero())
-            .into_styled(style)
-            .draw(&mut display)?;
-        assert_eq!(display, two_question_marks);
-
-        let mut display = MockDisplay::new();
-        Text::new("Ā💣", Point::zero())
-            .into_styled(style)
-            .draw(&mut display)?;
-        assert_eq!(display, two_question_marks);
-
-        Ok(())
+        assert_text_from_pattern("\0\r", Font8x16, two_question_marks);
+        assert_text_from_pattern("\x7F\u{A0}", Font8x16, two_question_marks);
+        assert_text_from_pattern("Ā💣", Font8x16, two_question_marks);
     }
 }

--- a/embedded-graphics/src/fonts/mod.rs
+++ b/embedded-graphics/src/fonts/mod.rs
@@ -26,6 +26,7 @@
 //! };
 //! # use embedded_graphics::mock_display::MockDisplay;
 //! # let mut display: MockDisplay<Rgb565> = MockDisplay::default();
+//! # display.set_allow_out_of_bounds_drawing(true);
 //!
 //! // Create a new text style
 //! let style = TextStyleBuilder::new(Font6x8)
@@ -51,6 +52,7 @@
 //! };
 //! # use embedded_graphics::mock_display::MockDisplay;
 //! # let mut display: MockDisplay<BinaryColor> = MockDisplay::default();
+//! # display.set_allow_out_of_bounds_drawing(true);
 //!
 //! Text::new("Hello Rust!", Point::zero())
 //!     .into_styled(TextStyle::new(Font6x8, BinaryColor::On))
@@ -59,6 +61,8 @@
 //!
 //! // this is equivalent to:
 //!
+//! # let mut display: MockDisplay<BinaryColor> = MockDisplay::default();
+//! # display.set_allow_out_of_bounds_drawing(true);
 //! Text::new("Hello Rust!", Point::new(20, 30))
 //!     .into_styled(TextStyle::new(Font6x8, BinaryColor::On))
 //!     .draw(&mut display)?;
@@ -82,6 +86,7 @@
 //! };
 //! # use embedded_graphics::mock_display::MockDisplay;
 //! # let mut display = MockDisplay::default();
+//! # display.set_allow_out_of_bounds_drawing(true);
 //!
 //! let value = 12.34567;
 //!
@@ -215,5 +220,28 @@ pub trait Font {
         let bitmap_bit = 7 - (bitmap_bit_index % 8);
 
         Self::FONT_IMAGE[bitmap_byte as usize] & (1 << bitmap_bit) != 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        drawable::Drawable, geometry::Point, mock_display::MockDisplay, pixelcolor::BinaryColor,
+        style::TextStyle,
+    };
+
+    /// Draws a text using the given font and checks it against the expected pattern.
+    pub(super) fn assert_text_from_pattern<F>(text: &str, font: F, pattern: &[&str])
+    where
+        F: Font + Copy,
+    {
+        let mut display = MockDisplay::new();
+        Text::new(text, Point::zero())
+            .into_styled(TextStyle::new(font, BinaryColor::On))
+            .draw(&mut display)
+            .unwrap();
+
+        assert_eq!(display, MockDisplay::from_pattern(pattern));
     }
 }

--- a/embedded-graphics/src/lib.rs
+++ b/embedded-graphics/src/lib.rs
@@ -103,23 +103,23 @@
 //! ```rust
 //! use embedded_graphics::{
 //!     fonts::{Font6x8, Text},
-//!     mock_display::MockDisplay,
+//! #   mock_display::MockDisplay,
 //!     pixelcolor::Rgb565,
 //!     prelude::*,
 //!     primitives::Circle,
 //!     style::{PrimitiveStyle, TextStyle},
 //! };
 //!
-//! // Create a draw target using the builtin MockDisplay. In real applications this would be
-//! // replaced by a draw target that is provided by a display driver crate.
-//! let mut display = MockDisplay::default();
-//! display.set_allow_overdraw(true);
-//! display.set_allow_out_of_bounds_drawing(true);
+//! # let mut display = MockDisplay::default();
+//! # display.set_allow_overdraw(true);
+//! # display.set_allow_out_of_bounds_drawing(true);
 //!
 //! let c = Circle::new(Point::new(12, 12), 17).into_styled(PrimitiveStyle::with_fill(Rgb565::RED));
 //! let t = Text::new("Hello Rust!", Point::new(20, 16))
 //!     .into_styled(TextStyle::new(Font6x8, Rgb565::GREEN));
 //!
+//! // The `display` variable contains a `DrawTarget` implementation provided by the display driver
+//! // crate. See the driver crate documentation for more information about how it is constructed.
 //! c.draw(&mut display)?;
 //! t.draw(&mut display)?;
 //! # Ok::<(), core::convert::Infallible>(())

--- a/embedded-graphics/src/lib.rs
+++ b/embedded-graphics/src/lib.rs
@@ -113,6 +113,8 @@
 //! // Create a draw target using the builtin MockDisplay. In real applications this would be
 //! // replaced by a draw target that is provided by a display driver crate.
 //! let mut display = MockDisplay::default();
+//! display.set_allow_overdraw(true);
+//! display.set_allow_out_of_bounds_drawing(true);
 //!
 //! let c = Circle::new(Point::new(12, 12), 17).into_styled(PrimitiveStyle::with_fill(Rgb565::RED));
 //! let t = Text::new("Hello Rust!", Point::new(20, 16))
@@ -136,10 +138,6 @@
 //!     style::{PrimitiveStyle, TextStyle},
 //! };
 //!
-//! // Create a draw target using the builtin MockDisplay. In real applications this would be
-//! // replaced by a draw target that is provided by a display driver crate.
-//! let mut display: MockDisplay<Rgb565> = MockDisplay::default();
-//!
 //! fn build_thing(text: &'static str) -> impl Iterator<Item = Pixel<Rgb565>> {
 //!     Rectangle::new(Point::new(0, 0), Size::new(40, 40))
 //!         .into_styled(PrimitiveStyle::with_stroke(Rgb565::CYAN, 1))
@@ -155,6 +153,8 @@
 //! }
 //!
 //! # let mut display = MockDisplay::default();
+//! # display.set_allow_overdraw(true);
+//! # display.set_allow_out_of_bounds_drawing(true);
 //! build_thing("Hello Rust!").draw(&mut display)?;
 //! # Ok::<(), core::convert::Infallible>(())
 //! ```
@@ -173,6 +173,7 @@
 //!
 //! ```rust
 //! # let mut display = embedded_graphics::mock_display::MockDisplay::default();
+//! # display.set_allow_overdraw(true);
 //! use embedded_graphics::{
 //!     pixelcolor::Rgb888,
 //!     prelude::*,
@@ -195,6 +196,7 @@
 //!
 //! ```rust
 //! # let mut display = embedded_graphics::mock_display::MockDisplay::default();
+//! # display.set_allow_overdraw(true);
 //! use embedded_graphics::{
 //!     pixelcolor::Rgb888,
 //!     prelude::*,
@@ -221,6 +223,7 @@
 //!
 //! ```rust
 //! # let mut display = embedded_graphics::mock_display::MockDisplay::default();
+//! # display.set_allow_overdraw(true);
 //! use embedded_graphics::{
 //!     pixelcolor::Rgb888,
 //!     prelude::*,
@@ -253,6 +256,7 @@
 //!
 //! ```rust
 //! # let mut display = embedded_graphics::mock_display::MockDisplay::default();
+//! # display.set_allow_overdraw(true);
 //! use embedded_graphics::{
 //!     pixelcolor::Rgb888,
 //!     prelude::*,
@@ -279,6 +283,7 @@
 //!
 //! ```rust
 //! # let mut display = embedded_graphics::mock_display::MockDisplay::default();
+//! # display.set_allow_overdraw(true);
 //! use embedded_graphics::{
 //!     pixelcolor::Rgb888,
 //!     prelude::*,
@@ -305,6 +310,7 @@
 //!
 //! ```rust
 //! # let mut display = embedded_graphics::mock_display::MockDisplay::default();
+//! # display.set_allow_overdraw(true);
 //! use embedded_graphics::{
 //!     pixelcolor::Rgb888,
 //!     prelude::*,
@@ -331,6 +337,7 @@
 //!
 //! ```rust
 //! # let mut display = embedded_graphics::mock_display::MockDisplay::default();
+//! # display.set_allow_overdraw(true);
 //! use embedded_graphics::{
 //!     pixelcolor::Rgb888,
 //!     prelude::*,
@@ -365,6 +372,7 @@
 //!
 //! ```rust
 //! # let mut display = embedded_graphics::mock_display::MockDisplay::default();
+//! # display.set_allow_overdraw(true);
 //! use embedded_graphics::{
 //!     pixelcolor::Rgb888,
 //!     prelude::*,
@@ -403,6 +411,7 @@
 //!
 //! ```rust
 //! # let mut display = embedded_graphics::mock_display::MockDisplay::default();
+//! # display.set_allow_overdraw(true);
 //! use embedded_graphics::{
 //!     fonts::{
 //!         Font6x8,
@@ -432,6 +441,7 @@
 //!
 //! ```rust
 //! # let mut display = embedded_graphics::mock_display::MockDisplay::default();
+//! # display.set_allow_overdraw(true);
 //! use embedded_graphics::{
 //!     image::Image,
 //!     pixelcolor::Rgb888,

--- a/embedded-graphics/src/mock_display.rs
+++ b/embedded-graphics/src/mock_display.rs
@@ -253,6 +253,10 @@ where
     ///
     /// # Examples
     ///
+    /// Invert a `MockDisplay` by applying [`BinaryColor::invert`] to the color of each pixel.
+    ///
+    /// [`BinaryColor::invert`]: ../pixelcolor/enum.BinaryColor.html#method.invert
+    ///
     /// ```
     /// use embedded_graphics::{mock_display::MockDisplay, pixelcolor::BinaryColor};
     ///
@@ -416,10 +420,8 @@ where
             }
         }
 
-        if !self.allow_overdraw {
-            if self.get_pixel(point).is_some() {
-                panic!("tried to draw pixel twice (x: {}, y: {})", point.x, point.y);
-            }
+        if !self.allow_overdraw && self.get_pixel(point).is_some() {
+            panic!("tried to draw pixel twice (x: {}, y: {})", point.x, point.y);
         }
 
         self.set_pixel(point, Some(color));

--- a/embedded-graphics/src/primitives/circle.rs
+++ b/embedded-graphics/src/primitives/circle.rs
@@ -24,9 +24,9 @@ use crate::{
 ///     style::{PrimitiveStyle, PrimitiveStyleBuilder},
 /// };
 /// # use embedded_graphics::mock_display::MockDisplay;
-/// # let mut display = MockDisplay::default();
 ///
 /// // Circle with 1 pixel wide white stroke with top-left point at (10, 20) with a diameter of 30
+/// # let mut display = MockDisplay::default();
 /// Circle::new(Point::new(10, 20), 30)
 ///     .into_styled(PrimitiveStyle::with_stroke(Rgb565::WHITE, 1))
 ///     .draw(&mut display)?;
@@ -38,13 +38,15 @@ use crate::{
 ///     .fill_color(Rgb565::GREEN)
 ///     .build();
 ///
-/// Circle::new(Point::new(50, 20), 30)
+/// # let mut display = MockDisplay::default();
+/// Circle::new(Point::new(50, 20), 10)
 ///     .into_styled(style)
 ///     .draw(&mut display)?;
 ///
 /// // Circle with blue fill and no stroke with a translation applied
+/// # let mut display = MockDisplay::default();
 /// Circle::new(Point::new(10, 20), 30)
-///     .translate(Point::new(65, 35))
+///     .translate(Point::new(20, 10))
 ///     .into_styled(PrimitiveStyle::with_fill(Rgb565::BLUE))
 ///     .draw(&mut display)?;
 /// # Ok::<(), core::convert::Infallible>(())

--- a/embedded-graphics/src/primitives/ellipse.rs
+++ b/embedded-graphics/src/primitives/ellipse.rs
@@ -24,27 +24,29 @@ use crate::{
 ///     style::{PrimitiveStyle, PrimitiveStyleBuilder},
 /// };
 /// # use embedded_graphics::mock_display::MockDisplay;
-/// # let mut display = MockDisplay::default();
 ///
-/// // Ellipse with 1 pixel wide white stroke with top-left point at (10, 20) with a size of (30, 50)
-/// Ellipse::new(Point::new(10, 20), Size::new(30, 50))
+/// // Ellipse with 1 pixel wide white stroke with top-left point at (10, 20) with a size of (30, 40)
+/// # let mut display = MockDisplay::default();
+/// Ellipse::new(Point::new(10, 20), Size::new(30, 40))
 ///     .into_styled(PrimitiveStyle::with_stroke(Rgb565::WHITE, 1))
 ///     .draw(&mut display)?;
 ///
-/// // Ellipse with styled stroke and fill with top-left point at (50, 20) with a size of (40, 30)
+/// // Ellipse with styled stroke and fill with top-left point at (20, 30) with a size of (40, 30)
 /// let style = PrimitiveStyleBuilder::new()
 ///     .stroke_color(Rgb565::RED)
 ///     .stroke_width(3)
 ///     .fill_color(Rgb565::GREEN)
 ///     .build();
 ///
-/// Ellipse::new(Point::new(50, 20), Size::new(40, 30))
+/// # let mut display = MockDisplay::default();
+/// Ellipse::new(Point::new(20, 30), Size::new(40, 30))
 ///     .into_styled(style)
 ///     .draw(&mut display)?;
 ///
 /// // Ellipse with blue fill and no stroke with a translation applied
+/// # let mut display = MockDisplay::default();
 /// Ellipse::new(Point::new(10, 20), Size::new(20, 40))
-///     .translate(Point::new(65, 35))
+///     .translate(Point::new(10, -15))
 ///     .into_styled(PrimitiveStyle::with_fill(Rgb565::BLUE))
 ///     .draw(&mut display)?;
 /// # Ok::<(), core::convert::Infallible>(())
@@ -361,14 +363,16 @@ mod tests {
 
     fn test_circles(style: PrimitiveStyle<BinaryColor>) {
         for diameter in 0..50 {
+            let top_left = Point::new_equal(style.stroke_width_i32());
+
             let mut expected = MockDisplay::new();
-            Circle::new(Point::new(0, 0), diameter)
+            Circle::new(top_left, diameter)
                 .into_styled(style)
                 .draw(&mut expected)
                 .unwrap();
 
             let mut display = MockDisplay::new();
-            Ellipse::new(Point::new(0, 0), Size::new(diameter, diameter))
+            Ellipse::new(top_left, Size::new(diameter, diameter))
                 .into_styled(style)
                 .draw(&mut display)
                 .unwrap();

--- a/embedded-graphics/src/primitives/line.rs
+++ b/embedded-graphics/src/primitives/line.rs
@@ -38,7 +38,7 @@ pub use styled_iterator::StyledIterator;
 ///
 /// // Green 10 pixel wide line with translation applied
 /// Line::new(Point::new(50, 20), Point::new(60, 35))
-///     .translate(Point::new(65, 35))
+///     .translate(Point::new(-30, 10))
 ///     .into_styled(PrimitiveStyle::with_stroke(Rgb565::GREEN, 10))
 ///     .draw(&mut display)?;
 /// # Ok::<(), core::convert::Infallible>(())

--- a/embedded-graphics/src/primitives/polyline.rs
+++ b/embedded-graphics/src/primitives/polyline.rs
@@ -30,6 +30,7 @@ use crate::{
 /// };
 /// # use embedded_graphics::mock_display::MockDisplay;
 /// # let mut display = MockDisplay::default();
+/// # display.set_allow_out_of_bounds_drawing(true);
 ///
 /// // A "heartbeat" shaped polyline
 /// let points: [Point; 10] = [

--- a/embedded-graphics/src/primitives/rectangle.rs
+++ b/embedded-graphics/src/primitives/rectangle.rs
@@ -24,20 +24,21 @@ use core::cmp::min;
 /// # use embedded_graphics::mock_display::MockDisplay;
 /// # let mut display = MockDisplay::default();
 ///
-/// // Rectangle with red 3 pixel wide stroke and green fill from (50, 20) to (60, 35)
+/// // Rectangle with red 3 pixel wide stroke and green fill with the top left corner at (30, 20) and
+/// // a size of (10, 15)
 /// let style = PrimitiveStyleBuilder::new()
 ///     .stroke_color(Rgb565::RED)
 ///     .stroke_width(3)
 ///     .fill_color(Rgb565::GREEN)
 ///     .build();
 ///
-/// Rectangle::new(Point::new(50, 20), Size::new(10, 15))
+/// Rectangle::new(Point::new(30, 20), Size::new(10, 15))
 ///     .into_styled(style)
 ///     .draw(&mut display)?;
 ///
 /// // Rectangle with translation applied
-/// Rectangle::new(Point::new(50, 20), Size::new(10, 15))
-///     .translate(Point::new(65, 35))
+/// Rectangle::new(Point::new(30, 20), Size::new(10, 15))
+///     .translate(Point::new(-20, -10))
 ///     .into_styled(style)
 ///     .draw(&mut display)?;
 /// # Ok::<(), core::convert::Infallible>(())

--- a/embedded-graphics/src/primitives/rounded_rectangle.rs
+++ b/embedded-graphics/src/primitives/rounded_rectangle.rs
@@ -60,7 +60,7 @@ use crate::{
 ///     .build();
 ///
 /// RoundedRectangle::with_equal_corners(
-///     Rectangle::new(Point::new(5, 5), Size::new(50, 60)),
+///     Rectangle::new(Point::new(5, 5), Size::new(40, 50)),
 ///     Size::new(10, 10),
 /// )
 /// .into_styled(style)
@@ -91,13 +91,13 @@ use crate::{
 ///     .build();
 ///
 /// let radii = CornerRadiiBuilder::new()
-///     .top_left(Size::new(10, 12))
-///     .top_right(Size::new(14, 16))
-///     .bottom_right(Size::new(18, 20))
-///     .bottom_left(Size::new(22, 24))
+///     .top_left(Size::new(5, 6))
+///     .top_right(Size::new(7, 8))
+///     .bottom_right(Size::new(9, 10))
+///     .bottom_left(Size::new(11, 12))
 ///     .build();
 ///
-/// RoundedRectangle::new(Rectangle::new(Point::new(5, 5), Size::new(50, 60)), radii)
+/// RoundedRectangle::new(Rectangle::new(Point::new(5, 5), Size::new(40, 50)), radii)
 ///     .into_styled(style)
 ///     .draw(&mut display)?;
 /// # Ok::<(), core::convert::Infallible>(())
@@ -131,7 +131,7 @@ use crate::{
 ///     .bottom_right(Size::new(5, 8))
 ///     .build();
 ///
-/// RoundedRectangle::new(Rectangle::new(Point::new(5, 5), Size::new(50, 60)), radii)
+/// RoundedRectangle::new(Rectangle::new(Point::new(5, 5), Size::new(40, 50)), radii)
 ///     .into_styled(style)
 ///     .draw(&mut display)?;
 /// # Ok::<(), core::convert::Infallible>(())

--- a/embedded-graphics/src/primitives/triangle.rs
+++ b/embedded-graphics/src/primitives/triangle.rs
@@ -29,15 +29,16 @@ use core::{
 /// };
 /// # use embedded_graphics::mock_display::MockDisplay;
 /// # let mut display = MockDisplay::default();
+/// # display.set_allow_overdraw(true);
 ///
 /// // Triangle with red 1 px wide stroke
-/// Triangle::new(Point::new(50, 20), Point::new(60, 35), Point::new(70, 80))
+/// Triangle::new(Point::new(40, 20), Point::new(50, 25), Point::new(60, 60))
 ///     .into_styled(PrimitiveStyle::with_stroke(Rgb565::RED, 1))
 ///     .draw(&mut display)?;
 ///
 /// // Triangle with translation applied
-/// Triangle::new(Point::new(50, 20), Point::new(60, 35), Point::new(70, 80))
-///     .translate(Point::new(65, 35))
+/// Triangle::new(Point::new(40, 20), Point::new(50, 25), Point::new(60, 60))
+///     .translate(Point::new(-10, -20))
 ///     .into_styled(PrimitiveStyle::with_stroke(Rgb565::GREEN, 1))
 ///     .draw(&mut display)?;
 /// # Ok::<(), core::convert::Infallible>(())
@@ -538,6 +539,7 @@ mod tests {
     #[test]
     fn stroke_fill_colors() {
         let mut display: MockDisplay<Rgb888> = MockDisplay::new();
+        display.set_allow_overdraw(true);
 
         Triangle::new(Point::new(2, 2), Point::new(8, 2), Point::new(2, 8))
             .into_styled(
@@ -597,6 +599,7 @@ mod tests {
     #[test]
     fn it_draws_filled_strokeless_tri() {
         let mut display: MockDisplay<BinaryColor> = MockDisplay::new();
+        display.set_allow_overdraw(true);
 
         Triangle::new(Point::new(2, 2), Point::new(2, 4), Point::new(4, 2))
             .into_styled(PrimitiveStyle::with_fill(BinaryColor::On))
@@ -674,6 +677,8 @@ mod tests {
     #[test]
     fn issue_308_infinite() {
         let mut display: MockDisplay<BinaryColor> = MockDisplay::new();
+        display.set_allow_overdraw(true);
+        display.set_allow_out_of_bounds_drawing(true);
 
         Triangle::new(Point::new(10, 10), Point::new(20, 30), Point::new(30, -10))
             .into_styled(PrimitiveStyle::with_fill(BinaryColor::On))
@@ -684,6 +689,8 @@ mod tests {
     #[test]
     fn off_screen() {
         let mut display: MockDisplay<BinaryColor> = MockDisplay::new();
+        display.set_allow_overdraw(true);
+        display.set_allow_out_of_bounds_drawing(true);
 
         Triangle::new(Point::new(5, 5), Point::new(10, 15), Point::new(15, -5))
             .into_styled(PrimitiveStyle::with_fill(BinaryColor::On))

--- a/simulator/src/bin/generate-example-screenshots.rs
+++ b/simulator/src/bin/generate-example-screenshots.rs
@@ -55,6 +55,7 @@ macro_rules! op {
 //!
 //! ```rust
 //! # let mut display = embedded_graphics::mock_display::MockDisplay::default();
+//! # display.set_allow_overdraw(true);
 //! {}
 //! # Ok::<(), core::convert::Infallible>(())
 //! ```


### PR DESCRIPTION
Hi! Thank you for helping out with Embedded Graphics development! Please:

- [x] Check that you've added passing tests and documentation
- [x] Add a simulator example(s) where applicable
- [x] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) and appropriate crate (`embedded-graphics`, `simulator`, `tinytga`, `tinybmp`) if your changes affect the **public API**
- [x] Run `rustfmt` on the project
- [x] Run `./build.sh` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

This PR adds the additional checks, we discussed in #356, to `MockDisplay`. I've adjusted some dimensions in the existing tests and examples to make them fit in the 64 px x 64 px display area. IMO this is better than allowing out of bounds drawing for many examples.

In addition to the `MockDisplay` changes the PR also cleans up the font test a bit. Some tests in the fonts were actually tests of the styled text drawable, so I moved them there. The fonts should now only contain tests that are relevant to the individual font.

There might be other tests, for example in the `primitives` module, that could benefit from the new features, but this can be implemented in another PR. There is also some overlap with the changes in #342, so we need to decide which to merge first.

Closes #356.