### PR TITLE
Replace linkchecker with cargo-deadlinks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,8 +6,8 @@ precheck_steps: &precheck_steps
     - checkout
     - restore_cache:
         key: v5-embedded-graphics-{{ .Environment.CIRCLE_JOB }}-{{ checksum "embedded-graphics/Cargo.toml" }}-{{ checksum "tinybmp/Cargo.toml" }}-{{ checksum "tinytga/Cargo.toml" }}-{{ checksum "simulator/Cargo.toml" }}
-    - run: sudo apt update && sudo apt install -qq libsdl2-dev linkchecker
-    - run: cargo install cargo-readme just
+    - run: sudo apt update && sudo apt install -qq libsdl2-dev
+    - run: cargo install cargo-readme just cargo-deadlinks
     - run: rustup default ${RUST_VERSION:-stable}
     - run: rustup toolchain add nightly -c rustfmt
     - run: rustup component add rustfmt

--- a/doc/development-setup.md
+++ b/doc/development-setup.md
@@ -9,22 +9,15 @@ rustup update
 # Ensure rustfmt is installed
 rustup component add rustfmt
 
-# Install `cargo-readme`
-cargo install cargo-readme
+# Install `cargo-readme` and `cargo-deadlinks`
+cargo install cargo-readme cargo-deadlinks
 
 # Install `just`
 cargo install just
 
-# Install SDL2 for simulator and linkchecker for build script
+# Install SDL2 for simulator for build script
+sudo apt install libsdl2-dev
 
-# Python 2 systems (Ubuntu older than 20.04, Linux Mint 19, etc)
-sudo apt install libsdl2-dev linkchecker
-
-# OR
-
-# Python 3 systems (Ubuntu 20.04+, Linux Mint 20, etc)
-sudo apt install python3-pip
-sudo pip3 install git+https://github.com/linkchecker/linkchecker.git
 ```
 
 ## Generating readmes

--- a/justfile
+++ b/justfile
@@ -52,13 +52,9 @@ generate-docs:
     cargo clean --doc
     cargo doc --all-features
 
-# Runs linkchecker on the docs
+# Runs cargo-deadlinks on the docs
 check-links: generate-docs
-    linkchecker --check-extern --ignore-url=^http \
-        target/doc/embedded_graphics/index.html \
-        target/doc/tinybmp/index.html \
-        target/doc/tinytga/index.html \
-        target/doc/embedded_graphics_simulator/index.html
+    cargo deadlinks
 
 #----------------------
 # README.md generation


### PR DESCRIPTION
Hi! Thank you for helping out with Embedded Graphics development! Please:

- [ ] Check that you've added passing tests and documentation
- [ ] Add a simulator example(s) where applicable
- [ ] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) and appropriate crate (`embedded-graphics`, `simulator`, `tinytga`, `tinybmp`) if your changes affect the **public API**
- [ ] Run `rustfmt` on the project
- [ ] Run `./build.sh` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

Let's see how this goes. One downside may be that deadlinks hasn't been updated for a while, though, so this may or may not be acceptable.
