### PR TITLE
Add more pulic methods to Point and Size

### DIFF
--- a/embedded-graphics/CHANGELOG.md
+++ b/embedded-graphics/CHANGELOG.md
@@ -29,6 +29,7 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 - [#363](https://github.com/jamwaffles/embedded-graphics/pull/363) Export `primitives::ContainsPoint` trait in prelude.
 - [#310](https://github.com/jamwaffles/embedded-graphics/pull/320) Added the `Arc` primitive.
 - [#310](https://github.com/jamwaffles/embedded-graphics/pull/320) Added the `Sector` primitive.
+- [#398](https://github.com/jamwaffles/embedded-graphics/pull/398) Added `Point::length_squared` and `component_min`, `component_max`, `component_mul` and `component_div` for `Point` and `Size`.
 
 ### Changed
 

--- a/embedded-graphics/src/geometry/point.rs
+++ b/embedded-graphics/src/geometry/point.rs
@@ -166,7 +166,7 @@ impl Point {
     ///
     /// assert_eq!(min, Point::new(15, 30));
     /// ```
-    pub(crate) fn component_min(self, other: Self) -> Self {
+    pub fn component_min(self, other: Self) -> Self {
         Self::new(self.x.min(other.x), self.y.min(other.y))
     }
 
@@ -181,7 +181,7 @@ impl Point {
     ///
     /// assert_eq!(min, Point::new(20, 50));
     /// ```
-    pub(crate) fn component_max(self, other: Self) -> Self {
+    pub fn component_max(self, other: Self) -> Self {
         Self::new(self.x.max(other.x), self.y.max(other.y))
     }
 

--- a/embedded-graphics/src/geometry/point.rs
+++ b/embedded-graphics/src/geometry/point.rs
@@ -199,7 +199,7 @@ impl Point {
     ///
     /// assert_eq!(p.length_squared(), 25);
     /// ```
-    pub(crate) fn length_squared(self) -> i32 {
+    pub fn length_squared(self) -> i32 {
         self.x.pow(2) + self.y.pow(2)
     }
 }

--- a/embedded-graphics/src/geometry/point.rs
+++ b/embedded-graphics/src/geometry/point.rs
@@ -159,7 +159,7 @@ impl Point {
     ///
     /// # Examples
     ///
-    /// ```rust,ignore
+    /// ```rust
     /// use embedded_graphics::geometry::Point;
     ///
     /// let min = Point::new(20, 30).component_min(Point::new(15, 50));
@@ -174,7 +174,7 @@ impl Point {
     ///
     /// # Examples
     ///
-    /// ```rust,ignore
+    /// ```rust
     /// use embedded_graphics::geometry::Point;
     ///
     /// let min = Point::new(20, 30).component_max(Point::new(15, 50));
@@ -192,7 +192,7 @@ impl Point {
     ///
     /// # Examples
     ///
-    /// ```rust,ignore
+    /// ```rust
     /// use embedded_graphics::geometry::Point;
     ///
     /// let p = Point::new(3, 4);
@@ -201,6 +201,36 @@ impl Point {
     /// ```
     pub fn length_squared(self) -> i32 {
         self.x.pow(2) + self.y.pow(2)
+    }
+
+    /// Returns the componentwise multiplication of two `Point`s.
+    ///
+    /// ```rust
+    /// use embedded_graphics::geometry::Point;
+    ///
+    /// let result = Point::new(20, 30).component_mul(Point::new(-2, 3));
+    ///
+    /// assert_eq!(result, Point::new(-40, 90));
+    /// ```
+    pub fn component_mul(self, other: Self) -> Self {
+        Self::new(self.x * other.x, self.y * other.y)
+    }
+
+    /// Returns the componentwise division of two `Points`s.
+    ///
+    /// # Panics
+    ///
+    /// Panics if one of the components of `other` equals zero.
+    ///
+    /// ```rust
+    /// use embedded_graphics::geometry::Point;
+    ///
+    /// let result = Point::new(20, 30).component_div(Point::new(10, -3));
+    ///
+    /// assert_eq!(result, Point::new(2, -10));
+    /// ```
+    pub fn component_div(self, other: Self) -> Self {
+        Self::new(self.x / other.x, self.y / other.y)
     }
 }
 

--- a/embedded-graphics/src/geometry/size.rs
+++ b/embedded-graphics/src/geometry/size.rs
@@ -187,9 +187,9 @@ impl Size {
         self.saturating_sub(Size::new(1, 1)) / 2
     }
 
-    /// Returns the componentwise minimum of two `Size`s
+    /// Returns the componentwise minimum of two `Size`s.
     ///
-    /// ```rust,ignore
+    /// ```rust
     /// use embedded_graphics::geometry::Size;
     ///
     /// let min = Size::new(20, 30).component_min(Size::new(15, 50));
@@ -200,9 +200,9 @@ impl Size {
         Self::new(self.width.min(other.width), self.height.min(other.height))
     }
 
-    /// Returns the componentwise maximum of two `Size`s
+    /// Returns the componentwise maximum of two `Size`s.
     ///
-    /// ```rust,ignore
+    /// ```rust
     /// use embedded_graphics::geometry::Size;
     ///
     /// let min = Size::new(20, 30).component_max(Size::new(15, 50));
@@ -211,6 +211,36 @@ impl Size {
     /// ```
     pub fn component_max(self, other: Self) -> Self {
         Self::new(self.width.max(other.width), self.height.max(other.height))
+    }
+
+    /// Returns the componentwise multiplication of two `Size`s.
+    ///
+    /// ```rust
+    /// use embedded_graphics::geometry::Size;
+    ///
+    /// let result = Size::new(20, 30).component_mul(Size::new(2, 3));
+    ///
+    /// assert_eq!(result, Size::new(40, 90));
+    /// ```
+    pub fn component_mul(self, other: Self) -> Self {
+        Self::new(self.width * other.width, self.height * other.height)
+    }
+
+    /// Returns the componentwise division of two `Size`s.
+    ///
+    /// # Panics
+    ///
+    /// Panics if one of the components of `other` equals zero.
+    ///
+    /// ```rust
+    /// use embedded_graphics::geometry::Size;
+    ///
+    /// let result = Size::new(20, 30).component_div(Size::new(5, 10));
+    ///
+    /// assert_eq!(result, Size::new(4, 3));
+    /// ```
+    pub fn component_div(self, other: Self) -> Self {
+        Self::new(self.width / other.width, self.height / other.height)
     }
 }
 

--- a/embedded-graphics/src/geometry/size.rs
+++ b/embedded-graphics/src/geometry/size.rs
@@ -196,7 +196,7 @@ impl Size {
     ///
     /// assert_eq!(min, Size::new(15, 30));
     /// ```
-    pub(crate) fn component_min(self, other: Self) -> Self {
+    pub fn component_min(self, other: Self) -> Self {
         Self::new(self.width.min(other.width), self.height.min(other.height))
     }
 
@@ -209,7 +209,7 @@ impl Size {
     ///
     /// assert_eq!(min, Size::new(20, 50));
     /// ```
-    pub(crate) fn component_max(self, other: Self) -> Self {
+    pub fn component_max(self, other: Self) -> Self {
         Self::new(self.width.max(other.width), self.height.max(other.height))
     }
 }


### PR DESCRIPTION
Hi! Thank you for helping out with Embedded Graphics development! Please:

- [ ] Check that you've added passing tests and documentation
- [ ] Add a simulator example(s) where applicable
- [ ] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) and appropriate crate (`embedded-graphics`, `simulator`, `tinytga`, `tinybmp`) if your changes affect the **public API**
- [ ] Run `rustfmt` on the project
- [ ] Run `./build.sh` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

This PR is part of #338 and makes some of the methods in `Point` and `Size` public and adds `component_mul` and `component_div` methods.
