### PR TITLE
Add conversions between Circle and Arc/Sector

### DIFF
--- a/embedded-graphics/src/lib.rs
+++ b/embedded-graphics/src/lib.rs
@@ -272,3 +272,57 @@ pub use crate::{
     draw_target::DrawTarget,
     drawable::{Drawable, Pixel},
 };
+
+/// Trait to convert unsigned into signed integer.
+pub(crate) trait SaturatingCast<T> {
+    /// Casts a unsigned integer into a positive value.
+    ///
+    /// If the value is too large the maximum positive value is returned instead.
+    fn saturating_cast(self) -> T;
+
+    /// Casts a unsigned integer into a negative value.
+    ///
+    /// If the value is too large the minimum negative value is returned instead.
+    fn saturating_cast_neg(self) -> T;
+}
+
+impl SaturatingCast<i32> for u32 {
+    fn saturating_cast(self) -> i32 {
+        if self < 0x8000_0000 {
+            self as i32
+        } else {
+            i32::max_value()
+        }
+    }
+
+    fn saturating_cast_neg(self) -> i32 {
+        if self < 0x8000_0000 {
+            -(self as i32)
+        } else {
+            i32::min_value()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn saturating_cast() {
+        assert_eq!(0u32.saturating_cast(), 0i32);
+        assert_eq!(0u32.saturating_cast_neg(), 0i32);
+
+        assert_eq!(1u32.saturating_cast(), 1i32);
+        assert_eq!(1u32.saturating_cast_neg(), -1i32);
+
+        assert_eq!(0x7FFF_FFFFu32.saturating_cast(), 0x7FFF_FFFFi32);
+        assert_eq!(0x7FFF_FFFFu32.saturating_cast_neg(), -0x7FFF_FFFFi32);
+
+        assert_eq!(0x8000_0000u32.saturating_cast(), 0x7FFF_FFFFi32);
+        assert_eq!(0x8000_0000u32.saturating_cast_neg(), -0x8000_0000i32);
+
+        assert_eq!(u32::max_value().saturating_cast(), 0x7FFF_FFFFi32);
+        assert_eq!(u32::max_value().saturating_cast_neg(), -0x8000_0000i32);
+    }
+}

--- a/embedded-graphics/src/primitives/arc/mod.rs
+++ b/embedded-graphics/src/primitives/arc/mod.rs
@@ -109,7 +109,7 @@ impl Arc {
         Circle::new(self.top_left, self.diameter)
     }
 
-    /// Return the center point of the arc
+    /// Return the center point of the arc.
     pub fn center(&self) -> Point {
         self.bounding_box().center()
     }

--- a/embedded-graphics/src/primitives/arc/mod.rs
+++ b/embedded-graphics/src/primitives/arc/mod.rs
@@ -7,7 +7,7 @@ mod styled;
 
 use crate::{
     geometry::{Angle, Dimensions, Point, Size},
-    primitives::{Primitive, Rectangle},
+    primitives::{Circle, Primitive, Rectangle},
     transform::Transform,
 };
 pub(in crate::primitives) use linear_equation::LinearEquation;
@@ -85,42 +85,33 @@ impl Arc {
         angle_start: Angle,
         angle_sweep: Angle,
     ) -> Self {
-        let top_left = center - Size::new_equal(diameter).center_offset();
+        Self::from_circle(
+            Circle::with_center(center, diameter),
+            angle_start,
+            angle_sweep,
+        )
+    }
 
-        Arc {
-            top_left,
-            diameter,
+    /// Creates an arc based on a circle.
+    ///
+    /// The resulting arc will match the `top_left` and `diameter` of the base circle.
+    pub fn from_circle(circle: Circle, angle_start: Angle, angle_sweep: Angle) -> Self {
+        Self {
+            top_left: circle.top_left,
+            diameter: circle.diameter,
             angle_start,
             angle_sweep,
         }
     }
 
+    /// Returns a circle with the same `top_left` and `diameter` as this arc.
+    pub fn to_circle(&self) -> Circle {
+        Circle::new(self.top_left, self.diameter)
+    }
+
     /// Return the center point of the arc
     pub fn center(&self) -> Point {
         self.bounding_box().center()
-    }
-
-    /// Return the center point of the arc scaled by a factor of 2
-    ///
-    /// This method is used to accurately calculate the outside edge of the arc.
-    /// The result is not equivalent to `self.center() * 2` because of rounding.
-    fn center_2x(&self) -> Point {
-        // The radius scaled up by a factor of 2 is equal to the diameter
-        let radius = self.diameter.saturating_sub(1);
-
-        self.top_left * 2 + Size::new(radius, radius)
-    }
-
-    pub(crate) fn expand(&self, offset: u32) -> Self {
-        let diameter = self.diameter.saturating_add(2 * offset);
-
-        Self::with_center(self.center(), diameter, self.angle_start, self.angle_sweep)
-    }
-
-    pub(crate) fn shrink(&self, offset: u32) -> Self {
-        let diameter = self.diameter.saturating_sub(2 * offset);
-
-        Self::with_center(self.center(), diameter, self.angle_start, self.angle_sweep)
     }
 }
 

--- a/embedded-graphics/src/primitives/arc/plane_sector.rs
+++ b/embedded-graphics/src/primitives/arc/plane_sector.rs
@@ -1,5 +1,5 @@
 use crate::{
-    geometry::{angle_consts::*, Angle, Dimensions, Point, Size},
+    geometry::{angle_consts::*, Angle, Dimensions, Point},
     primitives::{
         arc::{linear_equation::LineSide, LinearEquation},
         rectangle, Primitive, Rectangle,
@@ -88,7 +88,7 @@ impl PlaneSectorIterator {
     pub fn empty() -> Self {
         Self {
             plane_sector: PlaneSector::empty(),
-            points: Rectangle::new(Point::zero(), Size::zero()).points(),
+            points: Rectangle::zero().points(),
         }
     }
 }

--- a/embedded-graphics/src/primitives/arc/points.rs
+++ b/embedded-graphics/src/primitives/arc/points.rs
@@ -2,8 +2,8 @@ use crate::{
     geometry::Point,
     primitives::{
         arc::{Arc, PlaneSectorIterator},
-        circle,
         circle::DistanceIterator,
+        OffsetOutline,
     },
 };
 
@@ -18,21 +18,15 @@ pub struct Points {
 
 impl Points {
     pub(in crate::primitives) fn new(arc: &Arc) -> Self {
-        let outer_diameter = arc.diameter;
-        let inner_diameter = outer_diameter.saturating_sub(2);
+        let outer_circle = arc.to_circle();
+        let inner_circle = outer_circle.offset(-1);
 
-        let inner_threshold = circle::diameter_to_threshold(inner_diameter);
-        let outer_threshold = circle::diameter_to_threshold(outer_diameter);
-
-        let iter = DistanceIterator::new(
-            arc.center_2x(),
-            PlaneSectorIterator::new(arc, arc.center(), arc.angle_start, arc.angle_sweep),
-        );
+        let points = PlaneSectorIterator::new(arc, arc.center(), arc.angle_start, arc.angle_sweep);
 
         Self {
-            iter,
-            outer_threshold,
-            inner_threshold,
+            iter: outer_circle.distances(points),
+            outer_threshold: outer_circle.threshold(),
+            inner_threshold: inner_circle.threshold(),
         }
     }
 }

--- a/embedded-graphics/src/primitives/circle/distance_iterator.rs
+++ b/embedded-graphics/src/primitives/circle/distance_iterator.rs
@@ -3,7 +3,7 @@ use crate::geometry::Point;
 /// Iterator that returns the squared distance to the center for all points in the bounding box.
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub struct DistanceIterator<I> {
-    center: Point,
+    center_2x: Point,
     points: I,
 }
 
@@ -11,8 +11,8 @@ impl<I> DistanceIterator<I>
 where
     I: Iterator<Item = Point>,
 {
-    pub(in crate::primitives) fn new(center: Point, points: I) -> Self {
-        Self { center, points }
+    pub(super) fn new(center_2x: Point, points: I) -> Self {
+        Self { center_2x, points }
     }
 }
 
@@ -24,7 +24,7 @@ where
 
     fn next(&mut self) -> Option<Self::Item> {
         self.points.next().map(|p| {
-            let delta = self.center - p * 2;
+            let delta = self.center_2x - p * 2;
             let distance = delta.length_squared() as u32;
 
             (p, distance)
@@ -55,10 +55,7 @@ mod tests {
 
     #[test]
     fn distance_iter_empty() {
-        let mut iter = DistanceIterator::new(
-            Point::zero(),
-            Rectangle::new(Point::zero(), Size::zero()).points(),
-        );
+        let mut iter = DistanceIterator::new(Point::zero(), Rectangle::zero().points());
         assert_eq!(iter.next(), None);
     }
 }

--- a/embedded-graphics/src/primitives/circle/mod.rs
+++ b/embedded-graphics/src/primitives/circle/mod.rs
@@ -71,7 +71,7 @@ impl Circle {
 
     /// Create a new circle centered around a given point with a specific diameter
     pub fn with_center(center: Point, diameter: u32) -> Self {
-        let top_left = center - Size::new(diameter, diameter).center_offset();
+        let top_left = center - Size::new_equal(diameter).center_offset();
 
         Circle { top_left, diameter }
     }
@@ -90,6 +90,19 @@ impl Circle {
         let radius = self.diameter.saturating_sub(1);
 
         self.top_left * 2 + Size::new(radius, radius)
+    }
+
+    /// Returns the threshold for this circles diameter.
+    pub(in crate::primitives) fn threshold(&self) -> u32 {
+        diameter_to_threshold(self.diameter)
+    }
+
+    /// Returns the squared distance for every point returned by the iterator.
+    pub(in crate::primitives) fn distances<I>(&self, points: I) -> DistanceIterator<I>
+    where
+        I: Iterator<Item = Point>,
+    {
+        DistanceIterator::new(self.center_2x(), points)
     }
 }
 
@@ -118,15 +131,13 @@ impl ContainsPoint for Circle {
         let delta = self.center_2x() - point * 2;
         let distance = delta.length_squared() as u32;
 
-        let threshold = diameter_to_threshold(self.diameter);
-
-        distance < threshold
+        distance < self.threshold()
     }
 }
 
 impl Dimensions for Circle {
     fn bounding_box(&self) -> Rectangle {
-        Rectangle::new(self.top_left, Size::new(self.diameter, self.diameter))
+        Rectangle::new(self.top_left, Size::new_equal(self.diameter))
     }
 }
 

--- a/embedded-graphics/src/primitives/circle/points.rs
+++ b/embedded-graphics/src/primitives/circle/points.rs
@@ -1,6 +1,6 @@
 use crate::{
     geometry::{Dimensions, Point},
-    primitives::circle::{diameter_to_threshold, distance_iterator::DistanceIterator, Circle},
+    primitives::circle::{distance_iterator::DistanceIterator, Circle},
     primitives::rectangle,
     primitives::Primitive,
 };
@@ -14,11 +14,9 @@ pub struct Points {
 
 impl Points {
     pub(in crate::primitives) fn new(circle: &Circle) -> Self {
-        let threshold = diameter_to_threshold(circle.diameter);
-
         Self {
-            iter: DistanceIterator::new(circle.center_2x(), circle.bounding_box().points()),
-            threshold,
+            iter: circle.distances(circle.bounding_box().points()),
+            threshold: circle.threshold(),
         }
     }
 }

--- a/embedded-graphics/src/primitives/ellipse/points.rs
+++ b/embedded-graphics/src/primitives/ellipse/points.rs
@@ -30,7 +30,7 @@ impl Points {
 
     pub(in crate::primitives) fn empty() -> Self {
         Self {
-            iter: Rectangle::new(Point::zero(), Size::zero()).points(),
+            iter: Rectangle::zero().points(),
             center_2x: Point::zero(),
             size_sq: Size::zero(),
             threshold: 0,

--- a/embedded-graphics/src/primitives/ellipse/styled.rs
+++ b/embedded-graphics/src/primitives/ellipse/styled.rs
@@ -113,11 +113,12 @@ mod tests {
         pixelcolor::BinaryColor,
         primitives::{Circle, Primitive},
         style::{PrimitiveStyle, PrimitiveStyleBuilder, StrokeAlignment},
+        SaturatingCast,
     };
 
     fn test_circles(style: PrimitiveStyle<BinaryColor>) {
         for diameter in 0..50 {
-            let top_left = Point::new_equal(style.stroke_width_i32());
+            let top_left = Point::new_equal(style.stroke_width.saturating_cast());
 
             let mut expected = MockDisplay::new();
             Circle::new(top_left, diameter)

--- a/embedded-graphics/src/primitives/line/styled.rs
+++ b/embedded-graphics/src/primitives/line/styled.rs
@@ -5,6 +5,7 @@ use crate::{
     pixelcolor::PixelColor,
     primitives::line::{thick_points::ThickPoints, Line},
     style::{PrimitiveStyle, Styled},
+    SaturatingCast,
 };
 
 /// Styled line iterator.
@@ -26,10 +27,11 @@ where
 
         // Note: stroke color will be None if stroke width is 0
         let stroke_color = style.effective_stroke_color();
+        let stroke_width = style.stroke_width.saturating_cast();
 
         Self {
             stroke_color,
-            line_iter: ThickPoints::new(&primitive, style.stroke_width_i32()),
+            line_iter: ThickPoints::new(&primitive, stroke_width),
         }
     }
 }

--- a/embedded-graphics/src/primitives/polyline/mod.rs
+++ b/embedded-graphics/src/primitives/polyline/mod.rs
@@ -83,7 +83,7 @@ impl<'a> Primitive for Polyline<'a> {
 impl<'a> Dimensions for Polyline<'a> {
     fn bounding_box(&self) -> Rectangle {
         match self.vertices {
-            [] => Rectangle::new(Point::zero(), Size::zero()),
+            [] => Rectangle::zero(),
             [v] => Rectangle::new(*v, Size::zero()),
             vertices => {
                 let top_left = vertices
@@ -187,10 +187,7 @@ mod tests {
 
     #[test]
     fn special_case_dimensions() {
-        assert_eq!(
-            Polyline::new(&[]).bounding_box(),
-            Rectangle::new(Point::zero(), Size::zero())
-        );
+        assert_eq!(Polyline::new(&[]).bounding_box(), Rectangle::zero(),);
 
         assert_eq!(
             Polyline::new(&[Point::new(15, 17)]).bounding_box(),

--- a/embedded-graphics/src/primitives/rectangle/mod.rs
+++ b/embedded-graphics/src/primitives/rectangle/mod.rs
@@ -108,6 +108,11 @@ impl Rectangle {
         }
     }
 
+    /// Returns a zero sized rectangle.
+    pub(crate) fn zero() -> Rectangle {
+        Rectangle::new(Point::zero(), Size::zero())
+    }
+
     /// Returns the center of this rectangle.
     ///
     /// For rectangles with even width and/or height the returned value is rounded down
@@ -218,7 +223,7 @@ impl Rectangle {
         }
 
         // No overlap present
-        Rectangle::new(Point::zero(), Size::zero())
+        Rectangle::zero()
     }
 }
 

--- a/embedded-graphics/src/primitives/rounded_rectangle/points.rs
+++ b/embedded-graphics/src/primitives/rounded_rectangle/points.rs
@@ -1,5 +1,5 @@
 use crate::{
-    geometry::{Dimensions, Point, Size},
+    geometry::{Dimensions, Point},
     primitives::{
         rectangle::{self, Rectangle},
         rounded_rectangle::{
@@ -55,10 +55,10 @@ impl Points {
             top_right_iter: ellipse_quadrant::Points::empty(),
             bottom_right_iter: ellipse_quadrant::Points::empty(),
             bottom_left_iter: ellipse_quadrant::Points::empty(),
-            top_left_corner: Rectangle::new(Point::zero(), Size::zero()),
-            top_right_corner: Rectangle::new(Point::zero(), Size::zero()),
-            bottom_right_corner: Rectangle::new(Point::zero(), Size::zero()),
-            bottom_left_corner: Rectangle::new(Point::zero(), Size::zero()),
+            top_left_corner: Rectangle::zero(),
+            top_right_corner: Rectangle::zero(),
+            bottom_right_corner: Rectangle::zero(),
+            bottom_left_corner: Rectangle::zero(),
         }
     }
 }
@@ -92,7 +92,9 @@ impl Iterator for Points {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{pixel_iterator::IntoPixels, pixelcolor::BinaryColor, style::PrimitiveStyle};
+    use crate::{
+        geometry::Size, pixel_iterator::IntoPixels, pixelcolor::BinaryColor, style::PrimitiveStyle,
+    };
 
     #[test]
     fn points_equals_filled() {

--- a/embedded-graphics/src/primitives/sector/points.rs
+++ b/embedded-graphics/src/primitives/sector/points.rs
@@ -1,10 +1,6 @@
 use crate::{
     geometry::Point,
-    primitives::{
-        arc::PlaneSectorIterator,
-        circle::{self, DistanceIterator},
-        sector::Sector,
-    },
+    primitives::{arc::PlaneSectorIterator, circle::DistanceIterator, sector::Sector},
 };
 
 /// Iterator over all points inside the sector.
@@ -16,19 +12,17 @@ pub struct Points {
 
 impl Points {
     pub(in crate::primitives) fn new(sector: &Sector) -> Self {
-        let threshold = circle::diameter_to_threshold(sector.diameter);
+        let circle = sector.to_circle();
+        let points = PlaneSectorIterator::new(
+            sector,
+            sector.center(),
+            sector.angle_start,
+            sector.angle_sweep,
+        );
 
         Self {
-            iter: DistanceIterator::new(
-                sector.center_2x(),
-                PlaneSectorIterator::new(
-                    sector,
-                    sector.center(),
-                    sector.angle_start,
-                    sector.angle_sweep,
-                ),
-            ),
-            threshold,
+            iter: circle.distances(points),
+            threshold: circle.threshold(),
         }
     }
 }

--- a/embedded-graphics/src/style/primitive_style.rs
+++ b/embedded-graphics/src/style/primitive_style.rs
@@ -1,5 +1,4 @@
 use crate::pixelcolor::PixelColor;
-use core::convert::TryFrom;
 
 /// Style properties for primitives.
 ///
@@ -70,14 +69,6 @@ where
             fill_color: Some(fill_color),
             ..PrimitiveStyle::default()
         }
-    }
-
-    /// Returns the stroke width as an `i32`.
-    ///
-    /// If the stroke width is too large to fit into an `i32` the maximum value
-    /// for an `i32` is returned instead.
-    pub(crate) fn stroke_width_i32(&self) -> i32 {
-        i32::try_from(self.stroke_width).unwrap_or(i32::max_value())
     }
 
     /// Returns the stroke width on the outside of the shape.
@@ -303,22 +294,6 @@ mod tests {
         assert_eq!(style.fill_color, None);
         assert_eq!(style.stroke_color, Some(Rgb888::GREEN));
         assert_eq!(style.stroke_width, 123);
-    }
-
-    #[test]
-    fn stroke_width_i32() {
-        let mut style: PrimitiveStyle<BinaryColor> = PrimitiveStyle::default();
-        style.stroke_width = 1;
-        assert_eq!(style.stroke_width_i32(), 1);
-
-        style.stroke_width = 0x7FFFFFFF;
-        assert_eq!(style.stroke_width_i32(), 0x7FFFFFFF);
-
-        style.stroke_width = 0x80000000;
-        assert_eq!(style.stroke_width_i32(), 0x7FFFFFFF);
-
-        style.stroke_width = 0xFFFFFFFF;
-        assert_eq!(style.stroke_width_i32(), 0x7FFFFFFF);
     }
 
     #[test]

--- a/embedded-graphics/src/style/styled.rs
+++ b/embedded-graphics/src/style/styled.rs
@@ -5,8 +5,8 @@ use crate::{
     primitives::{OffsetOutline, Rectangle},
     style::PrimitiveStyle,
     transform::Transform,
+    SaturatingCast,
 };
-use core::convert::TryFrom;
 
 /// Styled.
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
@@ -74,15 +74,15 @@ where
 
     fn stroke_area(&self) -> Self::Primitive {
         // saturate offset at i32::max_value() if stroke width is to large
-        let offset = i32::try_from(self.style.outside_stroke_width()).unwrap_or(i32::max_value());
+        let offset = self.style.outside_stroke_width().saturating_cast();
 
         self.primitive.offset(offset)
     }
 
     fn fill_area(&self) -> Self::Primitive {
-        // saturate offset at i32::max_value() if stroke width is to large
-        let offset = i32::try_from(self.style.inside_stroke_width()).unwrap_or(i32::max_value());
+        // saturate offset at i32::min_value() if stroke width is to large
+        let offset = self.style.inside_stroke_width().saturating_cast_neg();
 
-        self.primitive.offset(-offset)
+        self.primitive.offset(offset)
     }
 }


### PR DESCRIPTION
Hi! Thank you for helping out with Embedded Graphics development! Please:

- [ ] Check that you've added passing tests and documentation
- [ ] Add a simulator example(s) where applicable
- [ ] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) and appropriate crate (`embedded-graphics`, `simulator`, `tinytga`, `tinybmp`) if your changes affect the **public API**
- [ ] Run `rustfmt` on the project
- [ ] Run `./build.sh` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

This PR adds `to_circle` and `from_circle` to `Arc` and `Sector`.  `to_circle` could have been implemented as `From<Arc> for Circle` but I decided to use a method to keep the API symmetrical.

The added functions also made it possible to reuse more of the circle code in `Arc` and `Sector` to reduce some code duplication. And I've also added a new `SaturatingCast` trait which is used for `offset` implementations and also replaces the old `PrimitiveStyle::stroke_width_i32`.

@jamwaffles: Does this need a changelog entry? `Arc` and `Sector` are new in 0.7 and already have a changelog entry.