### PR TITLE
Add ToBytes trait for colors

### DIFF
--- a/embedded-graphics/CHANGELOG.md
+++ b/embedded-graphics/CHANGELOG.md
@@ -34,6 +34,7 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 - [#409](https://github.com/jamwaffles/embedded-graphics/pull/409) Added `Clipped`, `Cropped` and `Translated` draw targets.
 - [#409](https://github.com/jamwaffles/embedded-graphics/pull/409) Added `OriginDimensions` trait for dimensions with `top_left == Point::zero()`.
 - [#420](https://github.com/jamwaffles/embedded-graphics/pull/420) Added support for `SubImage`s.
+- [#429](https://github.com/jamwaffles/embedded-graphics/pull/429) Added `ToBytes` trait to convert colors into byte arrays.
 
 ### Changed
 

--- a/embedded-graphics/src/pixelcolor/mod.rs
+++ b/embedded-graphics/src/pixelcolor/mod.rs
@@ -121,7 +121,7 @@ pub trait PixelColor: Copy + PartialEq {
 ///
 /// ## Get the `u16` representing an `Rgb565` color
 ///
-/// This example converts an [`Rgb565`] color into its underlying `u16` represenation.
+/// This example converts an [`Rgb565`] color into its underlying `u16` representation.
 ///
 /// ```rust
 /// use embedded_graphics::{pixelcolor::Rgb565, prelude::*};

--- a/embedded-graphics/src/pixelcolor/raw/mod.rs
+++ b/embedded-graphics/src/pixelcolor/raw/mod.rs
@@ -7,6 +7,20 @@
 //! Specifying a [`Raw`] type for a [`PixelColor`] is required to use that color
 //! with the [`Image`] struct.
 //!
+//! # Converting colors to raw data
+//!
+//! Colors can be converted into raw data by using two different methods. The [`into_storage`]
+//! method is used to convert a color into a single integer value and the [`to_bytes`] method
+//! is used to convert it into a byte array.
+//!
+//! ```
+//! use embedded_graphics::{prelude::*, pixelcolor::Rgb888};
+//!
+//! let color = Rgb888::new(0x11, 0x22, 0x33);
+//! assert_eq!(color.into_storage(), 0x00112233);
+//! assert_eq!(color.to_bytes(), [0x11, 0x22, 0x33]);
+//! ```
+//!
 //! # Implementing PixelColor with Raw support
 //!
 //! This example shows how to implement a new [`PixelColor`] that can be used
@@ -91,9 +105,14 @@
 //! [`PixelColor`]: ../trait.PixelColor.html
 //! [`Raw`]: ../trait.PixelColor.html#associatedtype.Raw
 //! [`Image`]: ../../image/struct.Image.html
+//! [`into_storage`]: ../trait.IntoStorage.html#tymethod.into_storage
+//! [`to_bytes`]: trait.ToBytes.html#tymethod.to_bytes
 
 mod iter;
+mod to_bytes;
+
 pub(crate) use iter::{RawDataIter, RawDataIterNext};
+pub use to_bytes::ToBytes;
 
 /// Trait implemented by all `RawUx` types.
 pub trait RawData:
@@ -102,6 +121,7 @@ pub trait RawData:
     + RawDataIterNext<LittleEndian>
     + RawDataIterNext<BigEndian>
     + From<<Self as RawData>::Storage>
+    + ToBytes
 {
     /// Storage type.
     ///

--- a/embedded-graphics/src/pixelcolor/raw/mod.rs
+++ b/embedded-graphics/src/pixelcolor/raw/mod.rs
@@ -10,15 +10,18 @@
 //! # Converting colors to raw data
 //!
 //! Colors can be converted into raw data by using two different methods. The [`into_storage`]
-//! method is used to convert a color into a single integer value and the [`to_bytes`] method
-//! is used to convert it into a byte array.
+//! method is used to convert a color into a single integer value. To convert a color into a byte
+//! array the methods provided by the [`ToBytes`] trait can be used. By using [`to_be_bytes`] the
+//! color components will have the same order in memory as in the name of the type.
 //!
 //! ```
 //! use embedded_graphics::{prelude::*, pixelcolor::Rgb888};
 //!
 //! let color = Rgb888::new(0x11, 0x22, 0x33);
+//!
 //! assert_eq!(color.into_storage(), 0x00112233);
-//! assert_eq!(color.to_bytes(), [0x11, 0x22, 0x33]);
+//!
+//! assert_eq!(color.to_be_bytes(), [0x11, 0x22, 0x33]);
 //! ```
 //!
 //! # Implementing PixelColor with Raw support
@@ -106,7 +109,8 @@
 //! [`Raw`]: ../trait.PixelColor.html#associatedtype.Raw
 //! [`Image`]: ../../image/struct.Image.html
 //! [`into_storage`]: ../trait.IntoStorage.html#tymethod.into_storage
-//! [`to_bytes`]: trait.ToBytes.html#tymethod.to_bytes
+//! [`ToBytes`]: trait.ToBytes.html
+//! [`to_be_bytes`]: trait.ToBytes.html#tymethod.to_bytes
 
 mod iter;
 mod to_bytes;

--- a/embedded-graphics/src/pixelcolor/raw/to_bytes.rs
+++ b/embedded-graphics/src/pixelcolor/raw/to_bytes.rs
@@ -9,7 +9,7 @@ use crate::pixelcolor::{
 ///
 /// [module-level documentation]: index.html#converting-colors-to-raw-data
 pub trait ToBytes {
-    /// Return type of `to_bytes`.
+    /// Return type of methods in this trait.
     type Bytes;
 
     /// Converts a color into a byte array with big endian byte order.

--- a/embedded-graphics/src/pixelcolor/raw/to_bytes.rs
+++ b/embedded-graphics/src/pixelcolor/raw/to_bytes.rs
@@ -12,62 +12,85 @@ pub trait ToBytes {
     /// Return type of `to_bytes`.
     type Bytes;
 
-    /// Converts a color into a byte array.
-    ///
-    /// The resulting array will always use big endian byte ordering regardless
-    /// of the host endianness.
-    fn to_bytes(self) -> Self::Bytes;
+    /// Converts a color into a byte array with big endian byte order.
+    fn to_be_bytes(self) -> Self::Bytes;
+
+    /// Converts a color into a byte array with little endian byte order.
+    fn to_le_bytes(self) -> Self::Bytes;
+
+    /// Converts a color into a byte array with native byte order.
+    fn to_ne_bytes(self) -> Self::Bytes;
 }
 
 macro_rules! impl_to_bytes {
-    ($type:ty) => {
+    ($type:ty, $bytes_type:ty) => {
         impl ToBytes for $type {
-            type Bytes = [u8; 1];
+            type Bytes = $bytes_type;
 
-            fn to_bytes(self) -> Self::Bytes {
-                [self.0]
+            fn to_be_bytes(self) -> Self::Bytes {
+                self.0.to_be_bytes()
+            }
+
+            fn to_le_bytes(self) -> Self::Bytes {
+                self.0.to_le_bytes()
+            }
+
+            fn to_ne_bytes(self) -> Self::Bytes {
+                self.0.to_ne_bytes()
             }
         }
     };
 }
 
-impl_to_bytes!(RawU1);
-impl_to_bytes!(RawU2);
-impl_to_bytes!(RawU4);
-impl_to_bytes!(RawU8);
-
-impl ToBytes for RawU16 {
-    type Bytes = [u8; 2];
-
-    fn to_bytes(self) -> Self::Bytes {
-        self.0.to_be_bytes()
-    }
-}
+impl_to_bytes!(RawU1, [u8; 1]);
+impl_to_bytes!(RawU2, [u8; 1]);
+impl_to_bytes!(RawU4, [u8; 1]);
+impl_to_bytes!(RawU8, [u8; 1]);
+impl_to_bytes!(RawU16, [u8; 2]);
+impl_to_bytes!(RawU32, [u8; 4]);
 
 impl ToBytes for RawU24 {
     type Bytes = [u8; 3];
 
-    fn to_bytes(self) -> Self::Bytes {
+    fn to_be_bytes(self) -> Self::Bytes {
         let mut ret = [0; 3];
 
         ret.copy_from_slice(&self.0.to_be_bytes()[1..4]);
 
         ret
     }
-}
 
-impl ToBytes for RawU32 {
-    type Bytes = [u8; 4];
+    fn to_le_bytes(self) -> Self::Bytes {
+        let mut ret = [0; 3];
 
-    fn to_bytes(self) -> Self::Bytes {
-        self.0.to_be_bytes()
+        ret.copy_from_slice(&self.0.to_le_bytes()[0..3]);
+
+        ret
+    }
+
+    #[cfg(target_endian = "big")]
+    fn to_ne_bytes(self) -> Self::Bytes {
+        self.to_be_bytes()
+    }
+
+    #[cfg(target_endian = "little")]
+    fn to_ne_bytes(self) -> Self::Bytes {
+        self.to_le_bytes()
     }
 }
 
 impl ToBytes for () {
     type Bytes = [u8; 0];
 
-    fn to_bytes(self) -> Self::Bytes {
+    fn to_be_bytes(self) -> Self::Bytes {
+        []
+    }
+
+    fn to_le_bytes(self) -> Self::Bytes {
+        []
+    }
+
+    fn to_ne_bytes(self) -> Self::Bytes {
         []
     }
 }
@@ -78,8 +101,16 @@ where
 {
     type Bytes = <<C as PixelColor>::Raw as ToBytes>::Bytes;
 
-    fn to_bytes(self) -> Self::Bytes {
-        self.into().to_bytes()
+    fn to_le_bytes(self) -> Self::Bytes {
+        self.into().to_le_bytes()
+    }
+
+    fn to_be_bytes(self) -> Self::Bytes {
+        self.into().to_be_bytes()
+    }
+
+    fn to_ne_bytes(self) -> Self::Bytes {
+        self.into().to_ne_bytes()
     }
 }
 
@@ -88,80 +119,234 @@ mod tests {
     use super::*;
     use crate::pixelcolor::{Bgr565, Bgr888, BinaryColor, Gray2, Gray4, Gray8, Rgb565, Rgb888};
 
+    fn assert_all_orders<T>(value: T, bytes: T::Bytes)
+    where
+        T: ToBytes + Copy,
+        T::Bytes: PartialEq + core::fmt::Debug,
+    {
+        assert_eq!(value.to_le_bytes(), bytes);
+        assert_eq!(value.to_be_bytes(), bytes);
+        assert_eq!(value.to_ne_bytes(), bytes);
+    }
+
     #[test]
     fn bpp1() {
-        assert_eq!(BinaryColor::Off.to_bytes(), [0]);
-        assert_eq!(BinaryColor::On.to_bytes(), [1]);
+        assert_all_orders(BinaryColor::Off, [0]);
+        assert_all_orders(BinaryColor::On, [1]);
     }
 
     #[test]
     fn bpp2() {
-        assert_eq!(Gray2::new(0).to_bytes(), [0]);
-        assert_eq!(Gray2::new(3).to_bytes(), [3]);
+        assert_all_orders(Gray2::new(0), [0]);
+        assert_all_orders(Gray2::new(3), [3]);
     }
 
     #[test]
     fn bpp4() {
-        assert_eq!(Gray4::new(0).to_bytes(), [0]);
-        assert_eq!(Gray4::new(15).to_bytes(), [15]);
+        assert_all_orders(Gray4::new(0), [0]);
+        assert_all_orders(Gray4::new(15), [15]);
     }
 
     #[test]
     fn bpp8() {
-        assert_eq!(Gray8::new(0).to_bytes(), [0]);
-        assert_eq!(Gray8::new(255).to_bytes(), [255]);
+        assert_all_orders(Gray8::new(0), [0]);
+        assert_all_orders(Gray8::new(255), [255]);
     }
 
     #[test]
-    fn bpp16_rgb() {
+    fn bpp16_rgb_be() {
         assert_eq!(
-            Rgb565::new(255, 0, 0).to_bytes(),
+            Rgb565::new(255, 0, 0).to_be_bytes(),
             [0b11111_000, 0b000_00000]
         );
         assert_eq!(
-            Rgb565::new(0, 255, 0).to_bytes(),
+            Rgb565::new(0, 255, 0).to_be_bytes(),
             [0b00000_111, 0b111_00000]
         );
         assert_eq!(
-            Rgb565::new(0, 0, 255).to_bytes(),
+            Rgb565::new(0, 0, 255).to_be_bytes(),
             [0b00000_000, 0b000_11111]
         );
     }
 
     #[test]
-    fn bpp16_bgr() {
+    fn bpp16_rgb_le() {
         assert_eq!(
-            Bgr565::new(255, 0, 0).to_bytes(),
+            Rgb565::new(255, 0, 0).to_le_bytes(),
+            [0b000_00000, 0b11111_000]
+        );
+        assert_eq!(
+            Rgb565::new(0, 255, 0).to_le_bytes(),
+            [0b111_00000, 0b00000_111]
+        );
+        assert_eq!(
+            Rgb565::new(0, 0, 255).to_le_bytes(),
+            [0b000_11111, 0b00000_000]
+        );
+    }
+
+    #[test]
+    fn bpp16_bgr_be() {
+        assert_eq!(
+            Bgr565::new(255, 0, 0).to_be_bytes(),
             [0b00000_000, 0b000_11111]
         );
         assert_eq!(
-            Bgr565::new(0, 255, 0).to_bytes(),
+            Bgr565::new(0, 255, 0).to_be_bytes(),
             [0b00000_111, 0b111_00000]
         );
         assert_eq!(
-            Bgr565::new(0, 0, 255).to_bytes(),
+            Bgr565::new(0, 0, 255).to_be_bytes(),
             [0b11111_000, 0b000_00000]
         );
     }
 
     #[test]
-    fn bpp24_rgb() {
-        assert_eq!(Rgb888::new(0xFF, 0x00, 0x00).to_bytes(), [0xFF, 0x00, 0x00]);
-        assert_eq!(Rgb888::new(0x00, 0xFF, 0x00).to_bytes(), [0x00, 0xFF, 0x00]);
-        assert_eq!(Rgb888::new(0x00, 0x00, 0xFF).to_bytes(), [0x00, 0x00, 0xFF]);
+    fn bpp16_bgr_le() {
+        assert_eq!(
+            Bgr565::new(255, 0, 0).to_le_bytes(),
+            [0b000_11111, 0b00000_000]
+        );
+        assert_eq!(
+            Bgr565::new(0, 255, 0).to_le_bytes(),
+            [0b111_00000, 0b00000_111]
+        );
+        assert_eq!(
+            Bgr565::new(0, 0, 255).to_le_bytes(),
+            [0b000_00000, 0b11111_000]
+        );
     }
 
     #[test]
-    fn bpp24_bgr() {
-        assert_eq!(Bgr888::new(0xFF, 0x00, 0x00).to_bytes(), [0x00, 0x00, 0xFF]);
-        assert_eq!(Bgr888::new(0x00, 0xFF, 0x00).to_bytes(), [0x00, 0xFF, 0x00]);
-        assert_eq!(Bgr888::new(0x00, 0x00, 0xFF).to_bytes(), [0xFF, 0x00, 0x00]);
+    fn bpp24_rgb_be() {
+        assert_eq!(
+            Rgb888::new(0xFF, 0x00, 0x00).to_be_bytes(),
+            [0xFF, 0x00, 0x00]
+        );
+        assert_eq!(
+            Rgb888::new(0x00, 0xFF, 0x00).to_be_bytes(),
+            [0x00, 0xFF, 0x00]
+        );
+        assert_eq!(
+            Rgb888::new(0x00, 0x00, 0xFF).to_be_bytes(),
+            [0x00, 0x00, 0xFF]
+        );
     }
 
     #[test]
-    fn bpp32() {
+    fn bpp24_rgb_le() {
+        assert_eq!(
+            Rgb888::new(0xFF, 0x00, 0x00).to_le_bytes(),
+            [0x00, 0x00, 0xFF]
+        );
+        assert_eq!(
+            Rgb888::new(0x00, 0xFF, 0x00).to_le_bytes(),
+            [0x00, 0xFF, 0x00]
+        );
+        assert_eq!(
+            Rgb888::new(0x00, 0x00, 0xFF).to_le_bytes(),
+            [0xFF, 0x00, 0x00]
+        );
+    }
+
+    #[test]
+    fn bpp24_bgr_be() {
+        assert_eq!(
+            Bgr888::new(0xFF, 0x00, 0x00).to_be_bytes(),
+            [0x00, 0x00, 0xFF]
+        );
+        assert_eq!(
+            Bgr888::new(0x00, 0xFF, 0x00).to_be_bytes(),
+            [0x00, 0xFF, 0x00]
+        );
+        assert_eq!(
+            Bgr888::new(0x00, 0x00, 0xFF).to_be_bytes(),
+            [0xFF, 0x00, 0x00]
+        );
+    }
+
+    #[test]
+    fn bpp24_bgr_le() {
+        assert_eq!(
+            Bgr888::new(0xFF, 0x00, 0x00).to_le_bytes(),
+            [0xFF, 0x00, 0x00]
+        );
+        assert_eq!(
+            Bgr888::new(0x00, 0xFF, 0x00).to_le_bytes(),
+            [0x00, 0xFF, 0x00]
+        );
+        assert_eq!(
+            Bgr888::new(0x00, 0x00, 0xFF).to_le_bytes(),
+            [0x00, 0x00, 0xFF]
+        );
+    }
+
+    #[test]
+    fn bpp32_be() {
         // This test uses `RawU32` instead of a color, because no color included
         // in this crate uses 32 bpp.
-        assert_eq!(RawU32::new(0x11223344).to_bytes(), [0x11, 0x22, 0x33, 0x44]);
+        assert_eq!(
+            RawU32::new(0x11223344).to_be_bytes(),
+            [0x11, 0x22, 0x33, 0x44]
+        );
+    }
+
+    #[test]
+    fn bpp32_le() {
+        // This test uses `RawU32` instead of a color, because no color included
+        // in this crate uses 32 bpp.
+        assert_eq!(
+            RawU32::new(0x11223344).to_le_bytes(),
+            [0x44, 0x33, 0x22, 0x11]
+        );
+    }
+
+    #[test]
+    fn native_byte_ordering() {
+        #[cfg(target_endian = "big")]
+        {
+            assert_eq!(RawU1::new(0x1).to_ne_bytes(), RawU1::new(0x1).to_be_bytes());
+            assert_eq!(RawU2::new(0x1).to_ne_bytes(), RawU2::new(0x1).to_be_bytes());
+            assert_eq!(RawU4::new(0x1).to_ne_bytes(), RawU4::new(0x1).to_be_bytes());
+            assert_eq!(
+                RawU8::new(0x12).to_ne_bytes(),
+                RawU8::new(0x12).to_be_bytes()
+            );
+            assert_eq!(
+                RawU16::new(0x1234).to_ne_bytes(),
+                RawU16::new(0x1234).to_be_bytes()
+            );
+            assert_eq!(
+                RawU24::new(0x123456).to_ne_bytes(),
+                RawU24::new(0x123456).to_be_bytes()
+            );
+            assert_eq!(
+                RawU32::new(0x12345678).to_ne_bytes(),
+                RawU32::new(0x12345678).to_be_bytes()
+            );
+        }
+
+        #[cfg(target_endian = "little")]
+        {
+            assert_eq!(RawU1::new(0x1).to_ne_bytes(), RawU1::new(0x1).to_le_bytes());
+            assert_eq!(RawU2::new(0x1).to_ne_bytes(), RawU2::new(0x1).to_le_bytes());
+            assert_eq!(RawU4::new(0x1).to_ne_bytes(), RawU4::new(0x1).to_le_bytes());
+            assert_eq!(
+                RawU8::new(0x12).to_ne_bytes(),
+                RawU8::new(0x12).to_le_bytes()
+            );
+            assert_eq!(
+                RawU16::new(0x1234).to_ne_bytes(),
+                RawU16::new(0x1234).to_le_bytes()
+            );
+            assert_eq!(
+                RawU24::new(0x123456).to_ne_bytes(),
+                RawU24::new(0x123456).to_le_bytes()
+            );
+            assert_eq!(
+                RawU32::new(0x12345678).to_ne_bytes(),
+                RawU32::new(0x12345678).to_le_bytes()
+            );
+        }
     }
 }

--- a/embedded-graphics/src/pixelcolor/raw/to_bytes.rs
+++ b/embedded-graphics/src/pixelcolor/raw/to_bytes.rs
@@ -1,0 +1,167 @@
+use crate::pixelcolor::{
+    raw::{RawU1, RawU16, RawU2, RawU24, RawU32, RawU4, RawU8},
+    PixelColor,
+};
+
+/// Trait to convert colors into a byte array.
+///
+/// See the [module-level documentation] for an example.
+///
+/// [module-level documentation]: index.html#converting-colors-to-raw-data
+pub trait ToBytes {
+    /// Return type of `to_bytes`.
+    type Bytes;
+
+    /// Converts a color into a byte array.
+    ///
+    /// The resulting array will always use big endian byte ordering regardless
+    /// of the host endianness.
+    fn to_bytes(self) -> Self::Bytes;
+}
+
+macro_rules! impl_to_bytes {
+    ($type:ty) => {
+        impl ToBytes for $type {
+            type Bytes = [u8; 1];
+
+            fn to_bytes(self) -> Self::Bytes {
+                [self.0]
+            }
+        }
+    };
+}
+
+impl_to_bytes!(RawU1);
+impl_to_bytes!(RawU2);
+impl_to_bytes!(RawU4);
+impl_to_bytes!(RawU8);
+
+impl ToBytes for RawU16 {
+    type Bytes = [u8; 2];
+
+    fn to_bytes(self) -> Self::Bytes {
+        self.0.to_be_bytes()
+    }
+}
+
+impl ToBytes for RawU24 {
+    type Bytes = [u8; 3];
+
+    fn to_bytes(self) -> Self::Bytes {
+        let mut ret = [0; 3];
+
+        ret.copy_from_slice(&self.0.to_be_bytes()[1..4]);
+
+        ret
+    }
+}
+
+impl ToBytes for RawU32 {
+    type Bytes = [u8; 4];
+
+    fn to_bytes(self) -> Self::Bytes {
+        self.0.to_be_bytes()
+    }
+}
+
+impl ToBytes for () {
+    type Bytes = [u8; 0];
+
+    fn to_bytes(self) -> Self::Bytes {
+        []
+    }
+}
+
+impl<C> ToBytes for C
+where
+    C: PixelColor + Into<<C as PixelColor>::Raw>,
+{
+    type Bytes = <<C as PixelColor>::Raw as ToBytes>::Bytes;
+
+    fn to_bytes(self) -> Self::Bytes {
+        self.into().to_bytes()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pixelcolor::{Bgr565, Bgr888, BinaryColor, Gray2, Gray4, Gray8, Rgb565, Rgb888};
+
+    #[test]
+    fn bpp1() {
+        assert_eq!(BinaryColor::Off.to_bytes(), [0]);
+        assert_eq!(BinaryColor::On.to_bytes(), [1]);
+    }
+
+    #[test]
+    fn bpp2() {
+        assert_eq!(Gray2::new(0).to_bytes(), [0]);
+        assert_eq!(Gray2::new(3).to_bytes(), [3]);
+    }
+
+    #[test]
+    fn bpp4() {
+        assert_eq!(Gray4::new(0).to_bytes(), [0]);
+        assert_eq!(Gray4::new(15).to_bytes(), [15]);
+    }
+
+    #[test]
+    fn bpp8() {
+        assert_eq!(Gray8::new(0).to_bytes(), [0]);
+        assert_eq!(Gray8::new(255).to_bytes(), [255]);
+    }
+
+    #[test]
+    fn bpp16_rgb() {
+        assert_eq!(
+            Rgb565::new(255, 0, 0).to_bytes(),
+            [0b11111_000, 0b000_00000]
+        );
+        assert_eq!(
+            Rgb565::new(0, 255, 0).to_bytes(),
+            [0b00000_111, 0b111_00000]
+        );
+        assert_eq!(
+            Rgb565::new(0, 0, 255).to_bytes(),
+            [0b00000_000, 0b000_11111]
+        );
+    }
+
+    #[test]
+    fn bpp16_bgr() {
+        assert_eq!(
+            Bgr565::new(255, 0, 0).to_bytes(),
+            [0b00000_000, 0b000_11111]
+        );
+        assert_eq!(
+            Bgr565::new(0, 255, 0).to_bytes(),
+            [0b00000_111, 0b111_00000]
+        );
+        assert_eq!(
+            Bgr565::new(0, 0, 255).to_bytes(),
+            [0b11111_000, 0b000_00000]
+        );
+    }
+
+    #[test]
+    fn bpp24_rgb() {
+        assert_eq!(Rgb888::new(0xFF, 0x00, 0x00).to_bytes(), [0xFF, 0x00, 0x00]);
+        assert_eq!(Rgb888::new(0x00, 0xFF, 0x00).to_bytes(), [0x00, 0xFF, 0x00]);
+        assert_eq!(Rgb888::new(0x00, 0x00, 0xFF).to_bytes(), [0x00, 0x00, 0xFF]);
+    }
+
+    #[test]
+    fn bpp24_bgr() {
+        assert_eq!(Bgr888::new(0xFF, 0x00, 0x00).to_bytes(), [0x00, 0x00, 0xFF]);
+        assert_eq!(Bgr888::new(0x00, 0xFF, 0x00).to_bytes(), [0x00, 0xFF, 0x00]);
+        assert_eq!(Bgr888::new(0x00, 0x00, 0xFF).to_bytes(), [0xFF, 0x00, 0x00]);
+    }
+
+    #[test]
+    fn bpp32() {
+        // This test uses `RawU32` instead of a color, because no color included
+        // in this crate uses 32 bpp.
+        assert_eq!(RawU32::new(0x11223344).to_bytes(), [0x11, 0x22, 0x33, 0x44]);
+    }
+}

--- a/embedded-graphics/src/prelude.rs
+++ b/embedded-graphics/src/prelude.rs
@@ -7,7 +7,10 @@ pub use crate::{
     geometry::{Angle, AngleUnit, Dimensions, OriginDimensions, Point, Size},
     image::{ImageDrawable, ImageDrawableExt},
     iterator::{ContiguousIteratorExt, IntoPixels, PixelIteratorExt},
-    pixelcolor::{raw::RawData, GrayColor, IntoStorage, PixelColor, RgbColor},
+    pixelcolor::{
+        raw::{RawData, ToBytes as _},
+        GrayColor, IntoStorage, PixelColor, RgbColor,
+    },
     primitives::{ContainsPoint, Primitive},
     style::StyledPrimitiveAreas,
     transform::Transform,

--- a/simulator/src/framebuffer.rs
+++ b/simulator/src/framebuffer.rs
@@ -96,7 +96,7 @@ impl DrawTarget for Framebuffer {
     {
         for Pixel(point, color) in pixels.into_iter() {
             if let Some(pixel) = self.get_pixel_mut(point) {
-                pixel.copy_from_slice(&color.to_bytes())
+                pixel.copy_from_slice(&color.to_be_bytes())
             }
         }
 

--- a/simulator/src/framebuffer.rs
+++ b/simulator/src/framebuffer.rs
@@ -96,9 +96,7 @@ impl DrawTarget for Framebuffer {
     {
         for Pixel(point, color) in pixels.into_iter() {
             if let Some(pixel) = self.get_pixel_mut(point) {
-                let color = &[color.r(), color.g(), color.b()];
-
-                pixel.copy_from_slice(color)
+                pixel.copy_from_slice(&color.to_bytes())
             }
         }
 


### PR DESCRIPTION
Hi! Thank you for helping out with Embedded Graphics development! Please:

- [ ] Check that you've added passing tests and documentation
- [ ] Add a simulator example(s) where applicable
- [ ] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) and appropriate crate (`embedded-graphics`, `simulator`, `tinytga`, `tinybmp`) if your changes affect the **public API**
- [ ] Run `rustfmt` on the project
- [ ] Run `just build` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

This PR adds an easier method to convert colors to byte arrays that was suggested in #423.