### PR TITLE
MockDisplay panic now prints which row width is incorrect

### DIFF
--- a/embedded-graphics/src/mock_display.rs
+++ b/embedded-graphics/src/mock_display.rs
@@ -428,7 +428,7 @@ where
             assert_eq!(
                 row.len(),
                 pattern_width,
-                "Row #{} is {} characters wide instead of {}",
+                "Row #{} is {} characters wide (must be {} characters to match previous rows)",
                 row_idx + 1,
                 row.len(),
                 pattern_width

--- a/embedded-graphics/src/mock_display.rs
+++ b/embedded-graphics/src/mock_display.rs
@@ -416,19 +416,21 @@ where
         let pattern_height = pattern.len();
         assert!(
             pattern_width <= SIZE,
-            "Test pattern must not be wider than {}",
+            "Test pattern must not be wider than {} columns",
             SIZE
         );
         assert!(
             pattern_height <= SIZE,
-            "Test pattern must not be taller than {}",
+            "Test pattern must not be taller than {} rows",
             SIZE
         );
-        for row in pattern {
+        for (row_idx, row) in pattern.iter().enumerate() {
             assert_eq!(
                 row.len(),
                 pattern_width,
-                "Every row in the pattern must be {} characters wide",
+                "Row #{} is {} characters wide instead of {}",
+                row_idx + 1,
+                row.len(),
                 pattern_width
             );
         }


### PR DESCRIPTION
Hi! Thank you for helping out with Embedded Graphics development! Please:

- [ ] Check that you've added passing tests and documentation
- [ ] Add a simulator example(s) where applicable
- [ ] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) and appropriate crate (`embedded-graphics`, `simulator`, `tinytga`, `tinybmp`) if your changes affect the **public API**
- [ ] Run `rustfmt` on the project
- [ ] Run `./build.sh` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

I'm not sure if this wording is acceptable, but I find it useful to print which row actually failed the validation.

Also add a dimension to the other panics, just to be overly pedantic.