### PR TITLE
Add OffsetOutline and StyledPrimitiveAreas

### DIFF
--- a/embedded-graphics/CHANGELOG.md
+++ b/embedded-graphics/CHANGELOG.md
@@ -30,6 +30,7 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 - [#310](https://github.com/jamwaffles/embedded-graphics/pull/320) Added the `Arc` primitive.
 - [#310](https://github.com/jamwaffles/embedded-graphics/pull/320) Added the `Sector` primitive.
 - [#398](https://github.com/jamwaffles/embedded-graphics/pull/398) Added `Point::length_squared` and `component_min`, `component_max`, `component_mul` and `component_div` for `Point` and `Size`.
+- [#400](https://github.com/jamwaffles/embedded-graphics/pull/400) Added `OffsetOutline` and `StyledPrimitiveAreas` traits.
 
 ### Changed
 

--- a/embedded-graphics/src/prelude.rs
+++ b/embedded-graphics/src/prelude.rs
@@ -8,6 +8,7 @@ pub use crate::{
     pixel_iterator::{IntoPixels, PixelIteratorExt},
     pixelcolor::{raw::RawData, GrayColor, IntoStorage, PixelColor, RgbColor},
     primitives::{ContainsPoint, Primitive},
+    style::StyledPrimitiveAreas,
     transform::Transform,
     DrawTarget, Drawable, Pixel,
 };

--- a/embedded-graphics/src/primitives/circle/styled.rs
+++ b/embedded-graphics/src/primitives/circle/styled.rs
@@ -7,7 +7,7 @@ use crate::{
     primitives::circle::{diameter_to_threshold, distance_iterator::DistanceIterator, Circle},
     primitives::rectangle::{self, Rectangle},
     primitives::Primitive,
-    style::{PrimitiveStyle, Styled},
+    style::{PrimitiveStyle, Styled, StyledPrimitiveAreas},
 };
 
 /// Pixel iterator for each pixel in the circle border
@@ -30,12 +30,9 @@ where
     C: PixelColor,
 {
     pub(in crate::primitives) fn new(styled: &Styled<Circle, PrimitiveStyle<C>>) -> Self {
-        let Styled { primitive, style } = styled;
+        let stroke_area = styled.stroke_area();
 
-        let stroke_area = primitive.expand(style.outside_stroke_width());
-        let fill_area = primitive.shrink(style.inside_stroke_width());
-
-        let inner_threshold = diameter_to_threshold(fill_area.diameter);
+        let inner_threshold = diameter_to_threshold(styled.fill_area().diameter);
         let outer_threshold = diameter_to_threshold(stroke_area.diameter);
 
         let iter = if !styled.style.is_transparent() {

--- a/embedded-graphics/src/primitives/ellipse/styled.rs
+++ b/embedded-graphics/src/primitives/ellipse/styled.rs
@@ -5,7 +5,7 @@ use crate::{
     pixel_iterator::IntoPixels,
     pixelcolor::PixelColor,
     primitives::ellipse::{compute_threshold, is_point_inside_ellipse, points::Points, Ellipse},
-    style::{PrimitiveStyle, Styled},
+    style::{PrimitiveStyle, Styled, StyledPrimitiveAreas},
 };
 
 /// Pixel iterator for each pixel in the ellipse border
@@ -27,16 +27,13 @@ where
     C: PixelColor,
 {
     pub(in crate::primitives) fn new(styled: &Styled<Ellipse, PrimitiveStyle<C>>) -> Self {
-        let Styled { primitive, style } = styled;
-
         let iter = if !styled.style.is_transparent() {
-            let stroke_area = primitive.expand(style.outside_stroke_width());
-            Points::new(&stroke_area)
+            Points::new(&styled.stroke_area())
         } else {
             Points::empty()
         };
 
-        let fill_area = primitive.shrink(style.inside_stroke_width());
+        let fill_area = styled.fill_area();
         let (inner_size_sq, threshold) = compute_threshold(fill_area.size);
 
         Self {

--- a/embedded-graphics/src/primitives/mod.rs
+++ b/embedded-graphics/src/primitives/mod.rs
@@ -50,3 +50,13 @@ pub trait ContainsPoint {
     /// Returns `true` if the given point is inside the shape.
     fn contains(&self, point: Point) -> bool;
 }
+
+/// Offset outline trait.
+pub trait OffsetOutline {
+    /// Offsets the outline of the shape.
+    ///
+    /// The offset is applied perpendicular to each element of the outline.
+    /// Offset values larger than zero will expand the shape and values smaller
+    /// than zero will shrink the shape.
+    fn offset(&self, offset: i32) -> Self;
+}

--- a/embedded-graphics/src/primitives/mod.rs
+++ b/embedded-graphics/src/primitives/mod.rs
@@ -56,7 +56,7 @@ pub trait OffsetOutline {
     /// Offsets the outline of the shape.
     ///
     /// The offset is applied perpendicular to each element of the outline.
-    /// Offset values larger than zero will expand the shape and values smaller
+    /// Offset values greater than zero will expand the shape and values less
     /// than zero will shrink the shape.
     fn offset(&self, offset: i32) -> Self;
 }

--- a/embedded-graphics/src/primitives/rounded_rectangle/styled.rs
+++ b/embedded-graphics/src/primitives/rounded_rectangle/styled.rs
@@ -7,7 +7,7 @@ use crate::{
         rounded_rectangle::{Points, RoundedRectangle},
         ContainsPoint,
     },
-    style::{PrimitiveStyle, Styled},
+    style::{PrimitiveStyle, Styled, StyledPrimitiveAreas},
 };
 
 /// Pixel iterator for each pixel in the rect border
@@ -27,22 +27,17 @@ where
     C: PixelColor,
 {
     pub(in crate::primitives) fn new(styled: &Styled<RoundedRectangle, PrimitiveStyle<C>>) -> Self {
-        let Styled { style, primitive } = styled;
-
         let iter = if !styled.style.is_transparent() {
-            let stroke_area = primitive.expand(style.outside_stroke_width());
-            Points::new(&stroke_area)
+            Points::new(&styled.stroke_area())
         } else {
             Points::empty()
         };
 
-        let fill_area = primitive.shrink(style.inside_stroke_width());
-
         Self {
             iter,
-            fill_area,
-            stroke_color: style.stroke_color,
-            fill_color: style.fill_color,
+            fill_area: styled.fill_area(),
+            stroke_color: styled.style.stroke_color,
+            fill_color: styled.style.fill_color,
         }
     }
 }

--- a/embedded-graphics/src/primitives/sector/styled.rs
+++ b/embedded-graphics/src/primitives/sector/styled.rs
@@ -7,7 +7,7 @@ use crate::{
         arc::PlaneSectorIterator, circle, circle::DistanceIterator, line::ThickPoints, Sector,
         Styled,
     },
-    style::PrimitiveStyle,
+    style::{PrimitiveStyle, StyledPrimitiveAreas},
     DrawTarget,
 };
 
@@ -43,10 +43,8 @@ where
     C: PixelColor,
 {
     fn new(styled: &Styled<Sector, PrimitiveStyle<C>>) -> Self {
-        let Styled { primitive, style } = styled;
-
-        let stroke_area = primitive.expand(style.outside_stroke_width());
-        let fill_area = primitive.shrink(style.inside_stroke_width());
+        let stroke_area = styled.stroke_area();
+        let fill_area = styled.fill_area();
 
         let inner_threshold = circle::diameter_to_threshold(fill_area.diameter);
         let outer_threshold = circle::diameter_to_threshold(stroke_area.diameter);

--- a/embedded-graphics/src/style/mod.rs
+++ b/embedded-graphics/src/style/mod.rs
@@ -5,5 +5,5 @@ mod styled;
 mod text_style;
 
 pub use primitive_style::{PrimitiveStyle, PrimitiveStyleBuilder, StrokeAlignment};
-pub use styled::Styled;
+pub use styled::{Styled, StyledPrimitiveAreas};
 pub use text_style::{TextStyle, TextStyleBuilder};

--- a/embedded-graphics/src/style/styled.rs
+++ b/embedded-graphics/src/style/styled.rs
@@ -1,8 +1,12 @@
 use crate::{
     geometry::{Dimensions, Point},
-    primitives::Rectangle,
+    pixelcolor::PixelColor,
+    prelude::Primitive,
+    primitives::{OffsetOutline, Rectangle},
+    style::PrimitiveStyle,
     transform::Transform,
 };
+use core::convert::TryFrom;
 
 /// Styled.
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
@@ -46,5 +50,39 @@ where
     //FIXME: The bounding box for a styled primitive should use the stroke width and alignment.
     fn bounding_box(&self) -> Rectangle {
         self.primitive.bounding_box()
+    }
+}
+
+/// Stroke and fill area trait.
+pub trait StyledPrimitiveAreas {
+    /// Type of primitive shape used for the stroke and fill areas.
+    type Primitive;
+
+    /// Returns the stroke area.
+    fn stroke_area(&self) -> Self::Primitive;
+
+    /// Returns the fill area.
+    fn fill_area(&self) -> Self::Primitive;
+}
+
+impl<T, C> StyledPrimitiveAreas for Styled<T, PrimitiveStyle<C>>
+where
+    T: Primitive + OffsetOutline,
+    C: PixelColor,
+{
+    type Primitive = T;
+
+    fn stroke_area(&self) -> Self::Primitive {
+        // saturate offset at i32::max_value() if stroke width is to large
+        let offset = i32::try_from(self.style.outside_stroke_width()).unwrap_or(i32::max_value());
+
+        self.primitive.offset(offset)
+    }
+
+    fn fill_area(&self) -> Self::Primitive {
+        // saturate offset at i32::max_value() if stroke width is to large
+        let offset = i32::try_from(self.style.inside_stroke_width()).unwrap_or(i32::max_value());
+
+        self.primitive.offset(-offset)
     }
 }


### PR DESCRIPTION
Hi! Thank you for helping out with Embedded Graphics development! Please:

- [x] Check that you've added passing tests and documentation
- [x] Add a simulator example(s) where applicable
- [x] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) and appropriate crate (`embedded-graphics`, `simulator`, `tinytga`, `tinybmp`) if your changes affect the **public API**
- [x] Run `rustfmt` on the project
- [x] Run `./build.sh` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

This PR adds the `OffsetOutline` trait discussed in #399 and a `StyledPrimitiveAreas` trait that implements the methods that were suggested in https://github.com/jamwaffles/embedded-graphics/pull/307#issuecomment-609475823.

Closes #399