### PR TITLE
Remove redundant PixelColor trait bounds

### DIFF
--- a/embedded-graphics/src/drawable.rs
+++ b/embedded-graphics/src/drawable.rs
@@ -97,7 +97,9 @@ where
 /// [`Drawable`]: trait.Drawable.html
 /// [`DrawTarget`]: ./trait.DrawTarget.html
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
-pub struct Pixel<C: PixelColor>(pub Point, pub C);
+pub struct Pixel<C>(pub Point, pub C)
+where
+    C: PixelColor;
 
 impl<C> Drawable<C> for Pixel<C>
 where

--- a/embedded-graphics/src/primitives/line/styled.rs
+++ b/embedded-graphics/src/primitives/line/styled.rs
@@ -16,7 +16,10 @@ where
     line_iter: ThickPoints,
 }
 
-impl<C: PixelColor> StyledPixels<C> {
+impl<C> StyledPixels<C>
+where
+    C: PixelColor,
+{
     pub(in crate::primitives::line) fn new(styled: &Styled<Line, PrimitiveStyle<C>>) -> Self {
         let Styled { primitive, style } = styled;
 
@@ -31,7 +34,10 @@ impl<C: PixelColor> StyledPixels<C> {
 }
 
 // [Bresenham's line algorithm](https://en.wikipedia.org/wiki/Bresenham%27s_line_algorithm)
-impl<C: PixelColor> Iterator for StyledPixels<C> {
+impl<C> Iterator for StyledPixels<C>
+where
+    C: PixelColor,
+{
     type Item = Pixel<C>;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/embedded-graphics/src/primitives/rectangle/styled.rs
+++ b/embedded-graphics/src/primitives/rectangle/styled.rs
@@ -13,7 +13,7 @@ use crate::{
 
 /// Pixel iterator for each pixel in the rect border
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
-pub struct StyledPixels<C: PixelColor>
+pub struct StyledPixels<C>
 where
     C: PixelColor,
 {

--- a/embedded-graphics/src/primitives/triangle/styled.rs
+++ b/embedded-graphics/src/primitives/triangle/styled.rs
@@ -11,7 +11,7 @@ use crate::{
 
 /// Pixel iterator for each pixel in the triangle border
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
-pub struct StyledPixels<C: PixelColor>
+pub struct StyledPixels<C>
 where
     C: PixelColor,
 {


### PR DESCRIPTION
Hi! Thank you for helping out with Embedded Graphics development! Please:

- [ ] Check that you've added passing tests and documentation
- [ ] Add a simulator example(s) where applicable
- [ ] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) and appropriate crate (`embedded-graphics`, `simulator`, `tinytga`, `tinybmp`) if your changes affect the **public API**
- [ ] Run `rustfmt` on the project
- [ ] Run `./build.sh` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

This PR removes some redundant `PixelColor` trait bounds and makes all of them use the `where` syntax.