### PR TITLE
Change Drawable::draw to use &self

### DIFF
--- a/embedded-graphics/CHANGELOG.md
+++ b/embedded-graphics/CHANGELOG.md
@@ -41,6 +41,7 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 - **(breaking)** [#342](https://github.com/jamwaffles/embedded-graphics/pull/342) Refactored the `DrawTarget` trait to better support common hardware capabilities.
 - **(breaking)** [#360](https://github.com/jamwaffles/embedded-graphics/pull/360) Make the `drawable` module private. `drawable::Drawable` and `drawable::Pixel` are now exported from the crate root.
 - **(breaking)** [#390](https://github.com/jamwaffles/embedded-graphics/pull/390) `Triangle.contains` now always returns `false` for colinear triangles.
+- **(breaking)** [#393](https://github.com/jamwaffles/embedded-graphics/pull/393) `DrawTarget::draw` now uses a reference to `self` instead of taking ownership of `self`. Because of this change `DrawTarget` can no longer be implemented for pixel iterators (`Iterator<Item = C>`), which can now be drawn using the `draw` method provided by the `PixelIteratorExt` extension trait.
 
 ### Fixed
 

--- a/embedded-graphics/src/drawable.rs
+++ b/embedded-graphics/src/drawable.rs
@@ -24,11 +24,14 @@ use crate::{geometry::Point, pixelcolor::PixelColor, DrawTarget};
 ///     text: &'a str,
 /// }
 ///
-/// impl<'a, C: 'a> Drawable<C> for &Button<'a, C>
+/// impl<C> Drawable<C> for Button<'_, C>
 /// where
 ///     C: PixelColor + From<BinaryColor>,
 /// {
-///     fn draw<D: DrawTarget<Color = C>>(self, display: &mut D) -> Result<(), D::Error> {
+///     fn draw<D>(&self, display: &mut D) -> Result<(), D::Error>
+///     where
+///         D: DrawTarget<Color = C>,
+///     {
 ///         Rectangle::new(self.top_left, self.size)
 ///             .into_styled(PrimitiveStyle::with_fill(self.bg_color))
 ///             .draw(display)?;
@@ -61,7 +64,9 @@ where
     C: PixelColor,
 {
     /// Draw the graphics object using the supplied DrawTarget.
-    fn draw<D: DrawTarget<Color = C>>(self, display: &mut D) -> Result<(), D::Error>;
+    fn draw<D>(&self, display: &mut D) -> Result<(), D::Error>
+    where
+        D: DrawTarget<Color = C>;
 }
 
 /// A single pixel.
@@ -105,18 +110,11 @@ impl<C> Drawable<C> for Pixel<C>
 where
     C: PixelColor,
 {
-    fn draw<D: DrawTarget<Color = C>>(self, display: &mut D) -> Result<(), D::Error> {
-        display.draw_iter(core::iter::once(self))
-    }
-}
-
-impl<C, T> Drawable<C> for &mut T
-where
-    C: PixelColor,
-    T: Iterator<Item = Pixel<C>>,
-{
-    fn draw<D: DrawTarget<Color = C>>(self, display: &mut D) -> Result<(), D::Error> {
-        display.draw_iter(self)
+    fn draw<D>(&self, display: &mut D) -> Result<(), D::Error>
+    where
+        D: DrawTarget<Color = C>,
+    {
+        display.draw_iter(core::iter::once(*self))
     }
 }
 

--- a/embedded-graphics/src/fonts/text.rs
+++ b/embedded-graphics/src/fonts/text.rs
@@ -64,12 +64,15 @@ impl Transform for Text<'_> {
     }
 }
 
-impl<C, F> Drawable<C> for &Styled<Text<'_>, TextStyle<C, F>>
+impl<C, F> Drawable<C> for Styled<Text<'_>, TextStyle<C, F>>
 where
     C: PixelColor,
     F: Font + Copy,
 {
-    fn draw<D: DrawTarget<Color = C>>(self, display: &mut D) -> Result<(), D::Error> {
+    fn draw<D>(&self, display: &mut D) -> Result<(), D::Error>
+    where
+        D: DrawTarget<Color = C>,
+    {
         display.draw_iter(self.into_iter())
     }
 }

--- a/embedded-graphics/src/image/mod.rs
+++ b/embedded-graphics/src/image/mod.rs
@@ -190,13 +190,16 @@ impl<I, C> Transform for Image<'_, I, C> {
     }
 }
 
-impl<'a, 'b, I, C> Drawable<C> for &'a Image<'b, I, C>
+impl<'a, I, C> Drawable<C> for Image<'a, I, C>
 where
-    &'b I: IntoPixelIter<C>,
+    &'a I: IntoPixelIter<C>,
     I: ImageDimensions,
     C: PixelColor + From<<C as PixelColor>::Raw>,
 {
-    fn draw<D: DrawTarget<Color = C>>(self, display: &mut D) -> Result<(), D::Error> {
+    fn draw<D>(&self, display: &mut D) -> Result<(), D::Error>
+    where
+        D: DrawTarget<Color = C>,
+    {
         display.fill_contiguous(&self.bounding_box(), self.into_iter().map(|p| p.1))
     }
 }

--- a/embedded-graphics/src/lib.rs
+++ b/embedded-graphics/src/lib.rs
@@ -557,6 +557,7 @@ pub mod fonts;
 pub mod geometry;
 pub mod image;
 pub mod mock_display;
+pub mod pixel_iterator;
 pub mod pixelcolor;
 pub mod prelude;
 pub mod primitives;

--- a/embedded-graphics/src/pixel_iterator.rs
+++ b/embedded-graphics/src/pixel_iterator.rs
@@ -1,0 +1,28 @@
+//! Pixel iterator
+
+use crate::drawable::Pixel;
+use crate::{pixelcolor::PixelColor, DrawTarget};
+
+/// Extension trait for pixel iterators.
+pub trait PixelIteratorExt<C>
+where
+    C: PixelColor,
+{
+    /// Draws the pixel iterator to a draw target.
+    fn draw<D>(self, target: &mut D) -> Result<(), D::Error>
+    where
+        D: DrawTarget<Color = C>;
+}
+
+impl<I, C> PixelIteratorExt<C> for I
+where
+    C: PixelColor,
+    I: Iterator<Item = Pixel<C>>,
+{
+    fn draw<D>(self, target: &mut D) -> Result<(), D::Error>
+    where
+        D: DrawTarget<Color = C>,
+    {
+        target.draw_iter(self)
+    }
+}

--- a/embedded-graphics/src/prelude.rs
+++ b/embedded-graphics/src/prelude.rs
@@ -5,6 +5,7 @@ pub use crate::{
     fonts::Font,
     geometry::{Angle, AngleUnit, Dimensions, Point, Size},
     image::{ImageDimensions, IntoPixelIter},
+    pixel_iterator::PixelIteratorExt,
     pixelcolor::{raw::RawData, GrayColor, IntoStorage, PixelColor, RgbColor},
     primitives::{ContainsPoint, Primitive},
     transform::Transform,

--- a/embedded-graphics/src/primitives/arc/styled.rs
+++ b/embedded-graphics/src/primitives/arc/styled.rs
@@ -77,11 +77,14 @@ where
     }
 }
 
-impl<'a, C: 'a> Drawable<C> for &Styled<Arc, PrimitiveStyle<C>>
+impl<C> Drawable<C> for Styled<Arc, PrimitiveStyle<C>>
 where
     C: PixelColor,
 {
-    fn draw<D: DrawTarget<Color = C>>(self, display: &mut D) -> Result<(), D::Error> {
+    fn draw<D>(&self, display: &mut D) -> Result<(), D::Error>
+    where
+        D: DrawTarget<Color = C>,
+    {
         display.draw_iter(self)
     }
 }

--- a/embedded-graphics/src/primitives/circle/styled.rs
+++ b/embedded-graphics/src/primitives/circle/styled.rs
@@ -93,11 +93,14 @@ where
     }
 }
 
-impl<'a, C: 'a> Drawable<C> for &Styled<Circle, PrimitiveStyle<C>>
+impl<C> Drawable<C> for Styled<Circle, PrimitiveStyle<C>>
 where
     C: PixelColor,
 {
-    fn draw<D: DrawTarget<Color = C>>(self, display: &mut D) -> Result<(), D::Error> {
+    fn draw<D>(&self, display: &mut D) -> Result<(), D::Error>
+    where
+        D: DrawTarget<Color = C>,
+    {
         display.draw_iter(self)
     }
 }

--- a/embedded-graphics/src/primitives/ellipse/styled.rs
+++ b/embedded-graphics/src/primitives/ellipse/styled.rs
@@ -90,11 +90,14 @@ where
     }
 }
 
-impl<'a, C: 'a> Drawable<C> for &Styled<Ellipse, PrimitiveStyle<C>>
+impl<C> Drawable<C> for Styled<Ellipse, PrimitiveStyle<C>>
 where
     C: PixelColor,
 {
-    fn draw<D: DrawTarget<Color = C>>(self, display: &mut D) -> Result<(), D::Error> {
+    fn draw<D>(&self, display: &mut D) -> Result<(), D::Error>
+    where
+        D: DrawTarget<Color = C>,
+    {
         display.draw_iter(self)
     }
 }

--- a/embedded-graphics/src/primitives/line/points.rs
+++ b/embedded-graphics/src/primitives/line/points.rs
@@ -61,10 +61,8 @@ impl Iterator for Points {
 mod tests {
     use super::*;
     use crate::{
-        drawable::{Drawable, Pixel},
-        mock_display::MockDisplay,
-        pixelcolor::BinaryColor,
-        primitives::Primitive,
+        drawable::Pixel, mock_display::MockDisplay, pixel_iterator::PixelIteratorExt,
+        pixelcolor::BinaryColor, primitives::Primitive,
     };
 
     fn test_points(start: Point, end: Point, expected: &[(i32, i32)]) {

--- a/embedded-graphics/src/primitives/line/styled.rs
+++ b/embedded-graphics/src/primitives/line/styled.rs
@@ -62,11 +62,14 @@ where
     }
 }
 
-impl<'a, C: 'a> Drawable<C> for &Styled<Line, PrimitiveStyle<C>>
+impl<C> Drawable<C> for Styled<Line, PrimitiveStyle<C>>
 where
     C: PixelColor,
 {
-    fn draw<D: DrawTarget<Color = C>>(self, display: &mut D) -> Result<(), D::Error> {
+    fn draw<D>(&self, display: &mut D) -> Result<(), D::Error>
+    where
+        D: DrawTarget<Color = C>,
+    {
         display.draw_iter(self)
     }
 }

--- a/embedded-graphics/src/primitives/polyline/styled.rs
+++ b/embedded-graphics/src/primitives/polyline/styled.rs
@@ -56,11 +56,14 @@ where
     }
 }
 
-impl<'a, C: 'a> Drawable<C> for &Styled<Polyline<'a>, PrimitiveStyle<C>>
+impl<'a, C> Drawable<C> for Styled<Polyline<'a>, PrimitiveStyle<C>>
 where
     C: PixelColor,
 {
-    fn draw<D: DrawTarget<Color = C>>(self, display: &mut D) -> Result<(), D::Error> {
+    fn draw<D>(&self, display: &mut D) -> Result<(), D::Error>
+    where
+        D: DrawTarget<Color = C>,
+    {
         display.draw_iter(self.into_iter())
     }
 }

--- a/embedded-graphics/src/primitives/rectangle/styled.rs
+++ b/embedded-graphics/src/primitives/rectangle/styled.rs
@@ -85,11 +85,14 @@ where
     }
 }
 
-impl<C> Drawable<C> for &Styled<Rectangle, PrimitiveStyle<C>>
+impl<C> Drawable<C> for Styled<Rectangle, PrimitiveStyle<C>>
 where
     C: PixelColor,
 {
-    fn draw<D: DrawTarget<Color = C>>(self, display: &mut D) -> Result<(), D::Error> {
+    fn draw<D>(&self, display: &mut D) -> Result<(), D::Error>
+    where
+        D: DrawTarget<Color = C>,
+    {
         let fill_area = self.primitive.shrink(self.style.inside_stroke_width());
 
         // Fill rectangle
@@ -159,6 +162,7 @@ mod tests {
         drawable::Drawable,
         geometry::{Point, Size},
         mock_display::MockDisplay,
+        pixel_iterator::PixelIteratorExt,
         pixelcolor::{BinaryColor, Rgb565, RgbColor},
         primitives::Primitive,
         style::{PrimitiveStyle, PrimitiveStyleBuilder, StrokeAlignment},

--- a/embedded-graphics/src/primitives/rounded_rectangle/ellipse_quadrant.rs
+++ b/embedded-graphics/src/primitives/rounded_rectangle/ellipse_quadrant.rs
@@ -114,9 +114,10 @@ impl Iterator for Points {
 mod tests {
     use super::*;
     use crate::{
-        drawable::{Drawable, Pixel},
+        drawable::Pixel,
         geometry::{Point, Size},
         mock_display::MockDisplay,
+        pixel_iterator::PixelIteratorExt,
         pixelcolor::BinaryColor,
         primitives::Primitive,
     };

--- a/embedded-graphics/src/primitives/rounded_rectangle/styled.rs
+++ b/embedded-graphics/src/primitives/rounded_rectangle/styled.rs
@@ -81,11 +81,14 @@ where
     }
 }
 
-impl<C> Drawable<C> for &Styled<RoundedRectangle, PrimitiveStyle<C>>
+impl<C> Drawable<C> for Styled<RoundedRectangle, PrimitiveStyle<C>>
 where
     C: PixelColor,
 {
-    fn draw<D: DrawTarget<Color = C>>(self, display: &mut D) -> Result<(), D::Error> {
+    fn draw<D>(&self, display: &mut D) -> Result<(), D::Error>
+    where
+        D: DrawTarget<Color = C>,
+    {
         display.draw_iter(self)
     }
 }

--- a/embedded-graphics/src/primitives/sector/styled.rs
+++ b/embedded-graphics/src/primitives/sector/styled.rs
@@ -139,11 +139,14 @@ where
     }
 }
 
-impl<'a, C: 'a> Drawable<C> for &Styled<Sector, PrimitiveStyle<C>>
+impl<C> Drawable<C> for Styled<Sector, PrimitiveStyle<C>>
 where
     C: PixelColor,
 {
-    fn draw<D: DrawTarget<Color = C>>(self, display: &mut D) -> Result<(), D::Error> {
+    fn draw<D>(&self, display: &mut D) -> Result<(), D::Error>
+    where
+        D: DrawTarget<Color = C>,
+    {
         display.draw_iter(self)
     }
 }

--- a/embedded-graphics/src/primitives/triangle/styled.rs
+++ b/embedded-graphics/src/primitives/triangle/styled.rs
@@ -74,11 +74,14 @@ where
     }
 }
 
-impl<'a, C: 'a> Drawable<C> for &Styled<Triangle, PrimitiveStyle<C>>
+impl<C> Drawable<C> for Styled<Triangle, PrimitiveStyle<C>>
 where
     C: PixelColor,
 {
-    fn draw<D: DrawTarget<Color = C>>(self, display: &mut D) -> Result<(), D::Error> {
+    fn draw<D>(&self, display: &mut D) -> Result<(), D::Error>
+    where
+        D: DrawTarget<Color = C>,
+    {
         display.draw_iter(self)
     }
 }

--- a/embedded-graphics/tests/chaining.rs
+++ b/embedded-graphics/tests/chaining.rs
@@ -41,7 +41,7 @@ impl DrawTarget for FakeDisplay {
 fn it_supports_chaining() -> Result<(), core::convert::Infallible> {
     let mut display = FakeDisplay {};
 
-    let mut chained = Rectangle::new(Point::new(0, 0), Size::new(1, 1))
+    let chained = Rectangle::new(Point::new(0, 0), Size::new(1, 1))
         .into_styled(PrimitiveStyle::default())
         .into_iter()
         .chain(
@@ -69,7 +69,7 @@ fn multi() -> impl Iterator<Item = Pixel<TestPixelColor>> {
 fn return_from_fn() -> Result<(), core::convert::Infallible> {
     let mut display = FakeDisplay {};
 
-    let mut chained = multi();
+    let chained = multi();
 
     chained.draw(&mut display)
 }
@@ -78,7 +78,7 @@ fn return_from_fn() -> Result<(), core::convert::Infallible> {
 fn implicit_into_iter() -> Result<(), core::convert::Infallible> {
     let mut display = FakeDisplay {};
 
-    let mut chained = Rectangle::new(Point::new(0, 0), Size::new(1, 1))
+    let chained = Rectangle::new(Point::new(0, 0), Size::new(1, 1))
         .into_styled(PrimitiveStyle::default())
         .into_iter()
         .chain(


### PR DESCRIPTION
Hi! Thank you for helping out with Embedded Graphics development! Please:

- [ ] Check that you've added passing tests and documentation
- [ ] Add a simulator example(s) where applicable
- [ ] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) and appropriate crate (`embedded-graphics`, `simulator`, `tinytga`, `tinybmp`) if your changes affect the **public API**
- [ ] Run `rustfmt` on the project
- [ ] Run `./build.sh` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

This PR changes `Drawable::draw` from using `self` to `&self`, which removes the requirement of implementing `Drawable` for `&T` instead of `T`.

Because the `draw` method no longer supports mutable references pixel iterators can no longer implement `Drawable`. As an alternative an extension trait for pixel iterators is added, which allows to draw iterators by using  the same `iter.draw(&mut target)` syntax.
