### PR TITLE
Add support for bottom-left image origin

### DIFF
--- a/embedded-graphics/src/image/mod.rs
+++ b/embedded-graphics/src/image/mod.rs
@@ -203,7 +203,12 @@ where
     where
         D: DrawTarget<Color = C>,
     {
-        display.fill_contiguous(&self.bounding_box(), self.into_pixels().map(|p| p.1))
+        // FIXME: fill_contiguous should be used whenever possible,
+        //        but the current implementation assumes an top-left to bottom-right
+        //        iteration order that isn't guaranteed
+        //display.fill_contiguous(&self.bounding_box(), self.into_pixels().map(|p| p.1))
+
+        display.draw_iter(self.into_pixels())
     }
 }
 

--- a/tinytga/CHANGELOG.md
+++ b/tinytga/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changed
 
 - **(breaking)** [#407](https://github.com/jamwaffles/embedded-graphics/pull/407) The `image_descriptor` in `TgaHeader` was replaced by `image_origin` and `alpha_channel_bits`.
+- **(breaking)** [#407](https://github.com/jamwaffles/embedded-graphics/pull/407) The `Pixel` type returned by `TgaIterator` now uses `u16` coordinates.
 
 ### Added
 

--- a/tinytga/CHANGELOG.md
+++ b/tinytga/CHANGELOG.md
@@ -6,14 +6,23 @@
 
 ## [Unreleased] - ReleaseDate
 
-- **(breaking)** #407 The `image_descriptor` in `TgaHeader` was replaced by `image_origin` and `alpha_channel_bits`.
-- #407 Added support for bottom-left origin images to `TgaIterator`.
+### Changed
+
+- **(breaking)** [#407](https://github.com/jamwaffles/embedded-graphics/pull/407) The `image_descriptor` in `TgaHeader` was replaced by `image_origin` and `alpha_channel_bits`.
+
+### Added
+
+- [#407](https://github.com/jamwaffles/embedded-graphics/pull/407) Added support for bottom-left origin images to `TgaIterator`.
+
+### Fixed
+
+- [#407](https://github.com/jamwaffles/embedded-graphics/pull/407) Additional data in `pixel_data`, beyond `width * height` pixels, is now discarded by `TgaIterator`.
 
 ## [0.3.2] - 2020-03-20
 
 ## [0.3.1] - 2020-02-17
 
-- **(breaking)** #247 "reverse" integration of tinytga into [`embedded-graphics`](https://crates.io/crates/embedded-graphics). tinytga now has a `graphics` feature that must be turned on to enable embedded-graphics support. The `tga` feature from embedded-graphics is removed.
+- **(breaking)** [#247](https://github.com/jamwaffles/embedded-graphics/pull/247) "reverse" integration of tinytga into [`embedded-graphics`](https://crates.io/crates/embedded-graphics). tinytga now has a `graphics` feature that must be turned on to enable embedded-graphics support. The `tga` feature from embedded-graphics is removed.
 
   **Before**
 
@@ -59,13 +68,13 @@
 
 ### Added
 
-- #217 Added support for TGA files with color map.
+- [#217](https://github.com/jamwaffles/embedded-graphics/pull/217) Added support for TGA files with color map.
 
 ### Fixed
 
-- #217 Images without a TGA footer are now parsed correctly.
-- #216 Fixed integer overflow for some RLE compressed TGA files.
-- #218 Test README examples in CI and update them to work with latest crate versions.
+- [#217](https://github.com/jamwaffles/embedded-graphics/pull/217) Images without a TGA footer are now parsed correctly.
+- [#216](https://github.com/jamwaffles/embedded-graphics/pull/216) Fixed integer overflow for some RLE compressed TGA files.
+- [#218](https://github.com/jamwaffles/embedded-graphics/pull/218) Test README examples in CI and update them to work with latest crate versions.
 
 <!-- next-url -->
 [unreleased]: https://github.com/jamwaffles/tinytga/compare/tinytga-v0.3.2...HEAD

--- a/tinytga/CHANGELOG.md
+++ b/tinytga/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ## [Unreleased] - ReleaseDate
 
+- **(breaking)** #407 The `image_descriptor` in `TgaHeader` was replaced by `image_origin` and `alpha_channel_bits`.
+- #407 Added support for bottom-left origin images to `TgaIterator`.
+
 ## [0.3.2] - 2020-03-20
 
 ## [0.3.1] - 2020-02-17

--- a/tinytga/README.md
+++ b/tinytga/README.md
@@ -23,7 +23,7 @@ data will need to be interpreted according to the `image_type` specified in the 
 ### Load a Run Length Encoded (RLE) TGA image
 
 ```rust
-use tinytga::{ImageType, Pixel, Tga, TgaFooter, TgaHeader};
+use tinytga::{ImageOrigin, ImageType, Pixel, Tga, TgaFooter, TgaHeader};
 
 // Include an image from a local path as bytes
 let data = include_bytes!("../tests/chessboard_4px_rle.tga");
@@ -46,7 +46,8 @@ assert_eq!(
         width: 4,
         height: 4,
         pixel_depth: 24,
-        image_descriptor: 32,
+        image_origin: ImageOrigin::TopLeft,
+        alpha_channel_bits: 0,
     }
 );
 

--- a/tinytga/README.md
+++ b/tinytga/README.md
@@ -47,7 +47,7 @@ assert_eq!(
         height: 4,
         pixel_depth: 24,
         image_origin: ImageOrigin::TopLeft,
-        alpha_channel_bits: 0,
+        alpha_channel_depth: 0,
     }
 );
 

--- a/tinytga/src/header.rs
+++ b/tinytga/src/header.rs
@@ -104,8 +104,8 @@ pub struct TgaHeader {
     /// Image origin
     pub image_origin: ImageOrigin,
 
-    /// Alpha channel bits
-    pub alpha_channel_bits: u8,
+    /// Alpha channel depth
+    pub alpha_channel_depth: u8,
 }
 
 fn has_color_map(input: &[u8]) -> IResult<&[u8], bool> {
@@ -144,7 +144,7 @@ pub fn header(input: &[u8]) -> IResult<&[u8], TgaHeader> {
 
     let (input, image_descriptor) = le_u8(input)?;
     let image_origin = ImageOrigin::from_image_descriptor(image_descriptor);
-    let alpha_channel_bits = image_descriptor & 0xF;
+    let alpha_channel_depth = image_descriptor & 0xF;
 
     let (input, _image_ident) = take(id_len)(input)?;
 
@@ -163,7 +163,7 @@ pub fn header(input: &[u8]) -> IResult<&[u8], TgaHeader> {
             height,
             pixel_depth,
             image_origin,
-            alpha_channel_bits,
+            alpha_channel_depth,
         },
     ))
 }

--- a/tinytga/src/lib.rs
+++ b/tinytga/src/lib.rs
@@ -226,7 +226,7 @@ impl<'a> IntoIterator for &'a Tga<'a> {
         let current_packet_len = current_packet.len();
 
         let y = if self.header.image_origin.is_bottom() {
-            u32::from(self.header.height).saturating_sub(1)
+            self.height().saturating_sub(1)
         } else {
             0
         };
@@ -269,10 +269,10 @@ pub struct TgaIterator<'a> {
     stride: usize,
 
     /// Current X coordinate from top-left of image
-    x: u32,
+    x: u16,
 
     /// Current Y coordinate from top-left of image
-    y: u32,
+    y: u16,
 
     /// Iteration is done
     done: bool,
@@ -384,7 +384,7 @@ impl<'a> Iterator for TgaIterator<'a> {
 
         self.x += 1;
 
-        if self.x >= u32::from(self.tga.width()) {
+        if self.x >= self.tga.width() {
             self.x = 0;
 
             if self.tga.header.image_origin.is_bottom() {
@@ -395,7 +395,7 @@ impl<'a> Iterator for TgaIterator<'a> {
                 }
             } else {
                 self.y += 1;
-                if self.y >= u32::from(self.tga.header.height) {
+                if self.y >= self.tga.height() {
                     self.done = true;
                 }
             }
@@ -439,7 +439,7 @@ mod e_g {
         fn next(&mut self) -> Option<Self::Item> {
             self.it.next().map(|p| {
                 let raw = C::Raw::from_u32(p.color);
-                EgPixel(Point::new(p.x as i32, p.y as i32), raw.into())
+                EgPixel(Point::new(i32::from(p.x), i32::from(p.y)), raw.into())
             })
         }
     }

--- a/tinytga/src/lib.rs
+++ b/tinytga/src/lib.rs
@@ -38,7 +38,7 @@
 //!         height: 4,
 //!         pixel_depth: 24,
 //!         image_origin: ImageOrigin::TopLeft,
-//!         alpha_channel_bits: 0,
+//!         alpha_channel_depth: 0,
 //!     }
 //! );
 //!

--- a/tinytga/src/pixel.rs
+++ b/tinytga/src/pixel.rs
@@ -2,10 +2,10 @@
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 pub struct Pixel {
     /// Pixel X coordinate from top left of image
-    pub x: u32,
+    pub x: u16,
 
     /// Pixel Y coordinate from top left of image
-    pub y: u32,
+    pub y: u16,
 
     /// Pixel color
     pub color: u32,

--- a/tinytga/tests/cbw8.rs
+++ b/tinytga/tests/cbw8.rs
@@ -25,7 +25,7 @@ fn cbw8() {
             height: 128,
             pixel_depth: 8,
             image_origin: ImageOrigin::BottomLeft,
-            alpha_channel_bits: 0,
+            alpha_channel_depth: 0,
         }
     );
 

--- a/tinytga/tests/cbw8.rs
+++ b/tinytga/tests/cbw8.rs
@@ -1,7 +1,6 @@
-use tinytga::{ImageType, Tga, TgaFooter, TgaHeader};
+use tinytga::{ImageOrigin, ImageType, Tga, TgaFooter, TgaHeader};
 
 #[test]
-#[ignore]
 fn cbw8() {
     let data = include_bytes!("./cbw8.tga");
 
@@ -10,7 +9,6 @@ fn cbw8() {
     println!("{:#?}", img.header);
     println!("{:#?}", img.footer);
     println!("Pixel data len {:#?}", img.pixel_data.len());
-    println!("Pixel data {:#?}", img.pixel_data);
 
     assert_eq!(
         img.header,
@@ -26,7 +24,8 @@ fn cbw8() {
             width: 128,
             height: 128,
             pixel_depth: 8,
-            image_descriptor: 0
+            image_origin: ImageOrigin::BottomLeft,
+            alpha_channel_bits: 0,
         }
     );
 

--- a/tinytga/tests/chequerboard-uncompressed-topleft.rs
+++ b/tinytga/tests/chequerboard-uncompressed-topleft.rs
@@ -29,7 +29,7 @@ fn chequerboard_uncompressed_topleft() {
             height: 8,
             pixel_depth: 8,
             image_origin: ImageOrigin::TopLeft,
-            alpha_channel_bits: 0,
+            alpha_channel_depth: 0,
         }
     );
 

--- a/tinytga/tests/chequerboard-uncompressed-topleft.rs
+++ b/tinytga/tests/chequerboard-uncompressed-topleft.rs
@@ -1,4 +1,4 @@
-use tinytga::{ImageType, Tga, TgaFooter, TgaHeader};
+use tinytga::{ImageOrigin, ImageType, Tga, TgaFooter, TgaHeader};
 
 #[test]
 fn chequerboard_uncompressed_topleft() {
@@ -28,7 +28,8 @@ fn chequerboard_uncompressed_topleft() {
             width: 8,
             height: 8,
             pixel_depth: 8,
-            image_descriptor: 32
+            image_origin: ImageOrigin::TopLeft,
+            alpha_channel_bits: 0,
         }
     );
 

--- a/tinytga/tests/chessboard_4px_raw.rs
+++ b/tinytga/tests/chessboard_4px_raw.rs
@@ -26,7 +26,7 @@ fn chessboard_4px_raw() {
             height: 4,
             pixel_depth: 24,
             image_origin: ImageOrigin::TopLeft,
-            alpha_channel_bits: 0,
+            alpha_channel_depth: 0,
         }
     );
 

--- a/tinytga/tests/chessboard_4px_raw.rs
+++ b/tinytga/tests/chessboard_4px_raw.rs
@@ -1,4 +1,4 @@
-use tinytga::{ImageType, Tga, TgaFooter, TgaHeader};
+use tinytga::{ImageOrigin, ImageType, Tga, TgaFooter, TgaHeader};
 
 #[test]
 fn chessboard_4px_raw() {
@@ -25,7 +25,8 @@ fn chessboard_4px_raw() {
             width: 4,
             height: 4,
             pixel_depth: 24,
-            image_descriptor: 32
+            image_origin: ImageOrigin::TopLeft,
+            alpha_channel_bits: 0,
         }
     );
 

--- a/tinytga/tests/chessboard_4px_rle.rs
+++ b/tinytga/tests/chessboard_4px_rle.rs
@@ -1,4 +1,4 @@
-use tinytga::{ImageType, Tga, TgaFooter, TgaHeader};
+use tinytga::{ImageOrigin, ImageType, Tga, TgaFooter, TgaHeader};
 
 #[test]
 fn chessboard_4px_rle() {
@@ -25,7 +25,8 @@ fn chessboard_4px_rle() {
             width: 4,
             height: 4,
             pixel_depth: 24,
-            image_descriptor: 32
+            image_origin: ImageOrigin::TopLeft,
+            alpha_channel_bits: 0,
         }
     );
 

--- a/tinytga/tests/chessboard_4px_rle.rs
+++ b/tinytga/tests/chessboard_4px_rle.rs
@@ -26,7 +26,7 @@ fn chessboard_4px_rle() {
             height: 4,
             pixel_depth: 24,
             image_origin: ImageOrigin::TopLeft,
-            alpha_channel_bits: 0,
+            alpha_channel_depth: 0,
         }
     );
 

--- a/tinytga/tests/chessboard_rle.rs
+++ b/tinytga/tests/chessboard_rle.rs
@@ -1,4 +1,4 @@
-use tinytga::{ImageType, Tga, TgaFooter, TgaHeader};
+use tinytga::{ImageOrigin, ImageType, Tga, TgaFooter, TgaHeader};
 
 #[test]
 fn chessboard_rle() {
@@ -25,7 +25,8 @@ fn chessboard_rle() {
             width: 8,
             height: 8,
             pixel_depth: 24,
-            image_descriptor: 32
+            image_origin: ImageOrigin::TopLeft,
+            alpha_channel_bits: 0,
         }
     );
 

--- a/tinytga/tests/chessboard_rle.rs
+++ b/tinytga/tests/chessboard_rle.rs
@@ -26,7 +26,7 @@ fn chessboard_rle() {
             height: 8,
             pixel_depth: 24,
             image_origin: ImageOrigin::TopLeft,
-            alpha_channel_bits: 0,
+            alpha_channel_depth: 0,
         }
     );
 

--- a/tinytga/tests/chessboard_uncompressed.rs
+++ b/tinytga/tests/chessboard_uncompressed.rs
@@ -1,4 +1,4 @@
-use tinytga::{ImageType, Tga, TgaFooter, TgaHeader};
+use tinytga::{ImageOrigin, ImageType, Tga, TgaFooter, TgaHeader};
 
 #[test]
 fn chessboard_uncompressed() {
@@ -25,7 +25,8 @@ fn chessboard_uncompressed() {
             width: 8,
             height: 8,
             pixel_depth: 24,
-            image_descriptor: 32
+            image_origin: ImageOrigin::TopLeft,
+            alpha_channel_bits: 0,
         }
     );
 

--- a/tinytga/tests/chessboard_uncompressed.rs
+++ b/tinytga/tests/chessboard_uncompressed.rs
@@ -26,7 +26,7 @@ fn chessboard_uncompressed() {
             height: 8,
             pixel_depth: 24,
             image_origin: ImageOrigin::TopLeft,
-            alpha_channel_bits: 0,
+            alpha_channel_depth: 0,
         }
     );
 

--- a/tinytga/tests/coordinates.rs
+++ b/tinytga/tests/coordinates.rs
@@ -41,7 +41,7 @@ fn coordinates() {
     let coords = img
         .into_iter()
         .map(|p| (p.x, p.y))
-        .collect::<Vec<(u32, u32)>>();
+        .collect::<Vec<(u16, u16)>>();
 
     assert_eq!(coords.len(), 4 * 4);
     assert_eq!(

--- a/tinytga/tests/coordinates.rs
+++ b/tinytga/tests/coordinates.rs
@@ -1,4 +1,4 @@
-use tinytga::{ImageType, Tga, TgaFooter, TgaHeader};
+use tinytga::{ImageOrigin, ImageType, Tga, TgaFooter, TgaHeader};
 
 #[test]
 fn coordinates() {
@@ -25,7 +25,8 @@ fn coordinates() {
             width: 4,
             height: 4,
             pixel_depth: 24,
-            image_descriptor: 32
+            image_origin: ImageOrigin::TopLeft,
+            alpha_channel_bits: 0,
         }
     );
 

--- a/tinytga/tests/coordinates.rs
+++ b/tinytga/tests/coordinates.rs
@@ -26,7 +26,7 @@ fn coordinates() {
             height: 4,
             pixel_depth: 24,
             image_origin: ImageOrigin::TopLeft,
-            alpha_channel_bits: 0,
+            alpha_channel_depth: 0,
         }
     );
 

--- a/tinytga/tests/embedded_graphics.rs
+++ b/tinytga/tests/embedded_graphics.rs
@@ -105,7 +105,6 @@ fn test_gray_tga(data: &[u8]) {
 
 /// Tests color mapped, uncompressed, bottom left origin TGA file.
 #[test]
-#[ignore]
 fn type1_bl() {
     test_color_tga(include_bytes!("./type1_bl.tga"));
 }
@@ -118,7 +117,6 @@ fn type1_tl() {
 
 /// Tests true color, uncompressed, bottom left origin TGA file.
 #[test]
-#[ignore]
 fn type2_bl() {
     test_color_tga(include_bytes!("./type2_bl.tga"));
 }
@@ -131,7 +129,6 @@ fn type2_tl() {
 
 /// Tests grayscale, uncompressed, bottom left origin TGA file.
 #[test]
-#[ignore]
 fn type3_bl() {
     test_gray_tga(include_bytes!("./type3_bl.tga"));
 }
@@ -144,7 +141,6 @@ fn type3_tl() {
 
 /// Tests color mapped, RLE compressed, bottom left origin TGA file.
 #[test]
-#[ignore]
 fn type9_bl() {
     test_color_tga(include_bytes!("./type9_bl.tga"));
 }
@@ -157,7 +153,6 @@ fn type9_tl() {
 
 /// Tests true color, RLE compressed, bottom left origin TGA file.
 #[test]
-#[ignore]
 fn type10_bl() {
     test_color_tga(include_bytes!("./type10_bl.tga"));
 }
@@ -170,7 +165,6 @@ fn type10_tl() {
 
 /// Tests grayscale, RLE compressed, bottom left origin TGA file.
 #[test]
-#[ignore]
 fn type11_bl() {
     test_gray_tga(include_bytes!("./type11_bl.tga"));
 }

--- a/tinytga/tests/types.rs
+++ b/tinytga/tests/types.rs
@@ -13,7 +13,7 @@ const HEADER_DEFAULT: TgaHeader = TgaHeader {
     height: 5,
     pixel_depth: 8,
     image_origin: ImageOrigin::BottomLeft,
-    alpha_channel_bits: 0,
+    alpha_channel_depth: 0,
 };
 
 #[test]

--- a/tinytga/tests/types.rs
+++ b/tinytga/tests/types.rs
@@ -1,4 +1,4 @@
-use tinytga::{ImageType, Tga, TgaHeader};
+use tinytga::{ImageOrigin, ImageType, Tga, TgaHeader};
 
 const HEADER_DEFAULT: TgaHeader = TgaHeader {
     id_len: 0,
@@ -12,7 +12,8 @@ const HEADER_DEFAULT: TgaHeader = TgaHeader {
     width: 9,
     height: 5,
     pixel_depth: 8,
-    image_descriptor: 0,
+    image_origin: ImageOrigin::BottomLeft,
+    alpha_channel_bits: 0,
 };
 
 #[test]
@@ -45,7 +46,7 @@ fn type1_tl() {
             color_map_start: 0,
             color_map_len: 8,
             color_map_depth: 24,
-            image_descriptor: 32,
+            image_origin: ImageOrigin::TopLeft,
             ..HEADER_DEFAULT
         }
     );
@@ -76,7 +77,7 @@ fn type2_tl() {
         TgaHeader {
             image_type: ImageType::Truecolor,
             pixel_depth: 24,
-            image_descriptor: 32,
+            image_origin: ImageOrigin::TopLeft,
             ..HEADER_DEFAULT
         }
     );
@@ -105,7 +106,7 @@ fn type3_tl() {
         tga.header,
         TgaHeader {
             image_type: ImageType::Monochrome,
-            image_descriptor: 32,
+            image_origin: ImageOrigin::TopLeft,
             ..HEADER_DEFAULT
         }
     );
@@ -142,7 +143,7 @@ fn type9_tl() {
             color_map_start: 0,
             color_map_len: 8,
             color_map_depth: 24,
-            image_descriptor: 32,
+            image_origin: ImageOrigin::TopLeft,
             ..HEADER_DEFAULT
         }
     );
@@ -173,7 +174,7 @@ fn type10_tl() {
         TgaHeader {
             image_type: ImageType::RleTruecolor,
             pixel_depth: 24,
-            image_descriptor: 32,
+            image_origin: ImageOrigin::TopLeft,
             ..HEADER_DEFAULT
         }
     );
@@ -202,7 +203,7 @@ fn type11_tl() {
         tga.header,
         TgaHeader {
             image_type: ImageType::RleMonochrome,
-            image_descriptor: 32,
+            image_origin: ImageOrigin::TopLeft,
             ..HEADER_DEFAULT
         }
     );

--- a/tinytga/tests/ubw8.rs
+++ b/tinytga/tests/ubw8.rs
@@ -1,7 +1,6 @@
-use tinytga::{ImageType, Pixel, Tga, TgaFooter, TgaHeader};
+use tinytga::{ImageOrigin, ImageType, Pixel, Tga, TgaFooter, TgaHeader};
 
 #[test]
-#[ignore]
 fn ubw8() {
     let data = include_bytes!("./ubw8.tga");
 
@@ -25,7 +24,8 @@ fn ubw8() {
             width: 128,
             height: 128,
             pixel_depth: 8,
-            image_descriptor: 0
+            image_origin: ImageOrigin::BottomLeft,
+            alpha_channel_bits: 0
         }
     );
 

--- a/tinytga/tests/ubw8.rs
+++ b/tinytga/tests/ubw8.rs
@@ -25,7 +25,7 @@ fn ubw8() {
             height: 128,
             pixel_depth: 8,
             image_origin: ImageOrigin::BottomLeft,
-            alpha_channel_bits: 0
+            alpha_channel_depth: 0
         }
     );
 


### PR DESCRIPTION
Hi! Thank you for helping out with Embedded Graphics development! Please:

- [ ] Check that you've added passing tests and documentation
- [ ] Add a simulator example(s) where applicable
- [ ] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) and appropriate crate (`embedded-graphics`, `simulator`, `tinytga`, `tinybmp`) if your changes affect the **public API**
- [ ] Run `rustfmt` on the project
- [ ] Run `./build.sh` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

This PR adds support for TGA images with bottom-left image origin to `tinytga`. Additionally the pixel iterator now ignores any data present in the `image_data` after `width * height` pixels, which seems to have fixed the `cbw8.rs` and `ubw8.tga` tests. This means that there are no more ignored tests in `tinytga`.

I had to temporarily change the `Drawable` implementation for `Image`, because it assumed the iteration order and ignored the pixel coordinates returned by the image data. I'll revisit this when I work on `SubImage`.