### PR TITLE
Bump simulator version to 0.2.1

### DIFF
--- a/simulator/Cargo.toml
+++ b/simulator/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-version = "0.2.0"
+version = "0.2.1"
 name = "embedded-graphics-simulator"
 description = "Embedded graphics simulator"
 authors = ["Byron Wasti <byron.wasti@gmail.com>", "James Waples <james@wapl.es>"]

--- a/simulator/README.md
+++ b/simulator/README.md
@@ -81,7 +81,7 @@ The `with-sdl` feature is enabled by default and can be disabled by adding `defa
 
 ```toml
 [dependencies.embedded-graphics-simulator]
-version = "0.2.0"
+version = "0.2.1"
 default-features = false
 ```
 


### PR DESCRIPTION
Hi! Thank you for helping out with Embedded Graphics development! Please:

- [ ] Check that you've added passing tests and documentation
- [ ] Add a simulator example(s) where applicable
- [ ] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) and appropriate crate (`embedded-graphics`, `simulator`, `tinytga`, `tinybmp`) if your changes affect the **public API**
- [ ] Run `rustfmt` on the project
- [ ] Run `./build.sh` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

Simulator was not updated along with the v0.6.2 release. This PR proposes releasing the simulator at that point as 0.2.1, containing the MouseMove event and with-sdl feature flag.
