### PR TITLE
Add IntellijJ IDEA folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ target/
 **/*.rs.bk
 Cargo.lock
 .DS_Store
+.idea/


### PR DESCRIPTION
I recently found the rust plugin that works with the community edition. To keep my sanity, let's exclude the IDE config from git.