### PR TITLE
Use associated type for Drawable color type

### DIFF
--- a/embedded-graphics/CHANGELOG.md
+++ b/embedded-graphics/CHANGELOG.md
@@ -45,6 +45,7 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 - **(breaking)** [#390](https://github.com/jamwaffles/embedded-graphics/pull/390) `Triangle.contains` now always returns `false` for colinear triangles.
 - **(breaking)** [#393](https://github.com/jamwaffles/embedded-graphics/pull/393) `DrawTarget::draw` now uses a reference to `self` instead of taking ownership of `self`. Because of this change `DrawTarget` can no longer be implemented for pixel iterators (`Iterator<Item = C>`), which can now be drawn using the `draw` method provided by the `PixelIteratorExt` extension trait.
 - **(breaking)** [#383](https://github.com/jamwaffles/embedded-graphics/pull/383) Replaced all `IntoIterator` impls with a custom `IntoPixels` trait. To get an iterator over pixels in an item, replace calls to `into_iter()` with `into_pixels()`.
+- **(breaking)** [#403](https://github.com/jamwaffles/embedded-graphics/pull/403) Use an associated type to define the color type for `Drawable`s.
 
 ### Fixed
 

--- a/embedded-graphics/src/drawable.rs
+++ b/embedded-graphics/src/drawable.rs
@@ -24,10 +24,12 @@ use crate::{geometry::Point, pixelcolor::PixelColor, DrawTarget};
 ///     text: &'a str,
 /// }
 ///
-/// impl<C> Drawable<C> for Button<'_, C>
+/// impl<C> Drawable for Button<'_, C>
 /// where
 ///     C: PixelColor + From<BinaryColor>,
 /// {
+///     type Color = C;
+///
 ///     fn draw<D>(&self, display: &mut D) -> Result<(), D::Error>
 ///     where
 ///         D: DrawTarget<Color = C>,
@@ -59,14 +61,14 @@ use crate::{geometry::Point, pixelcolor::PixelColor, DrawTarget};
 ///
 /// [`DrawTarget`]: ./trait.DrawTarget.html
 /// [`draw_iter`]: ./trait.DrawTarget.html#tymethod.draw_iter
-pub trait Drawable<C>
-where
-    C: PixelColor,
-{
+pub trait Drawable {
+    /// The pixel color type.
+    type Color: PixelColor;
+
     /// Draw the graphics object using the supplied DrawTarget.
     fn draw<D>(&self, display: &mut D) -> Result<(), D::Error>
     where
-        D: DrawTarget<Color = C>;
+        D: DrawTarget<Color = Self::Color>;
 }
 
 /// A single pixel.
@@ -106,10 +108,12 @@ pub struct Pixel<C>(pub Point, pub C)
 where
     C: PixelColor;
 
-impl<C> Drawable<C> for Pixel<C>
+impl<C> Drawable for Pixel<C>
 where
     C: PixelColor,
 {
+    type Color = C;
+
     fn draw<D>(&self, display: &mut D) -> Result<(), D::Error>
     where
         D: DrawTarget<Color = C>,

--- a/embedded-graphics/src/fonts/text.rs
+++ b/embedded-graphics/src/fonts/text.rs
@@ -65,11 +65,13 @@ impl Transform for Text<'_> {
     }
 }
 
-impl<C, F> Drawable<C> for Styled<Text<'_>, TextStyle<C, F>>
+impl<C, F> Drawable for Styled<Text<'_>, TextStyle<C, F>>
 where
     C: PixelColor,
     F: Font + Copy,
 {
+    type Color = C;
+
     fn draw<D>(&self, display: &mut D) -> Result<(), D::Error>
     where
         D: DrawTarget<Color = C>,

--- a/embedded-graphics/src/image/mod.rs
+++ b/embedded-graphics/src/image/mod.rs
@@ -191,12 +191,14 @@ impl<I, C> Transform for Image<'_, I, C> {
     }
 }
 
-impl<'a, I, C> Drawable<C> for Image<'a, I, C>
+impl<'a, I, C> Drawable for Image<'a, I, C>
 where
     &'a I: IntoPixelIter<C>,
     I: ImageDimensions,
     C: PixelColor + From<<C as PixelColor>::Raw>,
 {
+    type Color = C;
+
     fn draw<D>(&self, display: &mut D) -> Result<(), D::Error>
     where
         D: DrawTarget<Color = C>,

--- a/embedded-graphics/src/primitives/arc/styled.rs
+++ b/embedded-graphics/src/primitives/arc/styled.rs
@@ -78,10 +78,12 @@ where
     }
 }
 
-impl<C> Drawable<C> for Styled<Arc, PrimitiveStyle<C>>
+impl<C> Drawable for Styled<Arc, PrimitiveStyle<C>>
 where
     C: PixelColor,
 {
+    type Color = C;
+
     fn draw<D>(&self, display: &mut D) -> Result<(), D::Error>
     where
         D: DrawTarget<Color = C>,

--- a/embedded-graphics/src/primitives/circle/styled.rs
+++ b/embedded-graphics/src/primitives/circle/styled.rs
@@ -92,10 +92,12 @@ where
     }
 }
 
-impl<C> Drawable<C> for Styled<Circle, PrimitiveStyle<C>>
+impl<C> Drawable for Styled<Circle, PrimitiveStyle<C>>
 where
     C: PixelColor,
 {
+    type Color = C;
+
     fn draw<D>(&self, display: &mut D) -> Result<(), D::Error>
     where
         D: DrawTarget<Color = C>,

--- a/embedded-graphics/src/primitives/ellipse/styled.rs
+++ b/embedded-graphics/src/primitives/ellipse/styled.rs
@@ -89,10 +89,12 @@ where
     }
 }
 
-impl<C> Drawable<C> for Styled<Ellipse, PrimitiveStyle<C>>
+impl<C> Drawable for Styled<Ellipse, PrimitiveStyle<C>>
 where
     C: PixelColor,
 {
+    type Color = C;
+
     fn draw<D>(&self, display: &mut D) -> Result<(), D::Error>
     where
         D: DrawTarget<Color = C>,

--- a/embedded-graphics/src/primitives/line/styled.rs
+++ b/embedded-graphics/src/primitives/line/styled.rs
@@ -64,10 +64,12 @@ where
     }
 }
 
-impl<C> Drawable<C> for Styled<Line, PrimitiveStyle<C>>
+impl<C> Drawable for Styled<Line, PrimitiveStyle<C>>
 where
     C: PixelColor,
 {
+    type Color = C;
+
     fn draw<D>(&self, display: &mut D) -> Result<(), D::Error>
     where
         D: DrawTarget<Color = C>,

--- a/embedded-graphics/src/primitives/polyline/styled.rs
+++ b/embedded-graphics/src/primitives/polyline/styled.rs
@@ -58,10 +58,12 @@ where
     }
 }
 
-impl<'a, C> Drawable<C> for Styled<Polyline<'a>, PrimitiveStyle<C>>
+impl<'a, C> Drawable for Styled<Polyline<'a>, PrimitiveStyle<C>>
 where
     C: PixelColor,
 {
+    type Color = C;
+
     fn draw<D>(&self, display: &mut D) -> Result<(), D::Error>
     where
         D: DrawTarget<Color = C>,

--- a/embedded-graphics/src/primitives/rectangle/styled.rs
+++ b/embedded-graphics/src/primitives/rectangle/styled.rs
@@ -82,10 +82,12 @@ where
     }
 }
 
-impl<C> Drawable<C> for Styled<Rectangle, PrimitiveStyle<C>>
+impl<C> Drawable for Styled<Rectangle, PrimitiveStyle<C>>
 where
     C: PixelColor,
 {
+    type Color = C;
+
     fn draw<D>(&self, display: &mut D) -> Result<(), D::Error>
     where
         D: DrawTarget<Color = C>,

--- a/embedded-graphics/src/primitives/rounded_rectangle/styled.rs
+++ b/embedded-graphics/src/primitives/rounded_rectangle/styled.rs
@@ -78,10 +78,12 @@ where
     }
 }
 
-impl<C> Drawable<C> for Styled<RoundedRectangle, PrimitiveStyle<C>>
+impl<C> Drawable for Styled<RoundedRectangle, PrimitiveStyle<C>>
 where
     C: PixelColor,
 {
+    type Color = C;
+
     fn draw<D>(&self, display: &mut D) -> Result<(), D::Error>
     where
         D: DrawTarget<Color = C>,

--- a/embedded-graphics/src/primitives/sector/styled.rs
+++ b/embedded-graphics/src/primitives/sector/styled.rs
@@ -139,10 +139,12 @@ where
     }
 }
 
-impl<C> Drawable<C> for Styled<Sector, PrimitiveStyle<C>>
+impl<C> Drawable for Styled<Sector, PrimitiveStyle<C>>
 where
     C: PixelColor,
 {
+    type Color = C;
+
     fn draw<D>(&self, display: &mut D) -> Result<(), D::Error>
     where
         D: DrawTarget<Color = C>,

--- a/embedded-graphics/src/primitives/triangle/styled.rs
+++ b/embedded-graphics/src/primitives/triangle/styled.rs
@@ -76,10 +76,12 @@ where
     }
 }
 
-impl<C> Drawable<C> for Styled<Triangle, PrimitiveStyle<C>>
+impl<C> Drawable for Styled<Triangle, PrimitiveStyle<C>>
 where
     C: PixelColor,
 {
+    type Color = C;
+
     fn draw<D>(&self, display: &mut D) -> Result<(), D::Error>
     where
         D: DrawTarget<Color = C>,

--- a/generate_examples_screenshots.sh
+++ b/generate_examples_screenshots.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+OUTPUT_DIR=target/screenshots
+
+mkdir -p $OUTPUT_DIR
+
+for EXAMPLE in simulator/examples/*.rs
+do
+    NAME=$(basename "$EXAMPLE" .rs)
+
+    echo "Generating '$NAME' screenshot"
+
+    export EG_SIMULATOR_DUMP="$OUTPUT_DIR/$NAME.png"
+    cargo run --example "$NAME"
+done


### PR DESCRIPTION
Hi! Thank you for helping out with Embedded Graphics development! Please:

- [ ] Check that you've added passing tests and documentation
- [ ] Add a simulator example(s) where applicable
- [ ] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) and appropriate crate (`embedded-graphics`, `simulator`, `tinytga`, `tinybmp`) if your changes affect the **public API**
- [ ] Run `rustfmt` on the project
- [ ] Run `./build.sh` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

This PR changes `Drawable` to use an associated type for the color type. `DrawTarget` and `IntoIterator` were recently also changed to use associated types and IMO it also makes sense for `Drawable`.

@jamwaffles: Why did you remove `generate_examples_screenshots.sh` in #392? I use it as an additional check before committing  larger changes and have previously found errors, that weren't covered by unit tests, by looking at the generated screenshots.