### PR TITLE
Rename intoiterator

### DIFF
--- a/embedded-graphics/CHANGELOG.md
+++ b/embedded-graphics/CHANGELOG.md
@@ -42,6 +42,7 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 - **(breaking)** [#360](https://github.com/jamwaffles/embedded-graphics/pull/360) Make the `drawable` module private. `drawable::Drawable` and `drawable::Pixel` are now exported from the crate root.
 - **(breaking)** [#390](https://github.com/jamwaffles/embedded-graphics/pull/390) `Triangle.contains` now always returns `false` for colinear triangles.
 - **(breaking)** [#393](https://github.com/jamwaffles/embedded-graphics/pull/393) `DrawTarget::draw` now uses a reference to `self` instead of taking ownership of `self`. Because of this change `DrawTarget` can no longer be implemented for pixel iterators (`Iterator<Item = C>`), which can now be drawn using the `draw` method provided by the `PixelIteratorExt` extension trait.
+- **(breaking)** [#383](https://github.com/jamwaffles/embedded-graphics/pull/383) Replaced all `IntoIterator` impls with a custom `IntoPixels` trait. To get an iterator over pixels in an item, replace calls to `into_iter()` with `into_pixels()`.
 
 ### Fixed
 

--- a/embedded-graphics/src/fonts/text.rs
+++ b/embedded-graphics/src/fonts/text.rs
@@ -2,6 +2,7 @@ use crate::{
     drawable::{Drawable, Pixel},
     fonts::Font,
     geometry::{Dimensions, Point, Size},
+    pixel_iterator::IntoPixels,
     pixelcolor::PixelColor,
     primitives::Rectangle,
     style::{Styled, TextStyle},
@@ -73,20 +74,19 @@ where
     where
         D: DrawTarget<Color = C>,
     {
-        display.draw_iter(self.into_iter())
+        display.draw_iter(self.into_pixels())
     }
 }
 
-impl<'a, C, F> IntoIterator for &Styled<Text<'a>, TextStyle<C, F>>
+impl<'a, C, F> IntoPixels<C> for &Styled<Text<'a>, TextStyle<C, F>>
 where
     C: PixelColor,
     F: Font + Copy,
 {
-    type Item = Pixel<C>;
-    type IntoIter = StyledTextIterator<'a, C, F>;
+    type Iter = StyledTextIterator<'a, C, F>;
 
-    fn into_iter(self) -> Self::IntoIter {
-        Self::IntoIter {
+    fn into_pixels(self) -> Self::Iter {
+        Self::Iter {
             current_char: self.primitive.text.chars().next(),
             idx: 0,
             text: self.primitive.text,
@@ -411,7 +411,7 @@ mod tests {
         let mut text = Text::new("Testing string", Point::zero()).into_styled(style);
         text.translate_mut(Point::new(0, -12));
 
-        assert_eq!(text.into_iter().count(), 6 * 12 * "Testing string".len());
+        assert_eq!(text.into_pixels().count(), 6 * 12 * "Testing string".len());
     }
 
     #[test]
@@ -425,6 +425,6 @@ mod tests {
         let mut text = Text::new("A", Point::zero()).into_styled(style);
         text.translate_mut(Point::new(-6, 0));
 
-        assert_eq!(text.into_iter().count(), 6 * 12);
+        assert_eq!(text.into_pixels().count(), 6 * 12);
     }
 }

--- a/embedded-graphics/src/fonts/text.rs
+++ b/embedded-graphics/src/fonts/text.rs
@@ -78,11 +78,13 @@ where
     }
 }
 
-impl<'a, C, F> IntoPixels<C> for &Styled<Text<'a>, TextStyle<C, F>>
+impl<'a, C, F> IntoPixels for &Styled<Text<'a>, TextStyle<C, F>>
 where
     C: PixelColor,
     F: Font + Copy,
 {
+    type Color = C;
+
     type Iter = StyledTextIterator<'a, C, F>;
 
     fn into_pixels(self) -> Self::Iter {

--- a/embedded-graphics/src/geometry/size.rs
+++ b/embedded-graphics/src/geometry/size.rs
@@ -172,7 +172,7 @@ impl Size {
     }
 
     /// Creates a size from two corner points of a bounding box.
-    pub(crate) fn from_bounding_box(corner_1: Point, corner_2: Point) -> Self {
+    pub(crate) const fn from_bounding_box(corner_1: Point, corner_2: Point) -> Self {
         let width = (corner_1.x - corner_2.x).abs() as u32 + 1;
         let height = (corner_1.y - corner_2.y).abs() as u32 + 1;
 

--- a/embedded-graphics/src/image/mod.rs
+++ b/embedded-graphics/src/image/mod.rs
@@ -220,7 +220,7 @@ where
 impl<'a, 'b: 'a, I, C> IntoPixels<C> for &'a Image<'b, I, C>
 where
     &'b I: IntoPixelIter<C>,
-    C: PixelColor + From<<C as PixelColor>::Raw> + 'a,
+    C: PixelColor + From<<C as PixelColor>::Raw>,
 {
     type Iter = ImageIterator<'a, 'b, I, C>;
 

--- a/embedded-graphics/src/image/mod.rs
+++ b/embedded-graphics/src/image/mod.rs
@@ -297,7 +297,7 @@ mod tests {
             Pixel(Point::new(1, 1), Gray8::new(0xaa)),
         ];
 
-        assert!(image.into_pixels().eq(expected.iter().copied()));
+        assert!(image.pixels().eq(expected.iter().copied()));
     }
 
     #[test]

--- a/embedded-graphics/src/image/mod.rs
+++ b/embedded-graphics/src/image/mod.rs
@@ -51,6 +51,7 @@ use crate::{
     draw_target::DrawTarget,
     drawable::{Drawable, Pixel},
     geometry::{Dimensions, Point, Size},
+    pixel_iterator::Pixels,
     pixelcolor::PixelColor,
     primitives::Rectangle,
     transform::Transform,
@@ -200,7 +201,7 @@ where
     where
         D: DrawTarget<Color = C>,
     {
-        display.fill_contiguous(&self.bounding_box(), self.into_iter().map(|p| p.1))
+        display.fill_contiguous(&self.bounding_box(), self.pixels().map(|p| p.1))
     }
 }
 
@@ -216,15 +217,14 @@ where
     }
 }
 
-impl<'a, 'b, I, C> IntoIterator for &'a Image<'b, I, C>
+impl<'a, 'b: 'a, I, C> Pixels<'a, C> for Image<'b, I, C>
 where
     &'b I: IntoPixelIter<C>,
-    C: PixelColor + From<<C as PixelColor>::Raw>,
+    C: PixelColor + From<<C as PixelColor>::Raw> + 'a,
 {
-    type Item = Pixel<C>;
-    type IntoIter = ImageIterator<'a, 'b, I, C>;
+    type Iter = ImageIterator<'a, 'b, I, C>;
 
-    fn into_iter(self) -> Self::IntoIter {
+    fn pixels(&'a self) -> Self::Iter {
         ImageIterator {
             it: self.image_data.pixel_iter(),
             image: self,
@@ -296,7 +296,7 @@ mod tests {
             Pixel(Point::new(1, 1), Gray8::new(0xaa)),
         ];
 
-        assert!(image.into_iter().eq(expected.iter().copied()));
+        assert!(image.pixels().eq(expected.iter().copied()));
     }
 
     #[test]

--- a/embedded-graphics/src/image/mod.rs
+++ b/embedded-graphics/src/image/mod.rs
@@ -51,7 +51,7 @@ use crate::{
     draw_target::DrawTarget,
     drawable::{Drawable, Pixel},
     geometry::{Dimensions, Point, Size},
-    pixel_iterator::{IntoPixels, Pixels},
+    pixel_iterator::IntoPixels,
     pixelcolor::PixelColor,
     primitives::Rectangle,
     transform::Transform,
@@ -201,7 +201,7 @@ where
     where
         D: DrawTarget<Color = C>,
     {
-        display.fill_contiguous(&self.bounding_box(), self.pixels().map(|p| p.1))
+        display.fill_contiguous(&self.bounding_box(), self.into_pixels().map(|p| p.1))
     }
 }
 
@@ -272,7 +272,6 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::pixel_iterator::Pixels;
     use crate::pixelcolor::{BinaryColor, Gray8, GrayColor};
 
     #[test]
@@ -297,7 +296,7 @@ mod tests {
             Pixel(Point::new(1, 1), Gray8::new(0xaa)),
         ];
 
-        assert!(image.pixels().eq(expected.iter().copied()));
+        assert!(image.into_pixels().eq(expected.iter().copied()));
     }
 
     #[test]

--- a/embedded-graphics/src/image/mod.rs
+++ b/embedded-graphics/src/image/mod.rs
@@ -51,7 +51,7 @@ use crate::{
     draw_target::DrawTarget,
     drawable::{Drawable, Pixel},
     geometry::{Dimensions, Point, Size},
-    pixel_iterator::Pixels,
+    pixel_iterator::{IntoPixels, Pixels},
     pixelcolor::PixelColor,
     primitives::Rectangle,
     transform::Transform,
@@ -217,14 +217,14 @@ where
     }
 }
 
-impl<'a, 'b: 'a, I, C> Pixels<'a, C> for Image<'b, I, C>
+impl<'a, 'b: 'a, I, C> IntoPixels<C> for &'a Image<'b, I, C>
 where
     &'b I: IntoPixelIter<C>,
     C: PixelColor + From<<C as PixelColor>::Raw> + 'a,
 {
     type Iter = ImageIterator<'a, 'b, I, C>;
 
-    fn pixels(&'a self) -> Self::Iter {
+    fn into_pixels(self) -> Self::Iter {
         ImageIterator {
             it: self.image_data.pixel_iter(),
             image: self,
@@ -272,6 +272,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::pixel_iterator::Pixels;
     use crate::pixelcolor::{BinaryColor, Gray8, GrayColor};
 
     #[test]
@@ -296,7 +297,7 @@ mod tests {
             Pixel(Point::new(1, 1), Gray8::new(0xaa)),
         ];
 
-        assert!(image.pixels().eq(expected.iter().copied()));
+        assert!(image.into_pixels().eq(expected.iter().copied()));
     }
 
     #[test]

--- a/embedded-graphics/src/image/mod.rs
+++ b/embedded-graphics/src/image/mod.rs
@@ -217,7 +217,7 @@ where
     }
 }
 
-impl<'a, 'b: 'a, I, C> IntoPixels for &'a Image<'b, I, C>
+impl<'a, 'b, I, C> IntoPixels for &'a Image<'b, I, C>
 where
     &'b I: IntoPixelIter<C>,
     C: PixelColor + From<<C as PixelColor>::Raw>,

--- a/embedded-graphics/src/image/mod.rs
+++ b/embedded-graphics/src/image/mod.rs
@@ -217,11 +217,13 @@ where
     }
 }
 
-impl<'a, 'b: 'a, I, C> IntoPixels<C> for &'a Image<'b, I, C>
+impl<'a, 'b: 'a, I, C> IntoPixels for &'a Image<'b, I, C>
 where
     &'b I: IntoPixelIter<C>,
     C: PixelColor + From<<C as PixelColor>::Raw>,
 {
+    type Color = C;
+
     type Iter = ImageIterator<'a, 'b, I, C>;
 
     fn into_pixels(self) -> Self::Iter {

--- a/embedded-graphics/src/lib.rs
+++ b/embedded-graphics/src/lib.rs
@@ -159,8 +159,9 @@
 //!                 .into_styled(PrimitiveStyle::with_fill(Rgb565::RED)),
 //!         )
 //!         .chain(
-//!             &Text::new(text, Point::new(20, 16))
-//!                 .into_styled(TextStyle::new(Font6x8, Rgb565::GREEN)),
+//!             Text::new(text, Point::new(20, 16))
+//!                 .into_styled(TextStyle::new(Font6x8, Rgb565::GREEN))
+//!                 .into_pixels(),
 //!         )
 //! }
 //!

--- a/embedded-graphics/src/lib.rs
+++ b/embedded-graphics/src/lib.rs
@@ -153,7 +153,7 @@
 //! fn build_thing(text: &'static str) -> impl Iterator<Item = Pixel<Rgb565>> {
 //!     Rectangle::new(Point::new(0, 0), Size::new(40, 40))
 //!         .into_styled(PrimitiveStyle::with_stroke(Rgb565::CYAN, 1))
-//!         .pixels()
+//!         .into_pixels()
 //!         .chain(
 //!             &Circle::new(Point::new(12, 12), 17)
 //!                 .into_styled(PrimitiveStyle::with_fill(Rgb565::RED)),

--- a/embedded-graphics/src/lib.rs
+++ b/embedded-graphics/src/lib.rs
@@ -153,7 +153,7 @@
 //! fn build_thing(text: &'static str) -> impl Iterator<Item = Pixel<Rgb565>> {
 //!     Rectangle::new(Point::new(0, 0), Size::new(40, 40))
 //!         .into_styled(PrimitiveStyle::with_stroke(Rgb565::CYAN, 1))
-//!         .into_iter()
+//!         .pixels()
 //!         .chain(
 //!             &Circle::new(Point::new(12, 12), 17)
 //!                 .into_styled(PrimitiveStyle::with_fill(Rgb565::RED)),

--- a/embedded-graphics/src/lib.rs
+++ b/embedded-graphics/src/lib.rs
@@ -155,8 +155,9 @@
 //!         .into_styled(PrimitiveStyle::with_stroke(Rgb565::CYAN, 1))
 //!         .into_pixels()
 //!         .chain(
-//!             &Circle::new(Point::new(12, 12), 17)
-//!                 .into_styled(PrimitiveStyle::with_fill(Rgb565::RED)),
+//!             Circle::new(Point::new(12, 12), 17)
+//!                 .into_styled(PrimitiveStyle::with_fill(Rgb565::RED))
+//!                 .into_pixels(),
 //!         )
 //!         .chain(
 //!             Text::new(text, Point::new(20, 16))

--- a/embedded-graphics/src/lib.rs
+++ b/embedded-graphics/src/lib.rs
@@ -153,7 +153,7 @@
 //! fn build_thing(text: &'static str) -> impl Iterator<Item = Pixel<Rgb565>> {
 //!     Rectangle::new(Point::new(0, 0), Size::new(40, 40))
 //!         .into_styled(PrimitiveStyle::with_stroke(Rgb565::CYAN, 1))
-//!         .into_pixels()
+//!         .pixels()
 //!         .chain(
 //!             &Circle::new(Point::new(12, 12), 17)
 //!                 .into_styled(PrimitiveStyle::with_fill(Rgb565::RED)),

--- a/embedded-graphics/src/pixel_iterator.rs
+++ b/embedded-graphics/src/pixel_iterator.rs
@@ -29,25 +29,25 @@ where
 }
 
 /// Pixel iterator trait
-pub trait IntoPixelIterator<C>
+pub trait Pixels<'a, C>
 where
     C: PixelColor,
 {
     /// TODO: Doc
-    type Iter: Iterator<Item = Pixel<C>>;
+    type Iter: Iterator<Item = Pixel<C>> + 'a;
 
     /// TODO: Doc
-    fn pixels(self) -> Self::Iter;
+    fn pixels(&'a self) -> Self::Iter;
 }
 
 /// Sparse pixel iterator
-pub trait IntoSparsePixelIterator<C>
+pub trait SparsePixels<'a, C>
 where
     C: PixelColor,
 {
     ///  TODO: Doc
-    type Iter: Iterator<Item = Option<C>> + Dimensions;
+    type Iter: Iterator<Item = Option<C>> + Dimensions + 'a;
 
     /// TODO: Doc
-    fn sparse_pixels(self) -> Self::Iter;
+    fn sparse_pixels(&'a self) -> Self::Iter;
 }

--- a/embedded-graphics/src/pixel_iterator.rs
+++ b/embedded-graphics/src/pixel_iterator.rs
@@ -1,7 +1,7 @@
 //! Pixel iterator
 
 use crate::drawable::Pixel;
-use crate::primitives::rectangle::Rectangle;
+use crate::geometry::Dimensions;
 use crate::{pixelcolor::PixelColor, DrawTarget};
 
 /// Extension trait for pixel iterators.
@@ -29,7 +29,7 @@ where
 }
 
 /// Pixel iterator trait
-pub trait PixelIterator<C>
+pub trait IntoPixelIterator<C>
 where
     C: PixelColor,
 {
@@ -41,13 +41,13 @@ where
 }
 
 /// Sparse pixel iterator
-pub trait SparsePixelIterator<C>
+pub trait IntoSparsePixelIterator<C>
 where
     C: PixelColor,
 {
     ///  TODO: Doc
-    type Iter: Iterator<Item = Option<C>>;
+    type Iter: Iterator<Item = Option<C>> + Dimensions;
 
     /// TODO: Doc
-    fn sparse_pixels(self) -> (Rectangle, Self::Iter);
+    fn sparse_pixels(self) -> Self::Iter;
 }

--- a/embedded-graphics/src/pixel_iterator.rs
+++ b/embedded-graphics/src/pixel_iterator.rs
@@ -1,7 +1,6 @@
 //! Pixel iterator
 
 use crate::drawable::Pixel;
-use crate::geometry::Dimensions;
 use crate::{pixelcolor::PixelColor, DrawTarget};
 
 /// Extension trait for pixel iterators.

--- a/embedded-graphics/src/pixel_iterator.rs
+++ b/embedded-graphics/src/pixel_iterator.rs
@@ -28,12 +28,14 @@ where
 }
 
 ///  TODO: Doc
-pub trait IntoPixels<C>
-where
-    C: PixelColor,
-{
+pub trait IntoPixels {
+    /// The type of color for each pixel produced by the iterator returned from [`into_pixels`].
+    ///
+    /// [`into_pixels`]: #tymethod.into_pixels
+    type Color: PixelColor;
+
     ///  TODO: Doc
-    type Iter: Iterator<Item = Pixel<C>>;
+    type Iter: Iterator<Item = Pixel<Self::Color>>;
 
     ///  TODO: Doc
     fn into_pixels(self) -> Self::Iter;

--- a/embedded-graphics/src/pixel_iterator.rs
+++ b/embedded-graphics/src/pixel_iterator.rs
@@ -1,6 +1,7 @@
 //! Pixel iterator
 
 use crate::drawable::Pixel;
+use crate::primitives::rectangle::Rectangle;
 use crate::{pixelcolor::PixelColor, DrawTarget};
 
 /// Extension trait for pixel iterators.
@@ -37,4 +38,16 @@ where
 
     /// TODO: Doc
     fn pixels(self) -> Self::Iter;
+}
+
+/// Sparse pixel iterator
+pub trait SparsePixelIterator<C>
+where
+    C: PixelColor,
+{
+    ///  TODO: Doc
+    type Iter: Iterator<Item = Option<C>>;
+
+    /// TODO: Doc
+    fn sparse_pixels(self) -> (Rectangle, Self::Iter);
 }

--- a/embedded-graphics/src/pixel_iterator.rs
+++ b/embedded-graphics/src/pixel_iterator.rs
@@ -27,17 +27,25 @@ where
     }
 }
 
-///  TODO: Doc
+/// Produce an iterator over all pixels in an object.
+///
+/// This trait is implemented for _references_ to all styled items in embedded-graphics, therefore
+/// does not consume the original item.
 pub trait IntoPixels {
     /// The type of color for each pixel produced by the iterator returned from [`into_pixels`].
     ///
     /// [`into_pixels`]: #tymethod.into_pixels
     type Color: PixelColor;
 
-    ///  TODO: Doc
+    /// The iterator produced when calling [`into_pixels`].
+    ///
+    /// [`into_pixels`]: #tymethod.into_pixels
     type Iter: Iterator<Item = Pixel<Self::Color>>;
 
-    ///  TODO: Doc
+    /// Create an iterator over all pixels in the object.
+    ///
+    /// The iterator may return pixels in any order, however it may be beneficial for performance
+    /// reasons to return them starting at the top left corner in row-first order.
     fn into_pixels(self) -> Self::Iter;
 }
 

--- a/embedded-graphics/src/pixel_iterator.rs
+++ b/embedded-graphics/src/pixel_iterator.rs
@@ -28,42 +28,6 @@ where
     }
 }
 
-// /// Pixel iterator trait
-// pub trait Pixels<'a, C>
-// where
-//     C: PixelColor,
-// {
-//     /// TODO: Doc
-//     type Iter: Iterator<Item = Pixel<C>> + 'a;
-
-//     /// TODO: Doc
-//     fn pixels(&'a self) -> Self::Iter;
-// }
-
-// /// Sparse pixel iterator
-// pub trait SparsePixels<'a, C>
-// where
-//     C: PixelColor,
-// {
-//     ///  TODO: Doc
-//     type Iter: Iterator<Item = Option<C>> + Dimensions + 'a;
-
-//     /// TODO: Doc
-//     fn sparse_pixels(&'a self) -> Self::Iter;
-// }
-
-///  TODO: Doc
-pub trait Pixels<C>
-where
-    C: PixelColor,
-{
-    ///  TODO: Doc
-    type Iter: Iterator<Item = Pixel<C>>;
-
-    ///  TODO: Doc
-    fn pixels(self) -> Self::Iter;
-}
-
 ///  TODO: Doc
 pub trait IntoPixels<C>
 where
@@ -76,14 +40,15 @@ where
     fn into_pixels(self) -> Self::Iter;
 }
 
-impl<'a, C, T> Pixels<C> for &'a T
-where
-    &'a T: IntoPixels<C>,
-    C: PixelColor,
-{
-    type Iter = <Self as IntoPixels<C>>::Iter;
+// TODO: Implement as part of a new PR for sparse pixel iterators
+// ///  TODO: Doc
+// pub trait IntoSparsePixels<C>
+// where
+//     C: PixelColor,
+// {
+//     ///  TODO: Doc
+//     type Iter: Iterator<Item = Option<C>> + Dimensions;
 
-    fn pixels(self) -> Self::Iter {
-        self.into_pixels()
-    }
-}
+//     ///  TODO: Doc
+//     fn into_sparse_pixels(self) -> Self::Iter;
+// }

--- a/embedded-graphics/src/pixel_iterator.rs
+++ b/embedded-graphics/src/pixel_iterator.rs
@@ -28,26 +28,62 @@ where
     }
 }
 
-/// Pixel iterator trait
-pub trait Pixels<'a, C>
-where
-    C: PixelColor,
-{
-    /// TODO: Doc
-    type Iter: Iterator<Item = Pixel<C>> + 'a;
+// /// Pixel iterator trait
+// pub trait Pixels<'a, C>
+// where
+//     C: PixelColor,
+// {
+//     /// TODO: Doc
+//     type Iter: Iterator<Item = Pixel<C>> + 'a;
 
-    /// TODO: Doc
-    fn pixels(&'a self) -> Self::Iter;
-}
+//     /// TODO: Doc
+//     fn pixels(&'a self) -> Self::Iter;
+// }
 
-/// Sparse pixel iterator
-pub trait SparsePixels<'a, C>
+// /// Sparse pixel iterator
+// pub trait SparsePixels<'a, C>
+// where
+//     C: PixelColor,
+// {
+//     ///  TODO: Doc
+//     type Iter: Iterator<Item = Option<C>> + Dimensions + 'a;
+
+//     /// TODO: Doc
+//     fn sparse_pixels(&'a self) -> Self::Iter;
+// }
+
+///  TODO: Doc
+pub trait Pixels<C>
 where
     C: PixelColor,
 {
     ///  TODO: Doc
-    type Iter: Iterator<Item = Option<C>> + Dimensions + 'a;
+    type Iter: Iterator<Item = Pixel<C>>;
 
-    /// TODO: Doc
-    fn sparse_pixels(&'a self) -> Self::Iter;
+    ///  TODO: Doc
+    fn pixels(&self) -> Self::Iter;
+}
+
+///  TODO: Doc
+pub trait IntoPixels<C>
+where
+    C: PixelColor,
+{
+    ///  TODO: Doc
+    type Iter: Iterator<Item = Pixel<C>>;
+
+    ///  TODO: Doc
+    fn into_pixels(self) -> Self::Iter;
+}
+
+impl<'a, C, T> Pixels<C> for &'a T
+where
+    &'a T: IntoPixels<C>,
+    C: PixelColor,
+{
+    type Iter = <Self as IntoPixels<C>>::Iter;
+
+    fn pixels(&self) -> Self::Iter {
+        self.into_pixels()
+    }
 }

--- a/embedded-graphics/src/pixel_iterator.rs
+++ b/embedded-graphics/src/pixel_iterator.rs
@@ -61,7 +61,7 @@ where
     type Iter: Iterator<Item = Pixel<C>>;
 
     ///  TODO: Doc
-    fn pixels(&self) -> Self::Iter;
+    fn pixels(self) -> Self::Iter;
 }
 
 ///  TODO: Doc
@@ -83,7 +83,7 @@ where
 {
     type Iter = <Self as IntoPixels<C>>::Iter;
 
-    fn pixels(&self) -> Self::Iter {
+    fn pixels(self) -> Self::Iter {
         self.into_pixels()
     }
 }

--- a/embedded-graphics/src/pixel_iterator.rs
+++ b/embedded-graphics/src/pixel_iterator.rs
@@ -26,3 +26,15 @@ where
         target.draw_iter(self)
     }
 }
+
+/// Pixel iterator trait
+pub trait PixelIterator<C>
+where
+    C: PixelColor,
+{
+    /// TODO: Doc
+    type Iter: Iterator<Item = Pixel<C>>;
+
+    /// TODO: Doc
+    fn pixels(self) -> Self::Iter;
+}

--- a/embedded-graphics/src/prelude.rs
+++ b/embedded-graphics/src/prelude.rs
@@ -5,7 +5,7 @@ pub use crate::{
     fonts::Font,
     geometry::{Angle, AngleUnit, Dimensions, Point, Size},
     image::{ImageDimensions, IntoPixelIter},
-    pixel_iterator::{PixelIteratorExt, Pixels, SparsePixels},
+    pixel_iterator::{IntoPixels, PixelIteratorExt, Pixels},
     pixelcolor::{raw::RawData, GrayColor, IntoStorage, PixelColor, RgbColor},
     primitives::{ContainsPoint, Primitive},
     transform::Transform,

--- a/embedded-graphics/src/prelude.rs
+++ b/embedded-graphics/src/prelude.rs
@@ -5,7 +5,7 @@ pub use crate::{
     fonts::Font,
     geometry::{Angle, AngleUnit, Dimensions, Point, Size},
     image::{ImageDimensions, IntoPixelIter},
-    pixel_iterator::PixelIteratorExt,
+    pixel_iterator::{PixelIterator, PixelIteratorExt},
     pixelcolor::{raw::RawData, GrayColor, IntoStorage, PixelColor, RgbColor},
     primitives::{ContainsPoint, Primitive},
     transform::Transform,

--- a/embedded-graphics/src/prelude.rs
+++ b/embedded-graphics/src/prelude.rs
@@ -5,7 +5,7 @@ pub use crate::{
     fonts::Font,
     geometry::{Angle, AngleUnit, Dimensions, Point, Size},
     image::{ImageDimensions, IntoPixelIter},
-    pixel_iterator::{PixelIterator, PixelIteratorExt},
+    pixel_iterator::{IntoPixelIterator, IntoSparsePixelIterator, PixelIteratorExt},
     pixelcolor::{raw::RawData, GrayColor, IntoStorage, PixelColor, RgbColor},
     primitives::{ContainsPoint, Primitive},
     transform::Transform,

--- a/embedded-graphics/src/prelude.rs
+++ b/embedded-graphics/src/prelude.rs
@@ -5,7 +5,7 @@ pub use crate::{
     fonts::Font,
     geometry::{Angle, AngleUnit, Dimensions, Point, Size},
     image::{ImageDimensions, IntoPixelIter},
-    pixel_iterator::{IntoPixels, PixelIteratorExt, Pixels},
+    pixel_iterator::{IntoPixels, PixelIteratorExt},
     pixelcolor::{raw::RawData, GrayColor, IntoStorage, PixelColor, RgbColor},
     primitives::{ContainsPoint, Primitive},
     transform::Transform,

--- a/embedded-graphics/src/prelude.rs
+++ b/embedded-graphics/src/prelude.rs
@@ -5,7 +5,7 @@ pub use crate::{
     fonts::Font,
     geometry::{Angle, AngleUnit, Dimensions, Point, Size},
     image::{ImageDimensions, IntoPixelIter},
-    pixel_iterator::{IntoPixelIterator, IntoSparsePixelIterator, PixelIteratorExt},
+    pixel_iterator::{PixelIteratorExt, Pixels, SparsePixels},
     pixelcolor::{raw::RawData, GrayColor, IntoStorage, PixelColor, RgbColor},
     primitives::{ContainsPoint, Primitive},
     transform::Transform,

--- a/embedded-graphics/src/primitives/arc/points.rs
+++ b/embedded-graphics/src/primitives/arc/points.rs
@@ -54,8 +54,8 @@ impl Iterator for Points {
 mod tests {
     use super::*;
     use crate::{
-        drawable::Pixel, geometry::AngleUnit, pixelcolor::BinaryColor, primitives::Primitive,
-        style::PrimitiveStyle,
+        drawable::Pixel, geometry::AngleUnit, pixel_iterator::IntoPixels, pixelcolor::BinaryColor,
+        primitives::Primitive, style::PrimitiveStyle,
     };
 
     #[test]
@@ -65,7 +65,7 @@ mod tests {
         let styled_points = arc
             .clone()
             .into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 1))
-            .into_iter()
+            .into_pixels()
             .map(|Pixel(p, _)| p);
 
         assert!(arc.points().eq(styled_points));

--- a/embedded-graphics/src/primitives/arc/styled.rs
+++ b/embedded-graphics/src/primitives/arc/styled.rs
@@ -1,5 +1,6 @@
 use crate::{
     drawable::{Drawable, Pixel},
+    pixel_iterator::IntoPixels,
     pixelcolor::PixelColor,
     primitives::{
         arc::{plane_sector::PlaneSectorIterator, Arc},
@@ -85,18 +86,19 @@ where
     where
         D: DrawTarget<Color = C>,
     {
-        display.draw_iter(self)
+        display.draw_iter(self.into_pixels())
     }
 }
 
-impl<'a, C> IntoIterator for &'a Styled<Arc, PrimitiveStyle<C>>
+impl<'a, C> IntoPixels for &'a Styled<Arc, PrimitiveStyle<C>>
 where
     C: PixelColor,
 {
-    type Item = Pixel<C>;
-    type IntoIter = StyledPixels<C>;
+    type Color = C;
 
-    fn into_iter(self) -> Self::IntoIter {
+    type Iter = StyledPixels<Self::Color>;
+
+    fn into_pixels(self) -> Self::Iter {
         StyledPixels::new(self)
     }
 }

--- a/embedded-graphics/src/primitives/arc/styled.rs
+++ b/embedded-graphics/src/primitives/arc/styled.rs
@@ -90,7 +90,7 @@ where
     }
 }
 
-impl<'a, C> IntoPixels for &'a Styled<Arc, PrimitiveStyle<C>>
+impl<C> IntoPixels for &Styled<Arc, PrimitiveStyle<C>>
 where
     C: PixelColor,
 {

--- a/embedded-graphics/src/primitives/circle/styled.rs
+++ b/embedded-graphics/src/primitives/circle/styled.rs
@@ -82,7 +82,7 @@ where
     }
 }
 
-impl<'a, C> IntoPixels for &'a Styled<Circle, PrimitiveStyle<C>>
+impl<C> IntoPixels for &Styled<Circle, PrimitiveStyle<C>>
 where
     C: PixelColor,
 {

--- a/embedded-graphics/src/primitives/circle/styled.rs
+++ b/embedded-graphics/src/primitives/circle/styled.rs
@@ -2,6 +2,7 @@ use crate::{
     draw_target::DrawTarget,
     drawable::{Drawable, Pixel},
     geometry::{Dimensions, Point, Size},
+    pixel_iterator::IntoPixels,
     pixelcolor::PixelColor,
     primitives::circle::{diameter_to_threshold, distance_iterator::DistanceIterator, Circle},
     primitives::rectangle::{self, Rectangle},
@@ -81,14 +82,15 @@ where
     }
 }
 
-impl<'a, C> IntoIterator for &'a Styled<Circle, PrimitiveStyle<C>>
+impl<'a, C> IntoPixels for &'a Styled<Circle, PrimitiveStyle<C>>
 where
     C: PixelColor,
 {
-    type Item = Pixel<C>;
-    type IntoIter = StyledPixels<C>;
+    type Color = C;
 
-    fn into_iter(self) -> Self::IntoIter {
+    type Iter = StyledPixels<Self::Color>;
+
+    fn into_pixels(self) -> Self::Iter {
         StyledPixels::new(self)
     }
 }
@@ -101,7 +103,7 @@ where
     where
         D: DrawTarget<Color = C>,
     {
-        display.draw_iter(self)
+        display.draw_iter(self.into_pixels())
     }
 }
 
@@ -124,7 +126,7 @@ mod tests {
         let styled_points = circle
             .clone()
             .into_styled(PrimitiveStyle::with_fill(BinaryColor::On))
-            .into_iter()
+            .into_pixels()
             .map(|Pixel(p, _)| p);
 
         assert!(circle.points().eq(styled_points));
@@ -199,18 +201,18 @@ mod tests {
             Circle::new(Point::new(-5, -5), 21)
                 .into_styled(PrimitiveStyle::with_fill(BinaryColor::On));
 
-        assert!(circle.into_iter().count() > 0);
+        assert!(circle.into_pixels().count() > 0);
     }
 
     #[test]
     fn it_handles_negative_coordinates() {
         let positive = Circle::new(Point::new(10, 10), 5)
             .into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 1))
-            .into_iter();
+            .into_pixels();
 
         let negative = Circle::new(Point::new(-10, -10), 5)
             .into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 1))
-            .into_iter();
+            .into_pixels();
 
         assert!(negative.eq(positive.map(|Pixel(p, c)| Pixel(p - Point::new(20, 20), c))));
     }
@@ -275,7 +277,9 @@ mod tests {
                 size
             );
             assert!(
-                circle_no_stroke.into_iter().eq(circle_stroke.into_iter()),
+                circle_no_stroke
+                    .into_pixels()
+                    .eq(circle_stroke.into_pixels()),
                 "Filled and unfilled circle iters are unequal for radius {}",
                 size
             );

--- a/embedded-graphics/src/primitives/ellipse/styled.rs
+++ b/embedded-graphics/src/primitives/ellipse/styled.rs
@@ -79,7 +79,7 @@ where
     }
 }
 
-impl<'a, C> IntoPixels for &'a Styled<Ellipse, PrimitiveStyle<C>>
+impl<C> IntoPixels for &Styled<Ellipse, PrimitiveStyle<C>>
 where
     C: PixelColor,
 {

--- a/embedded-graphics/src/primitives/ellipse/styled.rs
+++ b/embedded-graphics/src/primitives/ellipse/styled.rs
@@ -2,6 +2,7 @@ use crate::{
     draw_target::DrawTarget,
     drawable::{Drawable, Pixel},
     geometry::{Point, Size},
+    pixel_iterator::IntoPixels,
     pixelcolor::PixelColor,
     primitives::ellipse::{compute_threshold, is_point_inside_ellipse, points::Points, Ellipse},
     style::{PrimitiveStyle, Styled},
@@ -78,14 +79,15 @@ where
     }
 }
 
-impl<'a, C> IntoIterator for &'a Styled<Ellipse, PrimitiveStyle<C>>
+impl<'a, C> IntoPixels for &'a Styled<Ellipse, PrimitiveStyle<C>>
 where
     C: PixelColor,
 {
-    type Item = Pixel<C>;
-    type IntoIter = StyledPixels<C>;
+    type Color = C;
 
-    fn into_iter(self) -> Self::IntoIter {
+    type Iter = StyledPixels<Self::Color>;
+
+    fn into_pixels(self) -> Self::Iter {
         StyledPixels::new(self)
     }
 }
@@ -98,7 +100,7 @@ where
     where
         D: DrawTarget<Color = C>,
     {
-        display.draw_iter(self)
+        display.draw_iter(self.into_pixels())
     }
 }
 

--- a/embedded-graphics/src/primitives/line/mod.rs
+++ b/embedded-graphics/src/primitives/line/mod.rs
@@ -127,6 +127,7 @@ mod tests {
         drawable::{Drawable, Pixel},
         geometry::Size,
         mock_display::MockDisplay,
+        pixel_iterator::IntoPixels,
         pixelcolor::BinaryColor,
         style::PrimitiveStyle,
     };
@@ -158,7 +159,7 @@ mod tests {
         let line =
             Line::new(start, end).into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 0));
 
-        assert!(line.into_iter().eq(core::iter::empty()));
+        assert!(line.into_pixels().eq(core::iter::empty()));
     }
 
     #[test]
@@ -346,7 +347,7 @@ mod tests {
         let styled_points: ArrayVec<[_; 32]> = line
             .clone()
             .into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 1))
-            .into_iter()
+            .into_pixels()
             .map(|Pixel(p, _)| p)
             .collect();
 

--- a/embedded-graphics/src/primitives/line/styled.rs
+++ b/embedded-graphics/src/primitives/line/styled.rs
@@ -1,6 +1,7 @@
 use crate::{
     draw_target::DrawTarget,
     drawable::{Drawable, Pixel},
+    pixel_iterator::IntoPixels,
     pixelcolor::PixelColor,
     primitives::line::{thick_points::ThickPoints, Line},
     style::{PrimitiveStyle, Styled},
@@ -50,14 +51,15 @@ where
     }
 }
 
-impl<'a, C> IntoIterator for &'a Styled<Line, PrimitiveStyle<C>>
+impl<'a, C> IntoPixels for &'a Styled<Line, PrimitiveStyle<C>>
 where
     C: PixelColor,
 {
-    type Item = Pixel<C>;
-    type IntoIter = StyledPixels<C>;
+    type Color = C;
 
-    fn into_iter(self) -> Self::IntoIter {
+    type Iter = StyledPixels<Self::Color>;
+
+    fn into_pixels(self) -> Self::Iter {
         StyledPixels::new(self)
     }
 }
@@ -70,6 +72,6 @@ where
     where
         D: DrawTarget<Color = C>,
     {
-        display.draw_iter(self)
+        display.draw_iter(self.into_pixels())
     }
 }

--- a/embedded-graphics/src/primitives/line/styled.rs
+++ b/embedded-graphics/src/primitives/line/styled.rs
@@ -51,7 +51,7 @@ where
     }
 }
 
-impl<'a, C> IntoPixels for &'a Styled<Line, PrimitiveStyle<C>>
+impl<C> IntoPixels for &Styled<Line, PrimitiveStyle<C>>
 where
     C: PixelColor,
 {

--- a/embedded-graphics/src/primitives/mod.rs
+++ b/embedded-graphics/src/primitives/mod.rs
@@ -47,6 +47,6 @@ pub trait Primitive: Dimensions {
 
 /// Trait to check if a point is inside a closed shape.
 pub trait ContainsPoint {
-    /// Returns `true` is the given point is inside the shape.
+    /// Returns `true` if the given point is inside the shape.
     fn contains(&self, point: Point) -> bool;
 }

--- a/embedded-graphics/src/primitives/polyline/styled.rs
+++ b/embedded-graphics/src/primitives/polyline/styled.rs
@@ -45,7 +45,7 @@ where
     }
 }
 
-impl<'a, C> IntoPixels for &'a Styled<Polyline<'a>, PrimitiveStyle<C>>
+impl<'a, C> IntoPixels for &Styled<Polyline<'a>, PrimitiveStyle<C>>
 where
     C: PixelColor,
 {

--- a/embedded-graphics/src/primitives/polyline/styled.rs
+++ b/embedded-graphics/src/primitives/polyline/styled.rs
@@ -1,6 +1,7 @@
 use crate::{
     draw_target::DrawTarget,
     drawable::{Drawable, Pixel},
+    pixel_iterator::IntoPixels,
     pixelcolor::PixelColor,
     primitives::{polyline, polyline::Polyline, Primitive},
     style::{PrimitiveStyle, Styled},
@@ -44,14 +45,15 @@ where
     }
 }
 
-impl<'a, C> IntoIterator for &'a Styled<Polyline<'a>, PrimitiveStyle<C>>
+impl<'a, C> IntoPixels for &'a Styled<Polyline<'a>, PrimitiveStyle<C>>
 where
     C: PixelColor,
 {
-    type Item = Pixel<C>;
-    type IntoIter = StyledPixels<'a, C>;
+    type Color = C;
 
-    fn into_iter(self) -> Self::IntoIter {
+    type Iter = StyledPixels<'a, C>;
+
+    fn into_pixels(self) -> Self::Iter {
         StyledPixels::new(self)
     }
 }
@@ -64,7 +66,7 @@ where
     where
         D: DrawTarget<Color = C>,
     {
-        display.draw_iter(self.into_iter())
+        display.draw_iter(self.into_pixels())
     }
 }
 
@@ -91,7 +93,7 @@ mod tests {
         let thick = polyline.into_styled(PrimitiveStyle::with_stroke(Rgb565::RED, 10));
         let thin = polyline.into_styled(PrimitiveStyle::with_stroke(Rgb565::RED, 1));
 
-        assert!(thick.into_iter().eq(thin.into_iter()));
+        assert!(thick.into_pixels().eq(thin.into_pixels()));
     }
 
     #[test]
@@ -123,13 +125,13 @@ mod tests {
         // No stroke width = no pixels
         assert!(Polyline::new(&points)
             .into_styled(PrimitiveStyle::with_stroke(Rgb565::BLUE, 0))
-            .into_iter()
+            .into_pixels()
             .eq(core::iter::empty()));
 
         // No stroke color = no pixels
         assert!(Polyline::new(&points)
             .into_styled::<Rgb565>(PrimitiveStyleBuilder::new().stroke_width(1).build())
-            .into_iter()
+            .into_pixels()
             .eq(core::iter::empty()));
     }
 }

--- a/embedded-graphics/src/primitives/rectangle/styled.rs
+++ b/embedded-graphics/src/primitives/rectangle/styled.rs
@@ -74,7 +74,7 @@ where
     }
 }
 
-impl<'a, C> IntoPixels for &'a Styled<Rectangle, PrimitiveStyle<C>>
+impl<C> IntoPixels for &Styled<Rectangle, PrimitiveStyle<C>>
 where
     C: PixelColor,
 {

--- a/embedded-graphics/src/primitives/rectangle/styled.rs
+++ b/embedded-graphics/src/primitives/rectangle/styled.rs
@@ -2,7 +2,7 @@ use crate::{
     draw_target::DrawTarget,
     drawable::{Drawable, Pixel},
     geometry::{Point, Size},
-    pixel_iterator::Pixels,
+    pixel_iterator::IntoPixels,
     pixelcolor::PixelColor,
     primitives::{
         rectangle::{Points, Rectangle},
@@ -74,13 +74,13 @@ where
     }
 }
 
-impl<'a, C> Pixels<'a, C> for Styled<Rectangle, PrimitiveStyle<C>>
+impl<'a, C> IntoPixels<C> for &'a Styled<Rectangle, PrimitiveStyle<C>>
 where
     C: PixelColor + 'a,
 {
     type Iter = StyledPixels<C>;
 
-    fn pixels(&self) -> Self::Iter {
+    fn into_pixels(self) -> Self::Iter {
         Self::Iter::new(self)
     }
 }
@@ -162,7 +162,7 @@ mod tests {
         drawable::Drawable,
         geometry::{Point, Size},
         mock_display::MockDisplay,
-        pixel_iterator::PixelIteratorExt,
+        pixel_iterator::{PixelIteratorExt, Pixels},
         pixelcolor::{BinaryColor, Rgb565, RgbColor},
         primitives::Primitive,
         style::{PrimitiveStyle, PrimitiveStyleBuilder, StrokeAlignment},
@@ -172,7 +172,7 @@ mod tests {
     fn it_draws_unfilled_rect() {
         let mut rect = Rectangle::new(Point::new(2, 2), Size::new(3, 3))
             .into_styled(PrimitiveStyle::with_stroke(Rgb565::RED, 1))
-            .pixels();
+            .into_pixels();
 
         assert_eq!(rect.next(), Some(Pixel(Point::new(2, 2), Rgb565::RED)));
         assert_eq!(rect.next(), Some(Pixel(Point::new(3, 2), Rgb565::RED)));
@@ -193,7 +193,7 @@ mod tests {
         let styled_points = rectangle
             .clone()
             .into_styled(PrimitiveStyle::with_fill(Rgb565::WHITE))
-            .pixels()
+            .into_pixels()
             .map(|Pixel(p, _)| p);
 
         assert!(rectangle.points().eq(styled_points));
@@ -248,7 +248,10 @@ mod tests {
         let mut drawn_center = MockDisplay::new();
         let mut iter_center = MockDisplay::new();
         rectangle_center.draw(&mut drawn_center).unwrap();
-        rectangle_center.pixels().draw(&mut iter_center).unwrap();
+        rectangle_center
+            .into_pixels()
+            .draw(&mut iter_center)
+            .unwrap();
         assert_eq!(drawn_center, iter_center);
 
         let rectangle_inside = Rectangle::new(TOP_LEFT - Point::new(1, 1), SIZE + Size::new(2, 2))
@@ -261,7 +264,10 @@ mod tests {
         let mut drawn_inside = MockDisplay::new();
         let mut iter_inside = MockDisplay::new();
         rectangle_inside.draw(&mut drawn_inside).unwrap();
-        rectangle_inside.pixels().draw(&mut iter_inside).unwrap();
+        rectangle_inside
+            .into_pixels()
+            .draw(&mut iter_inside)
+            .unwrap();
         assert_eq!(drawn_inside, iter_inside);
 
         let rectangle_outside = Rectangle::new(TOP_LEFT + Point::new(2, 2), SIZE - Size::new(4, 4))
@@ -274,7 +280,10 @@ mod tests {
         let mut drawn_outside = MockDisplay::new();
         let mut iter_outside = MockDisplay::new();
         rectangle_outside.draw(&mut drawn_outside).unwrap();
-        rectangle_outside.pixels().draw(&mut iter_outside).unwrap();
+        rectangle_outside
+            .into_pixels()
+            .draw(&mut iter_outside)
+            .unwrap();
         assert_eq!(drawn_outside, iter_outside);
     }
 
@@ -290,7 +299,7 @@ mod tests {
         let mut drawn = MockDisplay::new();
         let mut iter = MockDisplay::new();
         rectangle.draw(&mut drawn).unwrap();
-        rectangle.pixels().draw(&mut iter).unwrap();
+        rectangle.into_pixels().draw(&mut iter).unwrap();
         assert_eq!(drawn, iter);
     }
 
@@ -333,7 +342,7 @@ mod tests {
 
                 // Calls draw_iter()
                 rect.into_styled(style)
-                    .pixels()
+                    .into_pixels()
                     .draw(&mut display_iter)
                     .unwrap();
 

--- a/embedded-graphics/src/primitives/rectangle/styled.rs
+++ b/embedded-graphics/src/primitives/rectangle/styled.rs
@@ -2,7 +2,7 @@ use crate::{
     draw_target::DrawTarget,
     drawable::{Drawable, Pixel},
     geometry::{Point, Size},
-    pixel_iterator::IntoPixelIterator,
+    pixel_iterator::Pixels,
     pixelcolor::PixelColor,
     primitives::{
         rectangle::{Points, Rectangle},
@@ -74,13 +74,13 @@ where
     }
 }
 
-impl<C> IntoPixelIterator<C> for &Styled<Rectangle, PrimitiveStyle<C>>
+impl<'a, C> Pixels<'a, C> for Styled<Rectangle, PrimitiveStyle<C>>
 where
-    C: PixelColor,
+    C: PixelColor + 'a,
 {
     type Iter = StyledPixels<C>;
 
-    fn pixels(self) -> Self::Iter {
+    fn pixels(&self) -> Self::Iter {
         Self::Iter::new(self)
     }
 }

--- a/embedded-graphics/src/primitives/rectangle/styled.rs
+++ b/embedded-graphics/src/primitives/rectangle/styled.rs
@@ -162,7 +162,7 @@ mod tests {
         drawable::Drawable,
         geometry::{Point, Size},
         mock_display::MockDisplay,
-        pixel_iterator::{PixelIteratorExt, Pixels},
+        pixel_iterator::{IntoPixels, PixelIteratorExt},
         pixelcolor::{BinaryColor, Rgb565, RgbColor},
         primitives::Primitive,
         style::{PrimitiveStyle, PrimitiveStyleBuilder, StrokeAlignment},
@@ -172,7 +172,7 @@ mod tests {
     fn it_draws_unfilled_rect() {
         let mut rect = Rectangle::new(Point::new(2, 2), Size::new(3, 3))
             .into_styled(PrimitiveStyle::with_stroke(Rgb565::RED, 1))
-            .pixels();
+            .into_pixels();
 
         assert_eq!(rect.next(), Some(Pixel(Point::new(2, 2), Rgb565::RED)));
         assert_eq!(rect.next(), Some(Pixel(Point::new(3, 2), Rgb565::RED)));
@@ -193,7 +193,7 @@ mod tests {
         let styled_points = rectangle
             .clone()
             .into_styled(PrimitiveStyle::with_fill(Rgb565::WHITE))
-            .pixels()
+            .into_pixels()
             .map(|Pixel(p, _)| p);
 
         assert!(rectangle.points().eq(styled_points));
@@ -248,7 +248,10 @@ mod tests {
         let mut drawn_center = MockDisplay::new();
         let mut iter_center = MockDisplay::new();
         rectangle_center.draw(&mut drawn_center).unwrap();
-        rectangle_center.pixels().draw(&mut iter_center).unwrap();
+        rectangle_center
+            .into_pixels()
+            .draw(&mut iter_center)
+            .unwrap();
         assert_eq!(drawn_center, iter_center);
 
         let rectangle_inside = Rectangle::new(TOP_LEFT - Point::new(1, 1), SIZE + Size::new(2, 2))
@@ -261,7 +264,10 @@ mod tests {
         let mut drawn_inside = MockDisplay::new();
         let mut iter_inside = MockDisplay::new();
         rectangle_inside.draw(&mut drawn_inside).unwrap();
-        rectangle_inside.pixels().draw(&mut iter_inside).unwrap();
+        rectangle_inside
+            .into_pixels()
+            .draw(&mut iter_inside)
+            .unwrap();
         assert_eq!(drawn_inside, iter_inside);
 
         let rectangle_outside = Rectangle::new(TOP_LEFT + Point::new(2, 2), SIZE - Size::new(4, 4))
@@ -274,7 +280,10 @@ mod tests {
         let mut drawn_outside = MockDisplay::new();
         let mut iter_outside = MockDisplay::new();
         rectangle_outside.draw(&mut drawn_outside).unwrap();
-        rectangle_outside.pixels().draw(&mut iter_outside).unwrap();
+        rectangle_outside
+            .into_pixels()
+            .draw(&mut iter_outside)
+            .unwrap();
         assert_eq!(drawn_outside, iter_outside);
     }
 
@@ -290,7 +299,7 @@ mod tests {
         let mut drawn = MockDisplay::new();
         let mut iter = MockDisplay::new();
         rectangle.draw(&mut drawn).unwrap();
-        rectangle.pixels().draw(&mut iter).unwrap();
+        rectangle.into_pixels().draw(&mut iter).unwrap();
         assert_eq!(drawn, iter);
     }
 
@@ -333,7 +342,7 @@ mod tests {
 
                 // Calls draw_iter()
                 rect.into_styled(style)
-                    .pixels()
+                    .into_pixels()
                     .draw(&mut display_iter)
                     .unwrap();
 
@@ -364,7 +373,7 @@ mod tests {
 
         let styled = rectangle.into_styled(PrimitiveStyle::with_fill(BinaryColor::On));
 
-        let _pixels = styled.pixels();
+        let _pixels = styled.into_pixels();
 
         let moved = rectangle.translate(Point::new(1, 2));
 

--- a/embedded-graphics/src/primitives/rectangle/styled.rs
+++ b/embedded-graphics/src/primitives/rectangle/styled.rs
@@ -74,10 +74,12 @@ where
     }
 }
 
-impl<'a, C> IntoPixels<C> for &'a Styled<Rectangle, PrimitiveStyle<C>>
+impl<'a, C> IntoPixels for &'a Styled<Rectangle, PrimitiveStyle<C>>
 where
     C: PixelColor,
 {
+    type Color = C;
+
     type Iter = StyledPixels<C>;
 
     fn into_pixels(self) -> Self::Iter {

--- a/embedded-graphics/src/primitives/rectangle/styled.rs
+++ b/embedded-graphics/src/primitives/rectangle/styled.rs
@@ -76,7 +76,7 @@ where
 
 impl<'a, C> IntoPixels<C> for &'a Styled<Rectangle, PrimitiveStyle<C>>
 where
-    C: PixelColor + 'a,
+    C: PixelColor,
 {
     type Iter = StyledPixels<C>;
 

--- a/embedded-graphics/src/primitives/rectangle/styled.rs
+++ b/embedded-graphics/src/primitives/rectangle/styled.rs
@@ -1,3 +1,4 @@
+use crate::pixel_iterator::PixelIterator;
 use crate::{
     draw_target::DrawTarget,
     drawable::{Drawable, Pixel},
@@ -73,15 +74,14 @@ where
     }
 }
 
-impl<C> IntoIterator for &Styled<Rectangle, PrimitiveStyle<C>>
+impl<C> PixelIterator<C> for &Styled<Rectangle, PrimitiveStyle<C>>
 where
     C: PixelColor,
 {
-    type Item = Pixel<C>;
-    type IntoIter = StyledPixels<C>;
+    type Iter = StyledPixels<C>;
 
-    fn into_iter(self) -> Self::IntoIter {
-        StyledPixels::new(self)
+    fn pixels(self) -> Self::Iter {
+        Self::Iter::new(self)
     }
 }
 
@@ -172,7 +172,7 @@ mod tests {
     fn it_draws_unfilled_rect() {
         let mut rect = Rectangle::new(Point::new(2, 2), Size::new(3, 3))
             .into_styled(PrimitiveStyle::with_stroke(Rgb565::RED, 1))
-            .into_iter();
+            .pixels();
 
         assert_eq!(rect.next(), Some(Pixel(Point::new(2, 2), Rgb565::RED)));
         assert_eq!(rect.next(), Some(Pixel(Point::new(3, 2), Rgb565::RED)));
@@ -193,7 +193,7 @@ mod tests {
         let styled_points = rectangle
             .clone()
             .into_styled(PrimitiveStyle::with_fill(Rgb565::WHITE))
-            .into_iter()
+            .pixels()
             .map(|Pixel(p, _)| p);
 
         assert!(rectangle.points().eq(styled_points));
@@ -248,7 +248,7 @@ mod tests {
         let mut drawn_center = MockDisplay::new();
         let mut iter_center = MockDisplay::new();
         rectangle_center.draw(&mut drawn_center).unwrap();
-        rectangle_center.into_iter().draw(&mut iter_center).unwrap();
+        rectangle_center.pixels().draw(&mut iter_center).unwrap();
         assert_eq!(drawn_center, iter_center);
 
         let rectangle_inside = Rectangle::new(TOP_LEFT - Point::new(1, 1), SIZE + Size::new(2, 2))
@@ -261,7 +261,7 @@ mod tests {
         let mut drawn_inside = MockDisplay::new();
         let mut iter_inside = MockDisplay::new();
         rectangle_inside.draw(&mut drawn_inside).unwrap();
-        rectangle_inside.into_iter().draw(&mut iter_inside).unwrap();
+        rectangle_inside.pixels().draw(&mut iter_inside).unwrap();
         assert_eq!(drawn_inside, iter_inside);
 
         let rectangle_outside = Rectangle::new(TOP_LEFT + Point::new(2, 2), SIZE - Size::new(4, 4))
@@ -274,10 +274,7 @@ mod tests {
         let mut drawn_outside = MockDisplay::new();
         let mut iter_outside = MockDisplay::new();
         rectangle_outside.draw(&mut drawn_outside).unwrap();
-        rectangle_outside
-            .into_iter()
-            .draw(&mut iter_outside)
-            .unwrap();
+        rectangle_outside.pixels().draw(&mut iter_outside).unwrap();
         assert_eq!(drawn_outside, iter_outside);
     }
 
@@ -293,7 +290,7 @@ mod tests {
         let mut drawn = MockDisplay::new();
         let mut iter = MockDisplay::new();
         rectangle.draw(&mut drawn).unwrap();
-        rectangle.into_iter().draw(&mut iter).unwrap();
+        rectangle.pixels().draw(&mut iter).unwrap();
         assert_eq!(drawn, iter);
     }
 
@@ -336,7 +333,7 @@ mod tests {
 
                 // Calls draw_iter()
                 rect.into_styled(style)
-                    .into_iter()
+                    .pixels()
                     .draw(&mut display_iter)
                     .unwrap();
 

--- a/embedded-graphics/src/primitives/rectangle/styled.rs
+++ b/embedded-graphics/src/primitives/rectangle/styled.rs
@@ -172,7 +172,7 @@ mod tests {
     fn it_draws_unfilled_rect() {
         let mut rect = Rectangle::new(Point::new(2, 2), Size::new(3, 3))
             .into_styled(PrimitiveStyle::with_stroke(Rgb565::RED, 1))
-            .into_pixels();
+            .pixels();
 
         assert_eq!(rect.next(), Some(Pixel(Point::new(2, 2), Rgb565::RED)));
         assert_eq!(rect.next(), Some(Pixel(Point::new(3, 2), Rgb565::RED)));
@@ -193,7 +193,7 @@ mod tests {
         let styled_points = rectangle
             .clone()
             .into_styled(PrimitiveStyle::with_fill(Rgb565::WHITE))
-            .into_pixels()
+            .pixels()
             .map(|Pixel(p, _)| p);
 
         assert!(rectangle.points().eq(styled_points));
@@ -248,10 +248,7 @@ mod tests {
         let mut drawn_center = MockDisplay::new();
         let mut iter_center = MockDisplay::new();
         rectangle_center.draw(&mut drawn_center).unwrap();
-        rectangle_center
-            .into_pixels()
-            .draw(&mut iter_center)
-            .unwrap();
+        rectangle_center.pixels().draw(&mut iter_center).unwrap();
         assert_eq!(drawn_center, iter_center);
 
         let rectangle_inside = Rectangle::new(TOP_LEFT - Point::new(1, 1), SIZE + Size::new(2, 2))
@@ -264,10 +261,7 @@ mod tests {
         let mut drawn_inside = MockDisplay::new();
         let mut iter_inside = MockDisplay::new();
         rectangle_inside.draw(&mut drawn_inside).unwrap();
-        rectangle_inside
-            .into_pixels()
-            .draw(&mut iter_inside)
-            .unwrap();
+        rectangle_inside.pixels().draw(&mut iter_inside).unwrap();
         assert_eq!(drawn_inside, iter_inside);
 
         let rectangle_outside = Rectangle::new(TOP_LEFT + Point::new(2, 2), SIZE - Size::new(4, 4))
@@ -280,10 +274,7 @@ mod tests {
         let mut drawn_outside = MockDisplay::new();
         let mut iter_outside = MockDisplay::new();
         rectangle_outside.draw(&mut drawn_outside).unwrap();
-        rectangle_outside
-            .into_pixels()
-            .draw(&mut iter_outside)
-            .unwrap();
+        rectangle_outside.pixels().draw(&mut iter_outside).unwrap();
         assert_eq!(drawn_outside, iter_outside);
     }
 
@@ -299,7 +290,7 @@ mod tests {
         let mut drawn = MockDisplay::new();
         let mut iter = MockDisplay::new();
         rectangle.draw(&mut drawn).unwrap();
-        rectangle.into_pixels().draw(&mut iter).unwrap();
+        rectangle.pixels().draw(&mut iter).unwrap();
         assert_eq!(drawn, iter);
     }
 
@@ -342,7 +333,7 @@ mod tests {
 
                 // Calls draw_iter()
                 rect.into_styled(style)
-                    .into_pixels()
+                    .pixels()
                     .draw(&mut display_iter)
                     .unwrap();
 
@@ -365,5 +356,18 @@ mod tests {
         for i in 0..20 {
             compare_drawable_iter(Rectangle::new(Point::new(7, 7), Size::new_equal(i)))
         }
+    }
+
+    #[test]
+    fn reuse() {
+        let rectangle = Rectangle::new(Point::zero(), Size::new_equal(10));
+
+        let styled = rectangle.into_styled(PrimitiveStyle::with_fill(BinaryColor::On));
+
+        let _pixels = styled.pixels();
+
+        let moved = rectangle.translate(Point::new(1, 2));
+
+        assert_eq!(moved, Rectangle::new(Point::new(1, 2), Size::new_equal(10)));
     }
 }

--- a/embedded-graphics/src/primitives/rectangle/styled.rs
+++ b/embedded-graphics/src/primitives/rectangle/styled.rs
@@ -1,8 +1,8 @@
-use crate::pixel_iterator::PixelIterator;
 use crate::{
     draw_target::DrawTarget,
     drawable::{Drawable, Pixel},
     geometry::{Point, Size},
+    pixel_iterator::IntoPixelIterator,
     pixelcolor::PixelColor,
     primitives::{
         rectangle::{Points, Rectangle},
@@ -74,7 +74,7 @@ where
     }
 }
 
-impl<C> PixelIterator<C> for &Styled<Rectangle, PrimitiveStyle<C>>
+impl<C> IntoPixelIterator<C> for &Styled<Rectangle, PrimitiveStyle<C>>
 where
     C: PixelColor,
 {

--- a/embedded-graphics/src/primitives/rounded_rectangle/points.rs
+++ b/embedded-graphics/src/primitives/rounded_rectangle/points.rs
@@ -92,7 +92,7 @@ impl Iterator for Points {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{pixelcolor::BinaryColor, style::PrimitiveStyle};
+    use crate::{pixel_iterator::IntoPixels, pixelcolor::BinaryColor, style::PrimitiveStyle};
 
     #[test]
     fn points_equals_filled() {
@@ -103,7 +103,7 @@ mod tests {
 
         assert!(rounded_rect.points().eq(rounded_rect
             .into_styled(PrimitiveStyle::with_fill(BinaryColor::On))
-            .into_iter()
+            .into_pixels()
             .map(|pixel| pixel.0)));
     }
 }

--- a/embedded-graphics/src/primitives/rounded_rectangle/styled.rs
+++ b/embedded-graphics/src/primitives/rounded_rectangle/styled.rs
@@ -100,7 +100,7 @@ mod tests {
         drawable::Drawable,
         geometry::{Point, Size},
         mock_display::MockDisplay,
-        pixel_iterator::{IntoPixels, Pixels},
+        pixel_iterator::IntoPixels,
         pixelcolor::{BinaryColor, Rgb888, RgbColor},
         primitives::{rectangle::Rectangle, CornerRadii, Primitive},
         style::PrimitiveStyleBuilder,
@@ -133,7 +133,7 @@ mod tests {
 
         let rect = Rectangle::new(Point::zero(), Size::new(20, 30)).into_styled(style);
 
-        assert!(rounded_rect.into_iter().eq(rect.pixels()));
+        assert!(rounded_rect.into_iter().eq(rect.into_pixels()));
     }
 
     #[test]

--- a/embedded-graphics/src/primitives/rounded_rectangle/styled.rs
+++ b/embedded-graphics/src/primitives/rounded_rectangle/styled.rs
@@ -133,7 +133,7 @@ mod tests {
 
         let rect = Rectangle::new(Point::zero(), Size::new(20, 30)).into_styled(style);
 
-        assert!(rounded_rect.into_iter().eq(rect.into_pixels()));
+        assert!(rounded_rect.into_iter().eq(rect.pixels()));
     }
 
     #[test]

--- a/embedded-graphics/src/primitives/rounded_rectangle/styled.rs
+++ b/embedded-graphics/src/primitives/rounded_rectangle/styled.rs
@@ -100,6 +100,7 @@ mod tests {
         drawable::Drawable,
         geometry::{Point, Size},
         mock_display::MockDisplay,
+        pixel_iterator::PixelIterator,
         pixelcolor::{BinaryColor, Rgb888, RgbColor},
         primitives::{rectangle::Rectangle, CornerRadii, Primitive},
         style::PrimitiveStyleBuilder,
@@ -132,7 +133,7 @@ mod tests {
 
         let rect = Rectangle::new(Point::zero(), Size::new(20, 30)).into_styled(style);
 
-        assert!(rounded_rect.into_iter().eq(rect.into_iter()));
+        assert!(rounded_rect.into_iter().eq(rect.pixels()));
     }
 
     #[test]

--- a/embedded-graphics/src/primitives/rounded_rectangle/styled.rs
+++ b/embedded-graphics/src/primitives/rounded_rectangle/styled.rs
@@ -100,7 +100,7 @@ mod tests {
         drawable::Drawable,
         geometry::{Point, Size},
         mock_display::MockDisplay,
-        pixel_iterator::IntoPixelIterator,
+        pixel_iterator::Pixels,
         pixelcolor::{BinaryColor, Rgb888, RgbColor},
         primitives::{rectangle::Rectangle, CornerRadii, Primitive},
         style::PrimitiveStyleBuilder,

--- a/embedded-graphics/src/primitives/rounded_rectangle/styled.rs
+++ b/embedded-graphics/src/primitives/rounded_rectangle/styled.rs
@@ -1,6 +1,7 @@
 use crate::{
     draw_target::DrawTarget,
     drawable::{Drawable, Pixel},
+    pixel_iterator::IntoPixels,
     pixelcolor::PixelColor,
     primitives::{
         rounded_rectangle::{Points, RoundedRectangle},
@@ -69,14 +70,15 @@ where
     }
 }
 
-impl<C> IntoIterator for &Styled<RoundedRectangle, PrimitiveStyle<C>>
+impl<C> IntoPixels for &Styled<RoundedRectangle, PrimitiveStyle<C>>
 where
     C: PixelColor,
 {
-    type Item = Pixel<C>;
-    type IntoIter = StyledPixels<C>;
+    type Color = C;
 
-    fn into_iter(self) -> Self::IntoIter {
+    type Iter = StyledPixels<Self::Color>;
+
+    fn into_pixels(self) -> Self::Iter {
         StyledPixels::new(self)
     }
 }
@@ -89,7 +91,7 @@ where
     where
         D: DrawTarget<Color = C>,
     {
-        display.draw_iter(self)
+        display.draw_iter(self.into_pixels())
     }
 }
 
@@ -114,7 +116,7 @@ mod tests {
         )
         .into_styled(PrimitiveStyleBuilder::<BinaryColor>::new().build());
 
-        assert!(rounded_rect.into_iter().eq(core::iter::empty()));
+        assert!(rounded_rect.into_pixels().eq(core::iter::empty()));
     }
 
     #[test]
@@ -133,7 +135,7 @@ mod tests {
 
         let rect = Rectangle::new(Point::zero(), Size::new(20, 30)).into_styled(style);
 
-        assert!(rounded_rect.into_iter().eq(rect.into_pixels()));
+        assert!(rounded_rect.into_pixels().eq(rect.into_pixels()));
     }
 
     #[test]

--- a/embedded-graphics/src/primitives/rounded_rectangle/styled.rs
+++ b/embedded-graphics/src/primitives/rounded_rectangle/styled.rs
@@ -100,7 +100,7 @@ mod tests {
         drawable::Drawable,
         geometry::{Point, Size},
         mock_display::MockDisplay,
-        pixel_iterator::Pixels,
+        pixel_iterator::{IntoPixels, Pixels},
         pixelcolor::{BinaryColor, Rgb888, RgbColor},
         primitives::{rectangle::Rectangle, CornerRadii, Primitive},
         style::PrimitiveStyleBuilder,
@@ -133,7 +133,7 @@ mod tests {
 
         let rect = Rectangle::new(Point::zero(), Size::new(20, 30)).into_styled(style);
 
-        assert!(rounded_rect.into_iter().eq(rect.pixels()));
+        assert!(rounded_rect.into_iter().eq(rect.into_pixels()));
     }
 
     #[test]

--- a/embedded-graphics/src/primitives/rounded_rectangle/styled.rs
+++ b/embedded-graphics/src/primitives/rounded_rectangle/styled.rs
@@ -100,7 +100,7 @@ mod tests {
         drawable::Drawable,
         geometry::{Point, Size},
         mock_display::MockDisplay,
-        pixel_iterator::PixelIterator,
+        pixel_iterator::IntoPixelIterator,
         pixelcolor::{BinaryColor, Rgb888, RgbColor},
         primitives::{rectangle::Rectangle, CornerRadii, Primitive},
         style::PrimitiveStyleBuilder,

--- a/embedded-graphics/src/primitives/sector/points.rs
+++ b/embedded-graphics/src/primitives/sector/points.rs
@@ -48,8 +48,8 @@ impl Iterator for Points {
 mod tests {
     use super::*;
     use crate::{
-        drawable::Pixel, geometry::AngleUnit, pixelcolor::BinaryColor, primitives::Primitive,
-        style::PrimitiveStyle,
+        drawable::Pixel, geometry::AngleUnit, pixel_iterator::IntoPixels, pixelcolor::BinaryColor,
+        primitives::Primitive, style::PrimitiveStyle,
     };
 
     #[test]
@@ -59,7 +59,7 @@ mod tests {
         let styled_points = sector
             .clone()
             .into_styled(PrimitiveStyle::with_fill(BinaryColor::On))
-            .into_iter()
+            .into_pixels()
             .map(|Pixel(p, _)| p);
 
         assert!(sector.points().eq(styled_points));

--- a/embedded-graphics/src/primitives/sector/styled.rs
+++ b/embedded-graphics/src/primitives/sector/styled.rs
@@ -1,6 +1,7 @@
 use crate::{
     drawable::{Drawable, Pixel},
     geometry::Point,
+    pixel_iterator::IntoPixels,
     pixelcolor::PixelColor,
     primitives::{
         arc::PlaneSectorIterator, circle, circle::DistanceIterator, line::ThickPoints, Sector,
@@ -127,14 +128,15 @@ where
     }
 }
 
-impl<'a, C> IntoIterator for &'a Styled<Sector, PrimitiveStyle<C>>
+impl<'a, C> IntoPixels for &'a Styled<Sector, PrimitiveStyle<C>>
 where
     C: PixelColor,
 {
-    type Item = Pixel<C>;
-    type IntoIter = StyledPixels<C>;
+    type Color = C;
 
-    fn into_iter(self) -> Self::IntoIter {
+    type Iter = StyledPixels<Self::Color>;
+
+    fn into_pixels(self) -> Self::Iter {
         StyledPixels::new(self)
     }
 }
@@ -147,7 +149,7 @@ where
     where
         D: DrawTarget<Color = C>,
     {
-        display.draw_iter(self)
+        display.draw_iter(self.into_pixels())
     }
 }
 
@@ -238,7 +240,7 @@ mod tests {
             Sector::new(Point::new(-5, -5), 21, 0.0.deg(), 90.0.deg())
                 .into_styled(PrimitiveStyle::with_fill(BinaryColor::On));
 
-        assert!(sector.into_iter().count() > 0);
+        assert!(sector.into_pixels().count() > 0);
     }
 
     #[test]

--- a/embedded-graphics/src/primitives/sector/styled.rs
+++ b/embedded-graphics/src/primitives/sector/styled.rs
@@ -128,7 +128,7 @@ where
     }
 }
 
-impl<'a, C> IntoPixels for &'a Styled<Sector, PrimitiveStyle<C>>
+impl<C> IntoPixels for &Styled<Sector, PrimitiveStyle<C>>
 where
     C: PixelColor,
 {

--- a/embedded-graphics/src/primitives/triangle/points.rs
+++ b/embedded-graphics/src/primitives/triangle/points.rs
@@ -25,8 +25,8 @@ impl Iterator for Points {
 mod tests {
     use super::*;
     use crate::{
-        drawable::Pixel, pixelcolor::BinaryColor, primitives::Primitive, style::PrimitiveStyle,
-        transform::Transform,
+        drawable::Pixel, pixel_iterator::IntoPixels, pixelcolor::BinaryColor,
+        primitives::Primitive, style::PrimitiveStyle, transform::Transform,
     };
 
     #[test]
@@ -36,7 +36,7 @@ mod tests {
         let styled_points = triangle
             .clone()
             .into_styled(PrimitiveStyle::with_fill(BinaryColor::On))
-            .into_iter()
+            .into_pixels()
             .map(|Pixel(p, _)| p);
 
         assert!(triangle.points().eq(styled_points));

--- a/embedded-graphics/src/primitives/triangle/scanline_iterator.rs
+++ b/embedded-graphics/src/primitives/triangle/scanline_iterator.rs
@@ -160,7 +160,8 @@ impl Iterator for ScanlineIterator {
 mod tests {
     use super::*;
     use crate::{
-        drawable::Pixel, pixelcolor::BinaryColor, style::PrimitiveStyle, transform::Transform,
+        drawable::Pixel, pixel_iterator::IntoPixels, pixelcolor::BinaryColor,
+        style::PrimitiveStyle, transform::Transform,
     };
 
     #[test]
@@ -170,7 +171,7 @@ mod tests {
         let styled_points = triangle
             .clone()
             .into_styled(PrimitiveStyle::with_fill(BinaryColor::On))
-            .into_iter()
+            .into_pixels()
             .map(|Pixel(p, _)| p);
 
         assert!(triangle.points().eq(styled_points));

--- a/embedded-graphics/src/primitives/triangle/styled.rs
+++ b/embedded-graphics/src/primitives/triangle/styled.rs
@@ -1,6 +1,7 @@
 use crate::{
     draw_target::DrawTarget,
     drawable::{Drawable, Pixel},
+    pixel_iterator::IntoPixels,
     pixelcolor::PixelColor,
     primitives::triangle::{
         scanline_iterator::{PointType, ScanlineIterator},
@@ -62,14 +63,15 @@ where
     }
 }
 
-impl<C> IntoIterator for &Styled<Triangle, PrimitiveStyle<C>>
+impl<C> IntoPixels for &Styled<Triangle, PrimitiveStyle<C>>
 where
     C: PixelColor,
 {
-    type Item = Pixel<C>;
-    type IntoIter = StyledPixels<C>;
+    type Color = C;
 
-    fn into_iter(self) -> Self::IntoIter {
+    type Iter = StyledPixels<Self::Color>;
+
+    fn into_pixels(self) -> Self::Iter {
         StyledPixels::new(self)
     }
 }
@@ -82,7 +84,7 @@ where
     where
         D: DrawTarget<Color = C>,
     {
-        display.draw_iter(self)
+        display.draw_iter(self.into_pixels())
     }
 }
 
@@ -103,7 +105,7 @@ mod tests {
     fn unfilled_no_stroke_width_no_triangle() {
         let mut tri = Triangle::new(Point::new(2, 2), Point::new(4, 2), Point::new(2, 4))
             .into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 0))
-            .into_iter();
+            .into_pixels();
 
         assert_eq!(tri.next(), None);
     }
@@ -215,8 +217,8 @@ mod tests {
             .into_styled(PrimitiveStyle::with_fill(BinaryColor::On));
         let on_screen = off_screen.translate(Point::new(0, 35));
 
-        assert!(off_screen.into_iter().eq(on_screen
-            .into_iter()
+        assert!(off_screen.into_pixels().eq(on_screen
+            .into_pixels()
             .map(|Pixel(p, col)| Pixel(p - Point::new(0, 35), col))));
     }
 

--- a/embedded-graphics/tests/chaining.rs
+++ b/embedded-graphics/tests/chaining.rs
@@ -47,7 +47,7 @@ fn it_supports_chaining() -> Result<(), core::convert::Infallible> {
         .chain(
             Circle::new(Point::new(1, 1), 3)
                 .into_styled(PrimitiveStyle::default())
-                .into_iter(),
+                .into_pixels(),
         );
 
     chained.draw(&mut display)
@@ -56,11 +56,11 @@ fn it_supports_chaining() -> Result<(), core::convert::Infallible> {
 fn multi() -> impl Iterator<Item = Pixel<TestPixelColor>> {
     let line = Line::new(Point::new(0, 1), Point::new(2, 3))
         .into_styled(PrimitiveStyle::with_stroke(1u8.into(), 1))
-        .into_iter();
+        .into_pixels();
 
     let circle = Circle::new(Point::new(2, 2), 7)
         .into_styled(PrimitiveStyle::with_stroke(1u8.into(), 1))
-        .into_iter();
+        .into_pixels();
 
     line.chain(circle)
 }
@@ -70,22 +70,6 @@ fn return_from_fn() -> Result<(), core::convert::Infallible> {
     let mut display = FakeDisplay {};
 
     let chained = multi();
-
-    chained.draw(&mut display)
-}
-
-#[test]
-fn implicit_into_iter() -> Result<(), core::convert::Infallible> {
-    let mut display = FakeDisplay {};
-
-    let chained = Rectangle::new(Point::new(0, 0), Size::new(1, 1))
-        .into_styled(PrimitiveStyle::default())
-        .into_pixels()
-        .chain(
-            Circle::new(Point::new(1, 1), 3)
-                .into_styled(PrimitiveStyle::default())
-                .into_iter(),
-        );
 
     chained.draw(&mut display)
 }

--- a/embedded-graphics/tests/chaining.rs
+++ b/embedded-graphics/tests/chaining.rs
@@ -43,7 +43,7 @@ fn it_supports_chaining() -> Result<(), core::convert::Infallible> {
 
     let chained = Rectangle::new(Point::new(0, 0), Size::new(1, 1))
         .into_styled(PrimitiveStyle::default())
-        .into_iter()
+        .pixels()
         .chain(
             Circle::new(Point::new(1, 1), 3)
                 .into_styled(PrimitiveStyle::default())
@@ -80,7 +80,7 @@ fn implicit_into_iter() -> Result<(), core::convert::Infallible> {
 
     let chained = Rectangle::new(Point::new(0, 0), Size::new(1, 1))
         .into_styled(PrimitiveStyle::default())
-        .into_iter()
+        .pixels()
         .chain(
             Circle::new(Point::new(1, 1), 3)
                 .into_styled(PrimitiveStyle::default())

--- a/embedded-graphics/tests/chaining.rs
+++ b/embedded-graphics/tests/chaining.rs
@@ -43,7 +43,7 @@ fn it_supports_chaining() -> Result<(), core::convert::Infallible> {
 
     let chained = Rectangle::new(Point::new(0, 0), Size::new(1, 1))
         .into_styled(PrimitiveStyle::default())
-        .pixels()
+        .into_pixels()
         .chain(
             Circle::new(Point::new(1, 1), 3)
                 .into_styled(PrimitiveStyle::default())
@@ -80,7 +80,7 @@ fn implicit_into_iter() -> Result<(), core::convert::Infallible> {
 
     let chained = Rectangle::new(Point::new(0, 0), Size::new(1, 1))
         .into_styled(PrimitiveStyle::default())
-        .pixels()
+        .into_pixels()
         .chain(
             Circle::new(Point::new(1, 1), 3)
                 .into_styled(PrimitiveStyle::default())

--- a/embedded-graphics/tests/chaining.rs
+++ b/embedded-graphics/tests/chaining.rs
@@ -43,7 +43,7 @@ fn it_supports_chaining() -> Result<(), core::convert::Infallible> {
 
     let chained = Rectangle::new(Point::new(0, 0), Size::new(1, 1))
         .into_styled(PrimitiveStyle::default())
-        .into_pixels()
+        .pixels()
         .chain(
             Circle::new(Point::new(1, 1), 3)
                 .into_styled(PrimitiveStyle::default())
@@ -80,7 +80,7 @@ fn implicit_into_iter() -> Result<(), core::convert::Infallible> {
 
     let chained = Rectangle::new(Point::new(0, 0), Size::new(1, 1))
         .into_styled(PrimitiveStyle::default())
-        .into_pixels()
+        .pixels()
         .chain(
             Circle::new(Point::new(1, 1), 3)
                 .into_styled(PrimitiveStyle::default())

--- a/simulator/benches/fonts.rs
+++ b/simulator/benches/fonts.rs
@@ -12,7 +12,7 @@ fn font_6x8(c: &mut Criterion) {
         let object = Text::new("Hello world!", Point::zero())
             .into_styled(TextStyle::new(Font6x8, Gray8::new(10)));
 
-        b.iter(|| object.into_iter().collect::<Vec<Pixel<Gray8>>>())
+        b.iter(|| object.into_pixels().collect::<Vec<Pixel<Gray8>>>())
     });
 }
 
@@ -21,7 +21,7 @@ fn font_12x16(c: &mut Criterion) {
         let object = Text::new("Hello world!", Point::zero())
             .into_styled(TextStyle::new(Font12x16, Gray8::new(10)));
 
-        b.iter(|| object.into_iter().collect::<Vec<Pixel<Gray8>>>())
+        b.iter(|| object.into_pixels().collect::<Vec<Pixel<Gray8>>>())
     });
 }
 

--- a/simulator/benches/primitives.rs
+++ b/simulator/benches/primitives.rs
@@ -30,7 +30,7 @@ fn filled_rect(c: &mut Criterion) {
 
         let object = &Rectangle::new(Point::new(100, 100), Size::new(100, 100)).into_styled(style);
 
-        b.iter(|| object.into_iter().collect::<Vec<Pixel<Gray8>>>())
+        b.iter(|| object.pixels().collect::<Vec<Pixel<Gray8>>>())
     });
 }
 
@@ -39,7 +39,7 @@ fn empty_rect(c: &mut Criterion) {
         let object = &Rectangle::new(Point::new(100, 100), Size::new(100, 100))
             .into_styled(PrimitiveStyle::with_stroke(Gray8::new(10), 1));
 
-        b.iter(|| object.into_iter().collect::<Vec<Pixel<Gray8>>>())
+        b.iter(|| object.pixels().collect::<Vec<Pixel<Gray8>>>())
     });
 }
 

--- a/simulator/benches/primitives.rs
+++ b/simulator/benches/primitives.rs
@@ -30,7 +30,7 @@ fn filled_rect(c: &mut Criterion) {
 
         let object = &Rectangle::new(Point::new(100, 100), Size::new(100, 100)).into_styled(style);
 
-        b.iter(|| object.pixels().collect::<Vec<Pixel<Gray8>>>())
+        b.iter(|| object.into_pixels().collect::<Vec<Pixel<Gray8>>>())
     });
 }
 
@@ -39,7 +39,7 @@ fn empty_rect(c: &mut Criterion) {
         let object = &Rectangle::new(Point::new(100, 100), Size::new(100, 100))
             .into_styled(PrimitiveStyle::with_stroke(Gray8::new(10), 1));
 
-        b.iter(|| object.pixels().collect::<Vec<Pixel<Gray8>>>())
+        b.iter(|| object.into_pixels().collect::<Vec<Pixel<Gray8>>>())
     });
 }
 

--- a/simulator/benches/primitives.rs
+++ b/simulator/benches/primitives.rs
@@ -16,7 +16,7 @@ fn filled_circle(c: &mut Criterion) {
 
         let object = &Circle::new(Point::new(100, 100), 100).into_styled(style);
 
-        b.iter(|| object.into_iter().collect::<Vec<Pixel<Gray8>>>())
+        b.iter(|| object.into_pixels().collect::<Vec<Pixel<Gray8>>>())
     });
 }
 
@@ -48,7 +48,7 @@ fn line(c: &mut Criterion) {
         let object = &Line::new(Point::new(100, 100), Point::new(200, 200))
             .into_styled(PrimitiveStyle::with_stroke(Gray8::new(10), 1));
 
-        b.iter(|| object.into_iter().collect::<Vec<Pixel<Gray8>>>())
+        b.iter(|| object.into_pixels().collect::<Vec<Pixel<Gray8>>>())
     });
 }
 
@@ -57,7 +57,7 @@ fn thick_line(c: &mut Criterion) {
         let object = &Line::new(Point::new(100, 100), Point::new(150, 200))
             .into_styled(PrimitiveStyle::with_stroke(Gray8::new(10), 10));
 
-        b.iter(|| object.into_iter().collect::<Vec<Pixel<Gray8>>>())
+        b.iter(|| object.into_pixels().collect::<Vec<Pixel<Gray8>>>())
     });
 }
 
@@ -66,7 +66,7 @@ fn thicker_line(c: &mut Criterion) {
         let object = &Line::new(Point::new(20, 20), Point::new(150, 200))
             .into_styled(PrimitiveStyle::with_stroke(Gray8::new(10), 50));
 
-        b.iter(|| object.into_iter().collect::<Vec<Pixel<Gray8>>>())
+        b.iter(|| object.into_pixels().collect::<Vec<Pixel<Gray8>>>())
     });
 }
 
@@ -75,7 +75,7 @@ fn triangle(c: &mut Criterion) {
         let object = &Triangle::new(Point::new(5, 10), Point::new(15, 20), Point::new(5, 20))
             .into_styled(PrimitiveStyle::with_stroke(Gray8::new(10), 1));
 
-        b.iter(|| object.into_iter().collect::<Vec<Pixel<Gray8>>>())
+        b.iter(|| object.into_pixels().collect::<Vec<Pixel<Gray8>>>())
     });
 }
 
@@ -84,7 +84,7 @@ fn filled_triangle(c: &mut Criterion) {
         let object = &Triangle::new(Point::new(5, 10), Point::new(15, 20), Point::new(5, 20))
             .into_styled(PrimitiveStyle::with_fill(Gray8::new(1)));
 
-        b.iter(|| object.into_iter().collect::<Vec<Pixel<Gray8>>>())
+        b.iter(|| object.into_pixels().collect::<Vec<Pixel<Gray8>>>())
     });
 }
 
@@ -93,7 +93,7 @@ fn ellipse(c: &mut Criterion) {
         let object = &Ellipse::new(Point::new(10, 10), Size::new(50, 30))
             .into_styled(PrimitiveStyle::with_stroke(Gray8::new(1), 1));
 
-        b.iter(|| object.into_iter().collect::<Vec<Pixel<Gray8>>>())
+        b.iter(|| object.into_pixels().collect::<Vec<Pixel<Gray8>>>())
     });
 }
 
@@ -102,7 +102,7 @@ fn filled_ellipse(c: &mut Criterion) {
         let object = &Ellipse::new(Point::new(10, 10), Size::new(50, 30))
             .into_styled(PrimitiveStyle::with_fill(Gray8::new(1)));
 
-        b.iter(|| object.into_iter().collect::<Vec<Pixel<Gray8>>>())
+        b.iter(|| object.into_pixels().collect::<Vec<Pixel<Gray8>>>())
     });
 }
 
@@ -111,7 +111,7 @@ fn arc(c: &mut Criterion) {
         let object = &Arc::new(Point::new(100, 100), 100, -30.0.deg(), 150.0.deg())
             .into_styled(PrimitiveStyle::with_stroke(Gray8::new(1), 1));
 
-        b.iter(|| object.into_iter().collect::<Vec<Pixel<Gray8>>>())
+        b.iter(|| object.into_pixels().collect::<Vec<Pixel<Gray8>>>())
     });
 }
 
@@ -120,7 +120,7 @@ fn sector(c: &mut Criterion) {
         let object = &Sector::new(Point::new(100, 100), 100, -30.0.deg(), 150.0.deg())
             .into_styled(PrimitiveStyle::with_stroke(Gray8::new(1), 1));
 
-        b.iter(|| object.into_iter().collect::<Vec<Pixel<Gray8>>>())
+        b.iter(|| object.into_pixels().collect::<Vec<Pixel<Gray8>>>())
     });
 }
 
@@ -129,7 +129,7 @@ fn filled_sector(c: &mut Criterion) {
         let object = &Sector::new(Point::new(100, 100), 100, -30.0.deg(), 150.0.deg())
             .into_styled(PrimitiveStyle::with_fill(Gray8::new(1)));
 
-        b.iter(|| object.into_iter().collect::<Vec<Pixel<Gray8>>>())
+        b.iter(|| object.into_pixels().collect::<Vec<Pixel<Gray8>>>())
     });
 }
 
@@ -146,7 +146,7 @@ fn polyline(c: &mut Criterion) {
         let object =
             &Polyline::new(&points).into_styled(PrimitiveStyle::with_stroke(Gray8::new(1), 1));
 
-        b.iter(|| object.into_iter().collect::<Vec<Pixel<Gray8>>>())
+        b.iter(|| object.into_pixels().collect::<Vec<Pixel<Gray8>>>())
     });
 }
 
@@ -164,7 +164,7 @@ fn rounded_rectangle(c: &mut Criterion) {
                 .build(),
         );
 
-        b.iter(|| object.into_iter().collect::<Vec<Pixel<Gray8>>>())
+        b.iter(|| object.into_pixels().collect::<Vec<Pixel<Gray8>>>())
     });
 }
 
@@ -187,7 +187,7 @@ fn rounded_rectangle_corners(c: &mut Criterion) {
                 .build(),
         );
 
-        b.iter(|| object.into_iter().collect::<Vec<Pixel<Gray8>>>())
+        b.iter(|| object.into_pixels().collect::<Vec<Pixel<Gray8>>>())
     });
 }
 

--- a/simulator/examples/analog-clock.rs
+++ b/simulator/examples/analog-clock.rs
@@ -136,7 +136,7 @@ fn draw_digital_clock<'a>(time_str: &'a str) -> impl Iterator<Item = Pixel<Binar
     .into_styled(PrimitiveStyle::with_fill(BinaryColor::On));
 
     // Draw the white background first, then the black text. Order matters here
-    background.pixels().chain(&text)
+    background.into_pixels().chain(&text)
 }
 
 fn main() -> Result<(), core::convert::Infallible> {

--- a/simulator/examples/analog-clock.rs
+++ b/simulator/examples/analog-clock.rs
@@ -46,7 +46,7 @@ fn draw_face() -> impl Iterator<Item = Pixel<BinaryColor>> {
         .into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 2));
 
     // Create 12 `Line`s starting from the outer edge and drawing inwards by `tic_len` pixels
-    let tics = (0..12).into_iter().map(move |index| {
+    let tics = (0..12).map(move |index| {
         // Start angle around the circle, in radians
         let angle = START + (PI * 2.0 / 12.0) * index as f32;
 
@@ -58,12 +58,12 @@ fn draw_face() -> impl Iterator<Item = Pixel<BinaryColor>> {
 
         Line::new(start, end)
             .into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 1))
-            .into_iter()
+            .into_pixels()
     });
 
     // Create a single iterator of pixels, first iterating over the circle, then over the 12 lines
     // generated
-    face.into_iter().chain(tics.flatten())
+    face.into_pixels().chain(tics.flatten())
 }
 
 /// Draw the seconds hand given a seconds value (0 - 59)
@@ -89,7 +89,7 @@ fn draw_seconds_hand(seconds: u32) -> impl Iterator<Item = Pixel<BinaryColor>> {
     // Add a fancy circle near the end of the hand
     let decoration = Circle::with_center(decoration_position, 11).into_styled(decoration_style);
 
-    hand.into_iter().chain(&decoration)
+    hand.into_pixels().chain(decoration.into_pixels())
 }
 
 /// Draw the hour hand (0-11)

--- a/simulator/examples/analog-clock.rs
+++ b/simulator/examples/analog-clock.rs
@@ -136,7 +136,7 @@ fn draw_digital_clock<'a>(time_str: &'a str) -> impl Iterator<Item = Pixel<Binar
     .into_styled(PrimitiveStyle::with_fill(BinaryColor::On));
 
     // Draw the white background first, then the black text. Order matters here
-    background.into_iter().chain(&text)
+    background.pixels().chain(&text)
 }
 
 fn main() -> Result<(), core::convert::Infallible> {

--- a/simulator/examples/analog-clock.rs
+++ b/simulator/examples/analog-clock.rs
@@ -136,7 +136,7 @@ fn draw_digital_clock<'a>(time_str: &'a str) -> impl Iterator<Item = Pixel<Binar
     .into_styled(PrimitiveStyle::with_fill(BinaryColor::On));
 
     // Draw the white background first, then the black text. Order matters here
-    background.into_pixels().chain(&text)
+    background.into_pixels().chain(text.into_pixels())
 }
 
 fn main() -> Result<(), core::convert::Infallible> {

--- a/simulator/examples/chaining.rs
+++ b/simulator/examples/chaining.rs
@@ -30,7 +30,7 @@ fn main() -> Result<(), core::convert::Infallible> {
     // Draw an 3px wide outline around the display.
     Rectangle::new(Point::zero(), display.size())
         .into_styled(thick_stroke)
-        .into_iter()
+        .pixels()
         .chain(
             // Draw a triangle.
             Triangle::new(
@@ -45,7 +45,7 @@ fn main() -> Result<(), core::convert::Infallible> {
             // Draw a filled square
             Rectangle::new(Point::new(52, yoffset), Size::new(16, 16))
                 .into_styled(fill)
-                .into_iter(),
+                .pixels(),
         )
         .chain(
             // Draw a circle with a 3px wide stroke.

--- a/simulator/examples/chaining.rs
+++ b/simulator/examples/chaining.rs
@@ -39,7 +39,7 @@ fn main() -> Result<(), core::convert::Infallible> {
                 Point::new(16 + 8, yoffset),
             )
             .into_styled(thin_stroke)
-            .into_iter(),
+            .into_pixels(),
         )
         .chain(
             // Draw a filled square
@@ -51,7 +51,7 @@ fn main() -> Result<(), core::convert::Infallible> {
             // Draw a circle with a 3px wide stroke.
             Circle::new(Point::new(88, yoffset), 17)
                 .into_styled(thick_stroke)
-                .into_iter(),
+                .into_pixels(),
         )
         .chain({
             // Draw centered text.

--- a/simulator/examples/chaining.rs
+++ b/simulator/examples/chaining.rs
@@ -60,7 +60,7 @@ fn main() -> Result<(), core::convert::Infallible> {
 
             Text::new(text, Point::new(64 - width / 2, 40))
                 .into_styled(text_style)
-                .into_iter()
+                .into_pixels()
         })
         .draw(&mut display)?;
 

--- a/simulator/examples/chaining.rs
+++ b/simulator/examples/chaining.rs
@@ -30,7 +30,7 @@ fn main() -> Result<(), core::convert::Infallible> {
     // Draw an 3px wide outline around the display.
     Rectangle::new(Point::zero(), display.size())
         .into_styled(thick_stroke)
-        .pixels()
+        .into_pixels()
         .chain(
             // Draw a triangle.
             Triangle::new(
@@ -45,7 +45,7 @@ fn main() -> Result<(), core::convert::Infallible> {
             // Draw a filled square
             Rectangle::new(Point::new(52, yoffset), Size::new(16, 16))
                 .into_styled(fill)
-                .pixels(),
+                .into_pixels(),
         )
         .chain(
             // Draw a circle with a 3px wide stroke.

--- a/simulator/examples/line-thickness.rs
+++ b/simulator/examples/line-thickness.rs
@@ -45,7 +45,6 @@ fn draw(
         Point::zero(),
     )
     .into_styled(TextStyle::new(Font6x8, Rgb888::MAGENTA))
-    .into_iter()
     .draw(display)?;
 
     Line::new(start, position)

--- a/simulator/examples/primitives-stroke.rs
+++ b/simulator/examples/primitives-stroke.rs
@@ -37,7 +37,7 @@ fn main() -> Result<(), core::convert::Infallible> {
     circle
         .into_styled(thin_stroke)
         .into_iter()
-        .chain(rectangle.into_styled(thin_stroke).pixels())
+        .chain(rectangle.into_styled(thin_stroke).into_pixels())
         .chain(line.into_styled(thin_stroke).into_iter())
         .chain(triangle.into_styled(thin_stroke).into_iter())
         .chain(ellipse.into_styled(thin_stroke).into_iter())
@@ -53,7 +53,7 @@ fn main() -> Result<(), core::convert::Infallible> {
             rectangle
                 .translate(offset)
                 .into_styled(medium_stroke)
-                .pixels(),
+                .into_pixels(),
         )
         .chain(
             line.translate(offset)
@@ -89,7 +89,7 @@ fn main() -> Result<(), core::convert::Infallible> {
             rectangle
                 .translate(offset)
                 .into_styled(thick_stroke)
-                .pixels(),
+                .into_pixels(),
         )
         .chain(line.translate(offset).into_styled(thick_stroke).into_iter())
         .chain(

--- a/simulator/examples/primitives-stroke.rs
+++ b/simulator/examples/primitives-stroke.rs
@@ -36,19 +36,19 @@ fn main() -> Result<(), core::convert::Infallible> {
 
     circle
         .into_styled(thin_stroke)
-        .into_iter()
+        .into_pixels()
         .chain(rectangle.into_styled(thin_stroke).into_pixels())
-        .chain(line.into_styled(thin_stroke).into_iter())
-        .chain(triangle.into_styled(thin_stroke).into_iter())
-        .chain(ellipse.into_styled(thin_stroke).into_iter())
-        .chain(rounded_rectangle.into_styled(thin_stroke).into_iter())
+        .chain(line.into_styled(thin_stroke).into_pixels())
+        .chain(triangle.into_styled(thin_stroke).into_pixels())
+        .chain(ellipse.into_styled(thin_stroke).into_pixels())
+        .chain(rounded_rectangle.into_styled(thin_stroke).into_pixels())
         .draw(&mut display)?;
 
     let offset = Point::new(0, 64 + PADDING);
     circle
         .translate(offset)
         .into_styled(medium_stroke)
-        .into_iter()
+        .into_pixels()
         .chain(
             rectangle
                 .translate(offset)
@@ -58,25 +58,25 @@ fn main() -> Result<(), core::convert::Infallible> {
         .chain(
             line.translate(offset)
                 .into_styled(medium_stroke)
-                .into_iter(),
+                .into_pixels(),
         )
         .chain(
             triangle
                 .translate(offset)
                 .into_styled(medium_stroke)
-                .into_iter(),
+                .into_pixels(),
         )
         .chain(
             ellipse
                 .translate(offset)
                 .into_styled(medium_stroke)
-                .into_iter(),
+                .into_pixels(),
         )
         .chain(
             rounded_rectangle
                 .translate(offset)
                 .into_styled(medium_stroke)
-                .into_iter(),
+                .into_pixels(),
         )
         .draw(&mut display)?;
 
@@ -84,31 +84,35 @@ fn main() -> Result<(), core::convert::Infallible> {
     circle
         .translate(offset)
         .into_styled(thick_stroke)
-        .into_iter()
+        .into_pixels()
         .chain(
             rectangle
                 .translate(offset)
                 .into_styled(thick_stroke)
                 .into_pixels(),
         )
-        .chain(line.translate(offset).into_styled(thick_stroke).into_iter())
+        .chain(
+            line.translate(offset)
+                .into_styled(thick_stroke)
+                .into_pixels(),
+        )
         .chain(
             triangle
                 .translate(offset)
                 .into_styled(thick_stroke)
-                .into_iter(),
+                .into_pixels(),
         )
         .chain(
             ellipse
                 .translate(offset)
                 .into_styled(thick_stroke)
-                .into_iter(),
+                .into_pixels(),
         )
         .chain(
             rounded_rectangle
                 .translate(offset)
                 .into_styled(thick_stroke)
-                .into_iter(),
+                .into_pixels(),
         )
         .draw(&mut display)?;
 

--- a/simulator/examples/primitives-stroke.rs
+++ b/simulator/examples/primitives-stroke.rs
@@ -37,7 +37,7 @@ fn main() -> Result<(), core::convert::Infallible> {
     circle
         .into_styled(thin_stroke)
         .into_iter()
-        .chain(rectangle.into_styled(thin_stroke).into_iter())
+        .chain(rectangle.into_styled(thin_stroke).pixels())
         .chain(line.into_styled(thin_stroke).into_iter())
         .chain(triangle.into_styled(thin_stroke).into_iter())
         .chain(ellipse.into_styled(thin_stroke).into_iter())
@@ -53,7 +53,7 @@ fn main() -> Result<(), core::convert::Infallible> {
             rectangle
                 .translate(offset)
                 .into_styled(medium_stroke)
-                .into_iter(),
+                .pixels(),
         )
         .chain(
             line.translate(offset)
@@ -89,7 +89,7 @@ fn main() -> Result<(), core::convert::Infallible> {
             rectangle
                 .translate(offset)
                 .into_styled(thick_stroke)
-                .into_iter(),
+                .pixels(),
         )
         .chain(line.translate(offset).into_styled(thick_stroke).into_iter())
         .chain(

--- a/simulator/examples/text-transparent.rs
+++ b/simulator/examples/text-transparent.rs
@@ -16,7 +16,6 @@ fn main() -> Result<(), core::convert::Infallible> {
 
     Circle::new(Point::new(0, 0), 41)
         .into_styled(PrimitiveStyle::with_fill(Rgb565::RED))
-        .into_iter()
         .draw(&mut display)
         .unwrap();
 

--- a/tinybmp/tests/embedded_graphics.rs
+++ b/tinybmp/tests/embedded_graphics.rs
@@ -35,9 +35,9 @@ fn it_can_have_negative_offsets() {
     let image = Bmp::from_slice(include_bytes!("./chessboard-4px-color-16bit.bmp")).unwrap();
     let image: Image<_, Rgb565> = Image::new(&image, Point::zero()).translate(Point::new(-1, -1));
 
-    assert_eq!(image.into_iter().count(), 9);
+    assert_eq!(image.pixels().count(), 9);
 
-    let it = image.into_iter();
+    let it = image.pixels();
 
     let expected: [Pixel<Rgb565>; 9] = [
         Pixel(Point::new(0, 0), Rgb565::RED),
@@ -77,7 +77,7 @@ macro_rules! test_pattern {
 
         assert_eq!(image.bounding_box().size, Size::new(4, 2));
 
-        let mut iter = image.into_iter();
+        let mut iter = image.pixels();
         for (y, row) in pattern.iter().enumerate() {
             for (x, &expected_color) in row.iter().enumerate() {
                 let pos = Point::new(x as i32, y as i32);
@@ -119,7 +119,7 @@ fn colors_grey8() {
 
     assert_eq!(image.bounding_box().size, Size::new(3, 1));
 
-    let mut iter = image.into_iter();
+    let mut iter = image.pixels();
 
     let p = iter.next().unwrap();
     assert_eq!(p.0, Point::new(0, 0));
@@ -144,7 +144,7 @@ fn issue_136_row_size_is_multiple_of_4_bytes() {
 
     let mut display = MockDisplay::new();
     image
-        .into_iter()
+        .pixels()
         .map(|Pixel(p, c)| {
             Pixel(
                 p,

--- a/tinybmp/tests/embedded_graphics.rs
+++ b/tinybmp/tests/embedded_graphics.rs
@@ -35,9 +35,9 @@ fn it_can_have_negative_offsets() {
     let image = Bmp::from_slice(include_bytes!("./chessboard-4px-color-16bit.bmp")).unwrap();
     let image: Image<_, Rgb565> = Image::new(&image, Point::zero()).translate(Point::new(-1, -1));
 
-    assert_eq!(image.pixels().count(), 9);
+    assert_eq!(image.into_pixels().count(), 9);
 
-    let it = image.pixels();
+    let it = image.into_pixels();
 
     let expected: [Pixel<Rgb565>; 9] = [
         Pixel(Point::new(0, 0), Rgb565::RED),
@@ -77,7 +77,7 @@ macro_rules! test_pattern {
 
         assert_eq!(image.bounding_box().size, Size::new(4, 2));
 
-        let mut iter = image.pixels();
+        let mut iter = image.into_pixels();
         for (y, row) in pattern.iter().enumerate() {
             for (x, &expected_color) in row.iter().enumerate() {
                 let pos = Point::new(x as i32, y as i32);
@@ -119,7 +119,7 @@ fn colors_grey8() {
 
     assert_eq!(image.bounding_box().size, Size::new(3, 1));
 
-    let mut iter = image.pixels();
+    let mut iter = image.into_pixels();
 
     let p = iter.next().unwrap();
     assert_eq!(p.0, Point::new(0, 0));
@@ -144,7 +144,7 @@ fn issue_136_row_size_is_multiple_of_4_bytes() {
 
     let mut display = MockDisplay::new();
     image
-        .pixels()
+        .into_pixels()
         .map(|Pixel(p, c)| {
             Pixel(
                 p,

--- a/tinytga/tests/embedded_graphics.rs
+++ b/tinytga/tests/embedded_graphics.rs
@@ -30,7 +30,7 @@ fn chessboard_compressed() {
     let im = Tga::from_slice(include_bytes!("./chessboard_4px_rle.tga")).unwrap();
     let im: Image<_, Rgb888> = Image::new(&im, Point::zero());
 
-    let mut pixels = im.pixels();
+    let mut pixels = im.into_pixels();
 
     for (i, (x, y, color)) in PIXEL_COLORS.iter().enumerate() {
         assert_eq!(
@@ -50,7 +50,7 @@ fn chessboard_uncompressed() {
     let im = Tga::from_slice(include_bytes!("./chessboard_raw.tga")).unwrap();
     let im: Image<_, Rgb888> = Image::new(&im, Point::zero());
 
-    let mut pixels = im.pixels();
+    let mut pixels = im.into_pixels();
 
     for (i, (x, y, color)) in PIXEL_COLORS.iter().enumerate() {
         assert_eq!(

--- a/tinytga/tests/embedded_graphics.rs
+++ b/tinytga/tests/embedded_graphics.rs
@@ -30,7 +30,7 @@ fn chessboard_compressed() {
     let im = Tga::from_slice(include_bytes!("./chessboard_4px_rle.tga")).unwrap();
     let im: Image<_, Rgb888> = Image::new(&im, Point::zero());
 
-    let mut pixels = im.into_iter();
+    let mut pixels = im.pixels();
 
     for (i, (x, y, color)) in PIXEL_COLORS.iter().enumerate() {
         assert_eq!(
@@ -50,7 +50,7 @@ fn chessboard_uncompressed() {
     let im = Tga::from_slice(include_bytes!("./chessboard_raw.tga")).unwrap();
     let im: Image<_, Rgb888> = Image::new(&im, Point::zero());
 
-    let mut pixels = im.into_iter();
+    let mut pixels = im.pixels();
 
     for (i, (x, y, color)) in PIXEL_COLORS.iter().enumerate() {
         assert_eq!(


### PR DESCRIPTION
Hi! Thank you for helping out with Embedded Graphics development! Please:

- [x] Check that you've added passing tests and documentation
- [x] Add a simulator example(s) where applicable
- [x] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) and appropriate crate (`embedded-graphics`, `simulator`, `tinytga`, `tinybmp`) if your changes affect the **public API**
- [x] Run `rustfmt` on the project
- [x] Run `./build.sh` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

Inspired by https://github.com/jamwaffles/embedded-graphics/pull/365#issuecomment-644170782, this is a separate PR to change the use of `IntoIterator` trait impls to use a custom trait.

To that end, I've added the `PixelIterator` and `SparsePixelIterator` traits. The latter would be used in #365 and not this PR, but I think it's worth defining what both these traits should look like in the same PR.

Only `Rectangle` is ported so far to keep the diff clean at first so we can get the design sorted before I port all the primitives, fonts, image, etc.

It would also be good for backwards compatibility if we could `impl IntoIterator for T where T: PixelIterator`. I gave this a very quick try but the compiler doesn't like it. Before I spend more time on it, is it worth pursuing?

The current state as of opening is just something to get the conversation started.
