### PR TITLE
Initial SparseIterator experiment

### DIFF
--- a/embedded-graphics/src/draw_target/mod.rs
+++ b/embedded-graphics/src/draw_target/mod.rs
@@ -302,23 +302,22 @@ pub trait DrawTarget: Dimensions {
     /// [`core::convert::Infallible`]: https://doc.rust-lang.org/stable/core/convert/enum.Infallible.html
     type Error;
 
-    // TODO: Reenable this in a new PR with modified primitives iterators
-    // // TODO: Mention performance
-    // // TODO: Mention default impl behaviour
-    // /// Fill a given area with a transparent pixel iterator.
-    // ///
-    // /// Iteration order is guaranteed from top left to bottom right, however some pixels may be
-    // /// transparent which are represented as `None`.
-    // fn fill_sparse<I>(&mut self, area: &Rectangle, colors: I) -> Result<(), Self::Error>
-    // where
-    //     I: IntoIterator<Item = Option<Self::Color>>,
-    // {
-    //     self.draw_iter(
-    //         area.points()
-    //             .zip(colors)
-    //             .filter_map(|(pos, color)| color.map(|c| Pixel(pos, c))),
-    //     )
-    // }
+    // TODO: Mention performance
+    // TODO: Mention default impl behaviour
+    /// Fill a given area with a transparent pixel iterator.
+    ///
+    /// Iteration order is guaranteed from top left to bottom right, however some pixels may be
+    /// transparent which are represented as `None`.
+    fn fill_sparse<I>(&mut self, area: &Rectangle, colors: I) -> Result<(), Self::Error>
+    where
+        I: IntoIterator<Item = Option<Self::Color>>,
+    {
+        self.draw_iter(
+            area.points()
+                .zip(colors)
+                .filter_map(|(pos, color)| color.map(|c| Pixel(pos, c))),
+        )
+    }
 
     /// Draw individual pixels to the display without a defined order.
     ///

--- a/embedded-graphics/src/iterator/mod.rs
+++ b/embedded-graphics/src/iterator/mod.rs
@@ -58,7 +58,7 @@ where
     I::Item: PixelColor,
 {
     fn into_pixels(self, bounding_box: &Rectangle) -> contiguous::IntoPixels<Self> {
-        contiguous::IntoPixels::new(self, bounding_box.clone())
+        contiguous::IntoPixels::new(self, *bounding_box)
     }
 }
 

--- a/embedded-graphics/src/iterator/mod.rs
+++ b/embedded-graphics/src/iterator/mod.rs
@@ -1,7 +1,11 @@
 //! Iterators.
 
 use crate::{
-    draw_target::DrawTarget, geometry::Point, pixelcolor::PixelColor, primitives::Rectangle, Pixel,
+    draw_target::DrawTarget,
+    geometry::{Dimensions, Point},
+    pixelcolor::PixelColor,
+    primitives::Rectangle,
+    Pixel,
 };
 
 pub mod contiguous;
@@ -29,18 +33,17 @@ pub trait IntoPixels {
     fn into_pixels(self) -> Self::Iter;
 }
 
-// TODO: Implement as part of a new PR for sparse pixel iterators
-// ///  TODO: Doc
-// pub trait IntoSparsePixels<C>
-// where
-//     C: PixelColor,
-// {
-//     ///  TODO: Doc
-//     type Iter: Iterator<Item = Option<C>> + Dimensions;
+///  TODO: Doc
+pub trait IntoSparsePixels {
+    /// TODO: Doc
+    type Color: PixelColor;
 
-//     ///  TODO: Doc
-//     fn into_sparse_pixels(self) -> Self::Iter;
-// }
+    ///  TODO: Doc
+    type Iter: Iterator<Item = Option<Self::Color>> + Dimensions;
+
+    ///  TODO: Doc
+    fn into_sparse_pixels(self) -> Self::Iter;
+}
 
 /// Extension trait for contiguous iterators.
 pub trait ContiguousIteratorExt

--- a/embedded-graphics/src/primitives/filtered_iterator.rs
+++ b/embedded-graphics/src/primitives/filtered_iterator.rs
@@ -1,0 +1,45 @@
+use crate::{
+    pixelcolor::PixelColor,
+    primitives::{
+        rectangle::{self, Rectangle},
+        Primitive,
+    },
+    Pixel,
+};
+use core::iter::Zip;
+
+/// TODO: Doc
+#[derive(Debug, Clone)]
+pub struct FilteredIterator<C, I>
+where
+    C: PixelColor,
+    I: Iterator<Item = Option<C>>,
+{
+    iter: Zip<rectangle::Points, I>,
+}
+
+impl<C, I> FilteredIterator<C, I>
+where
+    C: PixelColor,
+    I: Iterator<Item = Option<C>>,
+{
+    /// TODO: Doc
+    pub fn new(sparse_iter: I, bounding_box: Rectangle) -> Self {
+        let iter = bounding_box.points().zip(sparse_iter);
+
+        Self { iter }
+    }
+}
+
+impl<C, I> Iterator for FilteredIterator<C, I>
+where
+    C: PixelColor,
+    I: Iterator<Item = Option<C>>,
+{
+    type Item = Pixel<C>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter
+            .find_map(|(point, color)| color.map(|c| Pixel(point, c)))
+    }
+}

--- a/embedded-graphics/src/primitives/mod.rs
+++ b/embedded-graphics/src/primitives/mod.rs
@@ -3,6 +3,7 @@
 pub mod arc;
 pub mod circle;
 pub mod ellipse;
+mod filtered_iterator;
 pub mod line;
 pub mod polyline;
 pub mod rectangle;


### PR DESCRIPTION
Hi! Thank you for helping out with Embedded Graphics development! Please:

- [ ] Check that you've added passing tests and documentation
- [ ] Add a simulator example(s) where applicable
- [ ] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) and appropriate crate (`embedded-graphics`, `simulator`, `tinytga`, `tinybmp`) if your changes affect the **public API**
- [ ] Run `rustfmt` on the project
- [ ] Run `./build.sh` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

Experiments with adding a `SparseIterator` struct which wraps a non-contiguous iterator into something that produces an `Option<C>` for each point in a rectangular area. This is the first idea that came to mind and it might be completely the wrong approach, but either way it would be great to get some feedback.

Closes #330 
