### PR TITLE
Fix triangle node overdraw

### DIFF
--- a/embedded-graphics/CHANGELOG.md
+++ b/embedded-graphics/CHANGELOG.md
@@ -49,6 +49,7 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 ### Fixed
 
 - [#317](https://github.com/jamwaffles/embedded-graphics/pull/317) The bounding box size for `Circle`s was off by one.
+- [#401](https://github.com/jamwaffles/embedded-graphics/pull/401) Triangle pixel iterators no longer produce a pixel for each node twice.
 
 ### Removed
 

--- a/embedded-graphics/src/primitives/triangle/points.rs
+++ b/embedded-graphics/src/primitives/triangle/points.rs
@@ -64,7 +64,6 @@ mod tests {
         assert_eq!(tri.next(), Some(Point::new(2, 3)));
         assert_eq!(tri.next(), Some(Point::new(2, 4)));
         assert_eq!(tri.next(), Some(Point::new(2, 4)));
-        assert_eq!(tri.next(), Some(Point::new(2, 4)));
         assert_eq!(tri.next(), None);
     }
 
@@ -76,7 +75,6 @@ mod tests {
         assert_eq!(tri.next(), Some(Point::new(2, 2)));
         assert_eq!(tri.next(), Some(Point::new(3, 2)));
         assert_eq!(tri.next(), Some(Point::new(3, 2)));
-        assert_eq!(tri.next(), Some(Point::new(4, 2)));
         assert_eq!(tri.next(), Some(Point::new(4, 2)));
         assert_eq!(tri.next(), Some(Point::new(4, 2)));
         assert_eq!(tri.next(), None);

--- a/embedded-graphics/src/primitives/triangle/points.rs
+++ b/embedded-graphics/src/primitives/triangle/points.rs
@@ -56,13 +56,8 @@ mod tests {
     fn it_draws_unfilled_tri_line_y() {
         let mut tri = Triangle::new(Point::new(2, 2), Point::new(2, 4), Point::new(2, 4)).points();
 
-        // Nodes are returned twice. first line a and b yield the same point.
-        // After that line a ends where line c starts.
-        assert_eq!(tri.next(), Some(Point::new(2, 2)));
         assert_eq!(tri.next(), Some(Point::new(2, 2)));
         assert_eq!(tri.next(), Some(Point::new(2, 3)));
-        assert_eq!(tri.next(), Some(Point::new(2, 3)));
-        assert_eq!(tri.next(), Some(Point::new(2, 4)));
         assert_eq!(tri.next(), Some(Point::new(2, 4)));
         assert_eq!(tri.next(), None);
     }
@@ -72,10 +67,7 @@ mod tests {
         let mut tri = Triangle::new(Point::new(2, 2), Point::new(4, 2), Point::new(4, 2)).points();
 
         assert_eq!(tri.next(), Some(Point::new(2, 2)));
-        assert_eq!(tri.next(), Some(Point::new(2, 2)));
         assert_eq!(tri.next(), Some(Point::new(3, 2)));
-        assert_eq!(tri.next(), Some(Point::new(3, 2)));
-        assert_eq!(tri.next(), Some(Point::new(4, 2)));
         assert_eq!(tri.next(), Some(Point::new(4, 2)));
         assert_eq!(tri.next(), None);
     }

--- a/embedded-graphics/src/primitives/triangle/scanline_iterator.rs
+++ b/embedded-graphics/src/primitives/triangle/scanline_iterator.rs
@@ -40,6 +40,9 @@ impl ScanlineIterator {
         let mut line_b = Line::new(v1, v3).points();
         let mut line_c = Line::new(v2, v3).points();
 
+        // Skip first point of line C as this overlaps with the last point of line A
+        line_c.next();
+
         let next_ac = line_a.next().or_else(|| line_c.next());
         let next_b = line_b.next();
 
@@ -73,6 +76,7 @@ impl ScanlineIterator {
             self.cur_ac = Some(ac);
             self.next_ac = self.line_a.next().or_else(|| self.line_c.next());
             self.x = 0;
+
             IterState::Border(ac)
         } else {
             IterState::None
@@ -84,6 +88,13 @@ impl ScanlineIterator {
             self.cur_b = Some(b);
             self.next_b = self.line_b.next();
             self.x = 0;
+
+            // // Check if the left line(s) overlap the right lines. If this check is true, it means
+            // // the AC line already drew it, so skip this pixel for line B.
+            // if self.cur_b == self.cur_ac {
+            //     return self.update_b();
+            // }
+
             IterState::Border(b)
         } else {
             IterState::None
@@ -91,6 +102,7 @@ impl ScanlineIterator {
     }
 
     pub(in crate::primitives::triangle) fn points(&mut self) -> IterState {
+        // dbg!(self.cur_ac, self.next_ac);
         match (self.cur_ac, self.cur_b) {
             // Point of ac line or b line is missing
             (None, _) => self.update_ac(),

--- a/embedded-graphics/src/primitives/triangle/scanline_iterator.rs
+++ b/embedded-graphics/src/primitives/triangle/scanline_iterator.rs
@@ -6,6 +6,7 @@ use crate::{
         Primitive,
     },
 };
+use core::cmp::Ordering;
 
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub enum PointType {
@@ -106,13 +107,13 @@ impl ScanlineIterator {
                     (Some(n_ac), Some(n_b)) => {
                         // If y component differs, take new points from edge until both side have
                         // the same y
-                        if n_ac.y < n_b.y {
-                            self.update_ac()
-                        } else if n_ac.y > n_b.y {
-                            self.update_b()
-                        } else {
-                            let (l, r) = sort_two_yx(n_ac, n_b);
-                            IterState::LeftRight(l, r)
+                        match n_ac.y.cmp(&n_b.y) {
+                            Ordering::Less => self.update_ac(),
+                            Ordering::Greater => self.update_b(),
+                            Ordering::Equal => {
+                                let (l, r) = sort_two_yx(n_ac, n_b);
+                                IterState::LeftRight(l, r)
+                            }
                         }
                     }
                     (None, Some(_)) => self.update_b(),

--- a/embedded-graphics/src/primitives/triangle/scanline_iterator.rs
+++ b/embedded-graphics/src/primitives/triangle/scanline_iterator.rs
@@ -30,8 +30,6 @@ pub struct ScanlineIterator {
     next_ac: Option<Point>,
     next_b: Option<Point>,
     x: i32,
-    max_y: i32,
-    min_y: i32,
 }
 
 impl ScanlineIterator {
@@ -54,8 +52,6 @@ impl ScanlineIterator {
             next_ac,
             next_b,
             x: 0,
-            min_y: v1.y,
-            max_y: v3.y,
         }
     }
 
@@ -69,8 +65,6 @@ impl ScanlineIterator {
             next_ac: None,
             next_b: None,
             x: 0,
-            max_y: 0,
-            min_y: 0,
         }
     }
 

--- a/embedded-graphics/src/primitives/triangle/scanline_iterator.rs
+++ b/embedded-graphics/src/primitives/triangle/scanline_iterator.rs
@@ -89,12 +89,6 @@ impl ScanlineIterator {
             self.next_b = self.line_b.next();
             self.x = 0;
 
-            // // Check if the left line(s) overlap the right lines. If this check is true, it means
-            // // the AC line already drew it, so skip this pixel for line B.
-            // if self.cur_b == self.cur_ac {
-            //     return self.update_b();
-            // }
-
             IterState::Border(b)
         } else {
             IterState::None
@@ -102,7 +96,6 @@ impl ScanlineIterator {
     }
 
     pub(in crate::primitives::triangle) fn points(&mut self) -> IterState {
-        // dbg!(self.cur_ac, self.next_ac);
         match (self.cur_ac, self.cur_b) {
             // Point of ac line or b line is missing
             (None, _) => self.update_ac(),
@@ -141,9 +134,12 @@ impl Iterator for ScanlineIterator {
         loop {
             match self.points() {
                 IterState::Border(point) => {
-                    // Draw edges of the triangle
-                    self.x += 1;
-                    return Some((PointType::Border, point));
+                    // Skip overlapping left/right border points
+                    if Some(point) != self.next_b {
+                        // Draw edges of the triangle
+                        self.x += 1;
+                        return Some((PointType::Border, point));
+                    }
                 }
                 IterState::LeftRight(l, r) => {
                     // Fill the space between the left and right points

--- a/embedded-graphics/src/primitives/triangle/styled.rs
+++ b/embedded-graphics/src/primitives/triangle/styled.rs
@@ -229,7 +229,6 @@ mod tests {
         let styled = triangle.into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 1));
 
         let mut tri_display: MockDisplay<BinaryColor> = MockDisplay::new();
-        // FIXME: Triangles should not be overdrawing
         tri_display.set_allow_overdraw(true);
         styled.draw(&mut tri_display).unwrap();
 
@@ -250,5 +249,16 @@ mod tests {
             .unwrap();
 
         assert_eq!(tri_display, lines_display);
+    }
+
+    #[test]
+    fn no_stroke_overdraw() {
+        let triangle = Triangle::new(Point::new(10, 10), Point::new(30, 20), Point::new(20, 25));
+
+        let styled = triangle.into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 1));
+
+        let mut display: MockDisplay<BinaryColor> = MockDisplay::new();
+
+        styled.draw(&mut display).unwrap();
     }
 }

--- a/embedded-graphics/src/primitives/triangle/styled.rs
+++ b/embedded-graphics/src/primitives/triangle/styled.rs
@@ -229,7 +229,6 @@ mod tests {
         let styled = triangle.into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 1));
 
         let mut tri_display: MockDisplay<BinaryColor> = MockDisplay::new();
-        tri_display.set_allow_overdraw(true);
         styled.draw(&mut tri_display).unwrap();
 
         let mut lines_display: MockDisplay<BinaryColor> = MockDisplay::new();


### PR DESCRIPTION
Hi! Thank you for helping out with Embedded Graphics development! Please:

- [x] Check that you've added passing tests and documentation
- [x] Add a simulator example(s) where applicable
- [x] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) and appropriate crate (`embedded-graphics`, `simulator`, `tinytga`, `tinybmp`) if your changes affect the **public API**
- [x] Run `rustfmt` on the project
- [x] Run `./build.sh` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

Each node of a triangle was drawn twice. This PR fixes that and closes #391 in the process. The triangle algorithm is kind of gnarly, so the fix is too...