### PR TITLE
Line joiners: scanline and lookback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ target/
 **/*.rs.bk
 Cargo.lock
 .DS_Store
+.idea/

--- a/embedded-graphics/src/mock_display.rs
+++ b/embedded-graphics/src/mock_display.rs
@@ -186,8 +186,7 @@ use core::{
     iter,
 };
 
-// TODO FIXME restore this to 64
-const SIZE: usize = 128;
+const SIZE: usize = 64;
 const DISPLAY_AREA: Rectangle = Rectangle::new(Point::zero(), Size::new_equal(SIZE as u32));
 
 /// Mock display struct

--- a/embedded-graphics/src/mock_display.rs
+++ b/embedded-graphics/src/mock_display.rs
@@ -186,7 +186,8 @@ use core::{
     iter,
 };
 
-const SIZE: usize = 64;
+// TODO FIXME restore this to 64
+const SIZE: usize = 128;
 const DISPLAY_AREA: Rectangle = Rectangle::new(Point::zero(), Size::new_equal(SIZE as u32));
 
 /// Mock display struct

--- a/embedded-graphics/src/primitives/line/mod.rs
+++ b/embedded-graphics/src/primitives/line/mod.rs
@@ -344,8 +344,8 @@ impl Line {
     pub fn length_squared(&self) -> u32 {
         let delta = self.end - self.start;
 
-        // Note: squaring result is always positive. `as u32` casts should be safe here.
-        delta.x.pow(2) as u32 + delta.y.pow(2) as u32
+        // Note: squaring result is always positive. `as u32` cast should be safe here.
+        delta.length_squared() as u32
     }
 }
 

--- a/embedded-graphics/src/primitives/line/mod.rs
+++ b/embedded-graphics/src/primitives/line/mod.rs
@@ -8,13 +8,7 @@ mod thick_points;
 pub use crate::primitives::line::thick_points::Side;
 use crate::{
     geometry::{Dimensions, Point},
-    primitives::{
-        line::{
-            bresenham::{Bresenham, BresenhamParameters, BresenhamPoint},
-            thick_points::ParallelsIterator,
-        },
-        Primitive, Rectangle, Triangle,
-    },
+    primitives::{line::thick_points::ParallelsIterator, Primitive, Rectangle, Triangle},
     style::StrokeAlignment,
     transform::Transform,
 };

--- a/embedded-graphics/src/primitives/line/points.rs
+++ b/embedded-graphics/src/primitives/line/points.rs
@@ -41,6 +41,11 @@ impl Points {
 
         self_
     }
+
+    /// Returns true if the iterator contains no points.
+    pub(in crate::primitives) fn is_empty(&self) -> bool {
+        self.points_remaining == 0
+    }
 }
 
 impl Iterator for Points {

--- a/embedded-graphics/src/primitives/line/thick_points.rs
+++ b/embedded-graphics/src/primitives/line/thick_points.rs
@@ -101,8 +101,7 @@ impl ParallelsIterator {
         // Thickness threshold, taking into account that fewer pixels are required to draw a
         // diagonal line of the same perceived width.
         // TODO: Dedupe here and line/mod.rs into a method on Line
-        let delta = (line.end - line.start).abs();
-        let thickness_threshold = 4 * thickness.pow(2) * delta.length_squared();
+        let thickness_threshold = (thickness * 2).pow(2) * line.length_squared() as i32;
         let thickness_accumulator =
             (parallel_parameters.error_step.minor + parallel_parameters.error_step.major) / 2;
 

--- a/embedded-graphics/src/primitives/line_joint.rs
+++ b/embedded-graphics/src/primitives/line_joint.rs
@@ -312,7 +312,7 @@ impl LineJoint {
         }
     }
 
-    /// Returns whether the joint is the end.
+    /// Returns whether the joint is the last one.
     pub fn is_end_joint(&self) -> bool {
         match self.kind {
             JointKind::End => true,

--- a/embedded-graphics/src/primitives/line_joint.rs
+++ b/embedded-graphics/src/primitives/line_joint.rs
@@ -311,4 +311,12 @@ impl LineJoint {
             _ => None,
         }
     }
+
+    /// Returns whether the joint is the end.
+    pub fn is_end_joint(&self) -> bool {
+        match self.kind {
+            JointKind::End => true,
+            _ => false,
+        }
+    }
 }

--- a/embedded-graphics/src/primitives/line_joint.rs
+++ b/embedded-graphics/src/primitives/line_joint.rs
@@ -173,12 +173,12 @@ impl LineJoint {
                 .segment_intersection(&second_edge_right)
                 || second_segment_end_edge.segment_intersection(&first_edge_right);
 
-            // Distance from midpoint to miter end point. This arbitrarily picks the left-side
-            // intersection, but the left/right intersections are symmetrical around `mid` anyway.
-            let miter_length_squared = Line::new(mid, l_intersection).length_squared();
-
             // Normal line: non-overlapping line end caps
             if !self_intersection_r && !self_intersection_l {
+                // Distance from midpoint to miter end point. This arbitrarily picks the left-side
+                // intersection, but the left/right intersections are symmetrical around `mid` anyway.
+                let miter_length_squared = Line::new(mid, l_intersection).length_squared();
+
                 // Intersection is within limit at which it will be chopped off into a bevel, so return
                 // a miter.
                 if miter_length_squared <= miter_limit {

--- a/embedded-graphics/src/primitives/polyline/thick_points.rs
+++ b/embedded-graphics/src/primitives/polyline/thick_points.rs
@@ -2,7 +2,7 @@ use crate::{
     prelude::Point,
     primitives::{
         polyline::triangle_iterator::TriangleIterator,
-        triangle::{self, FillScanlineIterator, Points, Triangle},
+        triangle::{Points, Triangle},
         ContainsPoint, Primitive,
     },
     style::StrokeAlignment,

--- a/embedded-graphics/src/primitives/polyline/thick_points.rs
+++ b/embedded-graphics/src/primitives/polyline/thick_points.rs
@@ -13,6 +13,8 @@ use crate::{
 pub(in crate::primitives) struct ThickPoints<'a> {
     triangle_iter: TriangleIterator<'a>,
     prev_triangle: Option<Triangle>,
+    prev_triangle2: Option<Triangle>,
+    prev_triangle3: Option<Triangle>,
     triangle: Triangle,
     points_iter: Points,
 }
@@ -29,6 +31,8 @@ impl<'a> ThickPoints<'a> {
 
             Self {
                 prev_triangle: None,
+                prev_triangle2: None,
+                prev_triangle3: None,
                 triangle,
                 triangle_iter,
                 points_iter,
@@ -39,6 +43,8 @@ impl<'a> ThickPoints<'a> {
     pub fn empty() -> Self {
         Self {
             prev_triangle: None,
+            prev_triangle2: None,
+            prev_triangle3: None,
             triangle: Triangle::empty(),
             triangle_iter: TriangleIterator::empty(),
             points_iter: Triangle::empty().points(),
@@ -52,10 +58,15 @@ impl<'a> Iterator for ThickPoints<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         loop {
             if let Some(point) = self.points_iter.next() {
-                if !ContainsPoint::contains(&self.prev_triangle, point) {
+                if !ContainsPoint::contains(&self.prev_triangle, point)
+                    && !ContainsPoint::contains(&self.prev_triangle2, point)
+                    && !ContainsPoint::contains(&self.prev_triangle3, point)
+                {
                     return Some(point);
                 }
             } else {
+                self.prev_triangle3 = self.prev_triangle2;
+                self.prev_triangle2 = self.prev_triangle;
                 self.prev_triangle = Some(self.triangle);
                 self.triangle = self.triangle_iter.next()?;
                 self.points_iter = self.triangle.points();

--- a/embedded-graphics/src/primitives/polyline/thick_points.rs
+++ b/embedded-graphics/src/primitives/polyline/thick_points.rs
@@ -1,8 +1,9 @@
 use crate::{
     prelude::Point,
     primitives::{
+        Primitive,
         polyline::triangle_iterator::TriangleIterator,
-        triangle::{MathematicalPoints, Triangle},
+        triangle::{self, FillScanlineIterator, Triangle, Points},
         ContainsPoint,
     },
     style::StrokeAlignment,
@@ -14,7 +15,7 @@ pub(in crate::primitives) struct ThickPoints<'a> {
     triangle_iter: TriangleIterator<'a>,
     prev_triangle: Option<Triangle>,
     triangle: Triangle,
-    points_iter: MathematicalPoints,
+    points_iter: Points,
 }
 
 impl<'a> ThickPoints<'a> {
@@ -25,7 +26,7 @@ impl<'a> ThickPoints<'a> {
             let mut triangle_iter = TriangleIterator::new(points, width, alignment);
 
             let triangle = triangle_iter.next().unwrap_or_else(Triangle::empty);
-            let points_iter = triangle.mathematical_points();
+            let points_iter = triangle.points();
 
             Self {
                 prev_triangle: None,
@@ -41,7 +42,7 @@ impl<'a> ThickPoints<'a> {
             prev_triangle: None,
             triangle: Triangle::empty(),
             triangle_iter: TriangleIterator::empty(),
-            points_iter: MathematicalPoints::empty(),
+            points_iter: Triangle::empty().points(),
         }
     }
 }
@@ -58,7 +59,7 @@ impl<'a> Iterator for ThickPoints<'a> {
             } else {
                 self.prev_triangle = Some(self.triangle);
                 self.triangle = self.triangle_iter.next()?;
-                self.points_iter = self.triangle.mathematical_points();
+                self.points_iter = self.triangle.points();
             }
         }
     }

--- a/embedded-graphics/src/primitives/polyline/thick_points.rs
+++ b/embedded-graphics/src/primitives/polyline/thick_points.rs
@@ -54,16 +54,11 @@ impl<'a> Iterator for ThickPoints<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         loop {
             if let Some(point) = self.points_iter.next() {
-                if !ContainsPoint::contains(&self.prev_triangle, point) {
-                    if self.triangle_iter.is_current_beveled() {
-                        if !ContainsPoint::contains(&self.prev_triangle2, point)
-                            && !ContainsPoint::contains(&self.prev_triangle3, point)
-                        {
-                            return Some(point);
-                        }
-                    } else {
-                        return Some(point);
-                    }
+                if !ContainsPoint::contains(&self.prev_triangle, point)
+                    && !ContainsPoint::contains(&self.prev_triangle2, point)
+                    && !ContainsPoint::contains(&self.prev_triangle3, point)
+                {
+                    return Some(point);
                 }
             } else {
                 self.prev_triangle3 = self.prev_triangle2;

--- a/embedded-graphics/src/primitives/polyline/thick_points.rs
+++ b/embedded-graphics/src/primitives/polyline/thick_points.rs
@@ -12,9 +12,9 @@ use crate::{
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub(in crate::primitives) struct ThickPoints<'a> {
     triangle_iter: TriangleIterator<'a>,
-    prev_triangle: Option<Triangle>,
-    prev_triangle2: Option<Triangle>,
-    prev_triangle3: Option<Triangle>,
+    prev_triangle: Triangle,
+    prev_triangle2: Triangle,
+    prev_triangle3: Triangle,
     triangle: Triangle,
     points_iter: Points,
 }
@@ -27,9 +27,9 @@ impl<'a> ThickPoints<'a> {
         let points_iter = triangle.points();
 
         Self {
-            prev_triangle: None,
-            prev_triangle2: None,
-            prev_triangle3: None,
+            prev_triangle: Triangle::empty(),
+            prev_triangle2: Triangle::empty(),
+            prev_triangle3: Triangle::empty(),
             triangle,
             triangle_iter,
             points_iter,
@@ -38,9 +38,9 @@ impl<'a> ThickPoints<'a> {
 
     pub fn empty() -> Self {
         Self {
-            prev_triangle: None,
-            prev_triangle2: None,
-            prev_triangle3: None,
+            prev_triangle: Triangle::empty(),
+            prev_triangle2: Triangle::empty(),
+            prev_triangle3: Triangle::empty(),
             triangle: Triangle::empty(),
             triangle_iter: TriangleIterator::empty(),
             points_iter: Triangle::empty().points(),
@@ -63,7 +63,7 @@ impl<'a> Iterator for ThickPoints<'a> {
             } else {
                 self.prev_triangle3 = self.prev_triangle2;
                 self.prev_triangle2 = self.prev_triangle;
-                self.prev_triangle = Some(self.triangle);
+                self.prev_triangle = self.triangle;
                 self.triangle = self.triangle_iter.next()?;
                 self.points_iter = self.triangle.points();
             }

--- a/embedded-graphics/src/primitives/polyline/thick_points.rs
+++ b/embedded-graphics/src/primitives/polyline/thick_points.rs
@@ -54,6 +54,8 @@ impl<'a> Iterator for ThickPoints<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         loop {
             if let Some(point) = self.points_iter.next() {
+                // We need to check previous triangles so we don't overdraw them
+                // TODO: depending on the joint, not all 3 checks are necessary - optimize this
                 if !ContainsPoint::contains(&self.prev_triangle, point)
                     && !ContainsPoint::contains(&self.prev_triangle2, point)
                     && !ContainsPoint::contains(&self.prev_triangle3, point)
@@ -75,14 +77,8 @@ impl<'a> Iterator for ThickPoints<'a> {
 mod test {
     use super::*;
     use crate::{
-        drawable::{Drawable, Pixel},
-        geometry::Dimensions,
-        mock_display::MockDisplay,
-        pixel_iterator::IntoPixels,
-        pixelcolor::BinaryColor,
-        primitives::{ContainsPoint, Polyline},
-        style::PrimitiveStyle,
-        transform::Transform,
+        drawable::Drawable, mock_display::MockDisplay, pixelcolor::BinaryColor,
+        primitives::Polyline, style::PrimitiveStyle,
     };
 
     #[test]

--- a/embedded-graphics/src/primitives/polyline/thick_points.rs
+++ b/embedded-graphics/src/primitives/polyline/thick_points.rs
@@ -21,22 +21,18 @@ pub(in crate::primitives) struct ThickPoints<'a> {
 
 impl<'a> ThickPoints<'a> {
     pub fn new(points: &'a [Point], width: u32, alignment: StrokeAlignment) -> Self {
-        if points.len() < 2 {
-            Self::empty()
-        } else {
-            let mut triangle_iter = TriangleIterator::new(points, width, alignment);
+        let mut triangle_iter = TriangleIterator::new(points, width, alignment);
 
-            let triangle = triangle_iter.next().unwrap_or_else(Triangle::empty);
-            let points_iter = triangle.points();
+        let triangle = triangle_iter.next().unwrap_or_else(Triangle::empty);
+        let points_iter = triangle.points();
 
-            Self {
-                prev_triangle: None,
-                prev_triangle2: None,
-                prev_triangle3: None,
-                triangle,
-                triangle_iter,
-                points_iter,
-            }
+        Self {
+            prev_triangle: None,
+            prev_triangle2: None,
+            prev_triangle3: None,
+            triangle,
+            triangle_iter,
+            points_iter,
         }
     }
 

--- a/embedded-graphics/src/primitives/polyline/thick_points.rs
+++ b/embedded-graphics/src/primitives/polyline/thick_points.rs
@@ -54,11 +54,16 @@ impl<'a> Iterator for ThickPoints<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         loop {
             if let Some(point) = self.points_iter.next() {
-                if !ContainsPoint::contains(&self.prev_triangle, point)
-                    && !ContainsPoint::contains(&self.prev_triangle2, point)
-                    && !ContainsPoint::contains(&self.prev_triangle3, point)
-                {
-                    return Some(point);
+                if !ContainsPoint::contains(&self.prev_triangle, point) {
+                    if self.triangle_iter.is_current_beveled() {
+                        if !ContainsPoint::contains(&self.prev_triangle2, point)
+                            && !ContainsPoint::contains(&self.prev_triangle3, point)
+                        {
+                            return Some(point);
+                        }
+                    } else {
+                        return Some(point);
+                    }
                 }
             } else {
                 self.prev_triangle3 = self.prev_triangle2;

--- a/embedded-graphics/src/primitives/polyline/thick_points.rs
+++ b/embedded-graphics/src/primitives/polyline/thick_points.rs
@@ -59,8 +59,6 @@ impl<'a> Iterator for ThickPoints<'a> {
                 self.prev_triangle = Some(self.triangle);
                 self.triangle = self.triangle_iter.next()?;
                 self.points_iter = self.triangle.mathematical_points();
-
-                return self.next();
             }
         }
     }

--- a/embedded-graphics/src/primitives/polyline/thick_points.rs
+++ b/embedded-graphics/src/primitives/polyline/thick_points.rs
@@ -1,10 +1,9 @@
 use crate::{
     prelude::Point,
     primitives::{
-        Primitive,
         polyline::triangle_iterator::TriangleIterator,
-        triangle::{self, FillScanlineIterator, Triangle, Points},
-        ContainsPoint,
+        triangle::{self, FillScanlineIterator, Points, Triangle},
+        ContainsPoint, Primitive,
     },
     style::StrokeAlignment,
 };

--- a/embedded-graphics/src/primitives/polyline/thick_points.rs
+++ b/embedded-graphics/src/primitives/polyline/thick_points.rs
@@ -75,3 +75,35 @@ impl<'a> Iterator for ThickPoints<'a> {
         }
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::{
+        drawable::{Drawable, Pixel},
+        geometry::Dimensions,
+        mock_display::MockDisplay,
+        pixel_iterator::IntoPixels,
+        pixelcolor::BinaryColor,
+        primitives::{ContainsPoint, Polyline},
+        style::PrimitiveStyle,
+        transform::Transform,
+    };
+
+    #[test]
+    fn test_no_overwrite_on_sharp_corner() {
+        let mut mock_display = MockDisplay::new();
+
+        Polyline::new(&[Point::new(35, 5), Point::new(25, 35), Point::new(15, 5)])
+            .into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 10))
+            .draw(&mut mock_display)
+            .unwrap();
+
+        let mut mock_display = MockDisplay::new();
+
+        Polyline::new(&[Point::new(15, 5), Point::new(25, 35), Point::new(35, 5)])
+            .into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 10))
+            .draw(&mut mock_display)
+            .unwrap();
+    }
+}

--- a/embedded-graphics/src/primitives/polyline/triangle_iterator.rs
+++ b/embedded-graphics/src/primitives/polyline/triangle_iterator.rs
@@ -65,25 +65,16 @@ impl<'a> TriangleIterator<'a> {
         }
     }
 
-    fn edge_triangle1(start_joint: EdgeCorners, end_joint: LineJoint) -> Triangle {
-        let EdgeCorners {
-            left: left_start,
-            right: right_start,
-        } = start_joint;
+    fn edge_triangle1(start_joint_corners: EdgeCorners, end_joint: LineJoint) -> Triangle {
         let LineJoint {
             first_edge_end: EdgeCorners { left: left_end, .. },
             ..
         } = end_joint;
 
-        // NOTE: Winding order is important here to prevent overdraw of the shared edge from
-        // right_start to left_end.
-        Triangle::new(left_start, left_end, right_start) // CW winding order
+        Triangle::new(start_joint_corners.left, left_end, start_joint_corners.right)
     }
 
-    fn edge_triangle2(start_joint: EdgeCorners, end_joint: LineJoint) -> Triangle {
-        let EdgeCorners {
-            right: right_start, ..
-        } = start_joint;
+    fn edge_triangle2(start_joint_corners: EdgeCorners, end_joint: LineJoint) -> Triangle {
         let LineJoint {
             first_edge_end:
                 EdgeCorners {
@@ -93,9 +84,7 @@ impl<'a> TriangleIterator<'a> {
             ..
         } = end_joint;
 
-        // NOTE: Winding order is important here to prevent overdraw of the shared edge from
-        // right_start to left_end.
-        Triangle::new(left_end, right_end, right_start) // CCW winding order
+        Triangle::new(left_end, right_end, start_joint_corners.right)
     }
 }
 

--- a/embedded-graphics/src/primitives/polyline/triangle_iterator.rs
+++ b/embedded-graphics/src/primitives/polyline/triangle_iterator.rs
@@ -7,11 +7,19 @@ use crate::{
     style::StrokeAlignment,
 };
 
+/// The internal state of `TriangleIterator`
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub(in crate::primitives) enum TriangleIteratorState {
+    /// Calculate the next joint
     NextJoint,
+
+    /// Return the first triangle of a joint
     First,
+
+    /// Return the second triangle of a joint
     Second,
+
+    /// Return the filler triangle for bevelled / degenerate joints
     Filler,
 }
 
@@ -71,6 +79,7 @@ impl<'a> TriangleIterator<'a> {
             ..
         } = end_joint;
 
+        // Don't return colinear triangles
         if start_joint_corners != end_joint.first_edge_end {
             Some(Triangle::new(
                 start_joint_corners.left,
@@ -92,6 +101,7 @@ impl<'a> TriangleIterator<'a> {
             ..
         } = end_joint;
 
+        // Don't return colinear triangles
         if start_joint_corners != end_joint.first_edge_end {
             Some(Triangle::new(
                 left_end,

--- a/embedded-graphics/src/primitives/polyline/triangle_iterator.rs
+++ b/embedded-graphics/src/primitives/polyline/triangle_iterator.rs
@@ -93,7 +93,11 @@ impl<'a> TriangleIterator<'a> {
         } = end_joint;
 
         if start_joint_corners != end_joint.first_edge_end {
-            Some(Triangle::new(left_end, right_end, start_joint_corners.right))
+            Some(Triangle::new(
+                left_end,
+                right_end,
+                start_joint_corners.right,
+            ))
         } else {
             None
         }

--- a/embedded-graphics/src/primitives/polyline/triangle_iterator.rs
+++ b/embedded-graphics/src/primitives/polyline/triangle_iterator.rs
@@ -65,20 +65,24 @@ impl<'a> TriangleIterator<'a> {
         }
     }
 
-    fn edge_triangle1(start_joint_corners: EdgeCorners, end_joint: LineJoint) -> Triangle {
+    fn edge_triangle1(start_joint_corners: EdgeCorners, end_joint: LineJoint) -> Option<Triangle> {
         let LineJoint {
             first_edge_end: EdgeCorners { left: left_end, .. },
             ..
         } = end_joint;
 
-        Triangle::new(
-            start_joint_corners.left,
-            left_end,
-            start_joint_corners.right,
-        )
+        if start_joint_corners != end_joint.first_edge_end {
+            Some(Triangle::new(
+                start_joint_corners.left,
+                left_end,
+                start_joint_corners.right,
+            ))
+        } else {
+            None
+        }
     }
 
-    fn edge_triangle2(start_joint_corners: EdgeCorners, end_joint: LineJoint) -> Triangle {
+    fn edge_triangle2(start_joint_corners: EdgeCorners, end_joint: LineJoint) -> Option<Triangle> {
         let LineJoint {
             first_edge_end:
                 EdgeCorners {
@@ -88,7 +92,11 @@ impl<'a> TriangleIterator<'a> {
             ..
         } = end_joint;
 
-        Triangle::new(left_end, right_end, start_joint_corners.right)
+        if start_joint_corners != end_joint.first_edge_end {
+            Some(Triangle::new(left_end, right_end, start_joint_corners.right))
+        } else {
+            None
+        }
     }
 }
 
@@ -131,12 +139,16 @@ impl<'a> Iterator for TriangleIterator<'a> {
 
                 TriangleIteratorState::First => {
                     self.state = TriangleIteratorState::Secound;
-                    return Some(Self::edge_triangle1(self.start_joint, self.end_joint));
+                    if let Some(t) = Self::edge_triangle1(self.start_joint, self.end_joint) {
+                        return Some(t);
+                    }
                 }
 
                 TriangleIteratorState::Secound => {
                     self.state = TriangleIteratorState::Filler;
-                    return Some(Self::edge_triangle2(self.start_joint, self.end_joint));
+                    if let Some(t) = Self::edge_triangle2(self.start_joint, self.end_joint) {
+                        return Some(t);
+                    }
                 }
 
                 TriangleIteratorState::Filler => {

--- a/embedded-graphics/src/primitives/polyline/triangle_iterator.rs
+++ b/embedded-graphics/src/primitives/polyline/triangle_iterator.rs
@@ -120,18 +120,21 @@ impl<'a> Iterator for TriangleIterator<'a> {
 
             // Compute next end joint. The iterator will stop if the `points.get()` calls below
             // return `None`, denoting that we've gone past the end of the points array.
+            let first_point = *self.points.get(self.start_idx)?;
+            let secound_point = *self.points.get(self.start_idx + 1)?;
+
             self.end_joint = if let Some(third_point) = self.points.get(self.start_idx + 2) {
                 LineJoint::from_points(
-                    *self.points.get(self.start_idx)?,
-                    *self.points.get(self.start_idx + 1)?,
+                first_point,
+                    secound_point,
                     *third_point,
                     self.width,
                     self.alignment,
                 )
             } else {
                 LineJoint::end(
-                    *self.points.get(self.start_idx)?,
-                    *self.points.get(self.start_idx + 1)?,
+                    first_point,
+                    secound_point,
                     self.width,
                     self.alignment,
                 )

--- a/embedded-graphics/src/primitives/polyline/triangle_iterator.rs
+++ b/embedded-graphics/src/primitives/polyline/triangle_iterator.rs
@@ -100,11 +100,7 @@ impl<'a> Iterator for TriangleIterator<'a> {
     type Item = Triangle;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if let Some(triangle) = self
-            .t1
-            .take()
-            .or_else(|| self.t2.take())
-        {
+        if let Some(triangle) = self.t1.take().or_else(|| self.t2.take()) {
             Some(triangle)
         }
         // We've gone through the list of triangles in this edge/joint. Reset state for next edge

--- a/embedded-graphics/src/primitives/polyline/triangle_iterator.rs
+++ b/embedded-graphics/src/primitives/polyline/triangle_iterator.rs
@@ -132,12 +132,7 @@ impl<'a> Iterator for TriangleIterator<'a> {
                     self.alignment,
                 )
             } else {
-                LineJoint::end(
-                    first_point,
-                    secound_point,
-                    self.width,
-                    self.alignment,
-                )
+                LineJoint::end(first_point, secound_point, self.width, self.alignment)
             };
 
             let (t1, t2) = Self::edge_triangles(start_joint, self.end_joint);

--- a/embedded-graphics/src/primitives/polyline/triangle_iterator.rs
+++ b/embedded-graphics/src/primitives/polyline/triangle_iterator.rs
@@ -11,7 +11,7 @@ use crate::{
 pub(in crate::primitives) enum TriangleIteratorState {
     NextJoint,
     First,
-    Secound,
+    Second,
     Filler,
 }
 
@@ -142,13 +142,13 @@ impl<'a> Iterator for TriangleIterator<'a> {
                 }
 
                 TriangleIteratorState::First => {
-                    self.state = TriangleIteratorState::Secound;
+                    self.state = TriangleIteratorState::Second;
                     if let Some(t) = Self::edge_triangle1(self.start_joint, self.end_joint) {
                         return Some(t);
                     }
                 }
 
-                TriangleIteratorState::Secound => {
+                TriangleIteratorState::Second => {
                     self.state = TriangleIteratorState::Filler;
                     if let Some(t) = Self::edge_triangle2(self.start_joint, self.end_joint) {
                         return Some(t);

--- a/embedded-graphics/src/primitives/polyline/triangle_iterator.rs
+++ b/embedded-graphics/src/primitives/polyline/triangle_iterator.rs
@@ -13,7 +13,6 @@ pub(in crate::primitives) struct TriangleIterator<'a> {
     start_idx: usize,
     t1: Option<Triangle>,
     t2: Option<Triangle>,
-    filler: Option<Triangle>,
     width: u32,
     alignment: StrokeAlignment,
     end_joint: LineJoint,
@@ -51,7 +50,6 @@ impl<'a> TriangleIterator<'a> {
                 t1: Some(t1),
                 t2: Some(t2),
                 start_idx,
-                filler: end_joint.filler(),
                 width,
                 alignment,
                 end_joint,
@@ -64,7 +62,6 @@ impl<'a> TriangleIterator<'a> {
             points: &[],
             t1: None,
             t2: None,
-            filler: None,
             start_idx: 0,
             width: 0,
             alignment: StrokeAlignment::Center,
@@ -107,13 +104,14 @@ impl<'a> Iterator for TriangleIterator<'a> {
             .t1
             .take()
             .or_else(|| self.t2.take())
-            .or_else(|| self.filler.take())
         {
             Some(triangle)
         }
         // We've gone through the list of triangles in this edge/joint. Reset state for next edge
         // and joint.
         else {
+            let t = self.end_joint.filler();
+
             self.start_idx += 1;
 
             let start_joint = self.end_joint;
@@ -139,9 +137,8 @@ impl<'a> Iterator for TriangleIterator<'a> {
 
             self.t1 = Some(t1);
             self.t2 = Some(t2);
-            self.filler = self.end_joint.filler();
 
-            self.next()
+            t.or_else(|| self.next())
         }
     }
 }

--- a/embedded-graphics/src/primitives/polyline/triangle_iterator.rs
+++ b/embedded-graphics/src/primitives/polyline/triangle_iterator.rs
@@ -71,7 +71,11 @@ impl<'a> TriangleIterator<'a> {
             ..
         } = end_joint;
 
-        Triangle::new(start_joint_corners.left, left_end, start_joint_corners.right)
+        Triangle::new(
+            start_joint_corners.left,
+            left_end,
+            start_joint_corners.right,
+        )
     }
 
     fn edge_triangle2(start_joint_corners: EdgeCorners, end_joint: LineJoint) -> Triangle {

--- a/embedded-graphics/src/primitives/polyline/triangle_iterator.rs
+++ b/embedded-graphics/src/primitives/polyline/triangle_iterator.rs
@@ -22,6 +22,7 @@ pub(in crate::primitives) struct TriangleIterator<'a> {
     width: u32,
     alignment: StrokeAlignment,
     start_joint: EdgeCorners, // it's not necessary to store the whole joint so save some memory
+    start_beveled: bool,
     end_joint: LineJoint,
 }
 
@@ -46,6 +47,7 @@ impl<'a> TriangleIterator<'a> {
                 width,
                 alignment,
                 start_joint: start_joint.second_edge_start,
+                start_beveled: false,
                 end_joint,
             }
         }
@@ -61,6 +63,7 @@ impl<'a> TriangleIterator<'a> {
                 left: Point::zero(),
                 right: Point::zero(),
             },
+            start_beveled: false,
             end_joint: LineJoint::empty(),
         }
     }
@@ -90,6 +93,11 @@ impl<'a> TriangleIterator<'a> {
 
         Triangle::new(left_end, right_end, start_joint_corners.right)
     }
+
+    /// Returns true if current joint is beveled
+    pub fn is_current_beveled(&self) -> bool {
+        self.start_beveled
+    }
 }
 
 impl<'a> Iterator for TriangleIterator<'a> {
@@ -105,6 +113,7 @@ impl<'a> Iterator for TriangleIterator<'a> {
 
                     self.state = TriangleIteratorState::First;
                     self.start_joint = self.end_joint.second_edge_start;
+                    self.start_beveled = self.end_joint.filler().is_some();
 
                     // Compute next end joint. The iterator will stop if the `points.get()` calls below
                     // return `None`, denoting that we've gone past the end of the points array.

--- a/embedded-graphics/src/primitives/polyline/triangle_iterator.rs
+++ b/embedded-graphics/src/primitives/polyline/triangle_iterator.rs
@@ -22,7 +22,6 @@ pub(in crate::primitives) struct TriangleIterator<'a> {
     width: u32,
     alignment: StrokeAlignment,
     start_joint: EdgeCorners, // it's not necessary to store the whole joint so save some memory
-    start_beveled: bool,
     end_joint: LineJoint,
 }
 
@@ -47,7 +46,6 @@ impl<'a> TriangleIterator<'a> {
                 width,
                 alignment,
                 start_joint: start_joint.second_edge_start,
-                start_beveled: false,
                 end_joint,
             }
         }
@@ -63,7 +61,6 @@ impl<'a> TriangleIterator<'a> {
                 left: Point::zero(),
                 right: Point::zero(),
             },
-            start_beveled: false,
             end_joint: LineJoint::empty(),
         }
     }
@@ -93,11 +90,6 @@ impl<'a> TriangleIterator<'a> {
 
         Triangle::new(left_end, right_end, start_joint_corners.right)
     }
-
-    /// Returns true if current joint is beveled
-    pub fn is_current_beveled(&self) -> bool {
-        self.start_beveled
-    }
 }
 
 impl<'a> Iterator for TriangleIterator<'a> {
@@ -113,7 +105,6 @@ impl<'a> Iterator for TriangleIterator<'a> {
 
                     self.state = TriangleIteratorState::First;
                     self.start_joint = self.end_joint.second_edge_start;
-                    self.start_beveled = self.end_joint.filler().is_some();
 
                     // Compute next end joint. The iterator will stop if the `points.get()` calls below
                     // return `None`, denoting that we've gone past the end of the points array.

--- a/embedded-graphics/src/primitives/polyline/triangle_iterator.rs
+++ b/embedded-graphics/src/primitives/polyline/triangle_iterator.rs
@@ -125,7 +125,7 @@ impl<'a> Iterator for TriangleIterator<'a> {
 
             self.end_joint = if let Some(third_point) = self.points.get(self.start_idx + 2) {
                 LineJoint::from_points(
-                first_point,
+                    first_point,
                     secound_point,
                     *third_point,
                     self.width,

--- a/embedded-graphics/src/primitives/triangle/fill_scanline_iterator.rs
+++ b/embedded-graphics/src/primitives/triangle/fill_scanline_iterator.rs
@@ -3,7 +3,7 @@ use crate::{
     geometry::Point,
     primitives::{
         line::{self, Line},
-        triangle::{sort_two_x, sort_yx, Triangle},
+        triangle::{sort_yx, Triangle},
         Primitive,
     },
 };
@@ -154,6 +154,20 @@ mod tests {
 
         check(Triangle::new(Point::new(5, 10), Point::new(10, 15), Point::new(15, 10)));
         check(Triangle::new(Point::new(5, 10), Point::new(15, 10), Point::new(10, 15)));
+
+        check(Triangle::new(Point::new(30, 0), Point::new(40, 10), Point::new(42, 10)));
+
+        /*
+        for x in 10..15 {
+            for y in 10..15 {
+                for z in 10..15 {
+                    for w in 10..15 {
+                        check(Triangle::new(Point::new(30, 30), Point::new(30, 30) + Point::new(x, y), Point::new(30, 30)+ Point::new(z, w)));
+                    }
+                }
+            }
+        }
+        */
     }
 
     #[test]

--- a/embedded-graphics/src/primitives/triangle/fill_scanline_iterator.rs
+++ b/embedded-graphics/src/primitives/triangle/fill_scanline_iterator.rs
@@ -34,28 +34,26 @@ impl FillScanlineIterator {
     pub(in crate::primitives) fn new(triangle: &Triangle) -> Self {
         let (v1, v2, v3) = sort_yx(triangle.p1, triangle.p2, triangle.p3);
 
-        let mut line_a = if v1.y == v2.y {
+        let line_a = if v1.y == v2.y {
             line::Points::empty()
         } else {
             Line::new(v1, v2).points()
         };
-        let mut line_b = if v2.y == v3.y {
+        let line_b = if v2.y == v3.y {
             line::Points::empty()
         } else {
             Line::new(v2, v3).points()
         };
-        let mut line_c = Line::new(v1, v3).points();
+        let line_c = Line::new(v1, v3).points();
 
-        let self_ = Self {
+        Self {
             line_a,
             line_b,
             line_c,
             next_a: None,
             next_c: None,
             scan_points: line::Points::empty(),
-        };
-
-        self_
+        }
     }
 
     fn update_ab(&mut self) -> Option<(Point, Point)> {

--- a/embedded-graphics/src/primitives/triangle/fill_scanline_iterator.rs
+++ b/embedded-graphics/src/primitives/triangle/fill_scanline_iterator.rs
@@ -1,0 +1,121 @@
+//!
+use crate::{
+    geometry::Point,
+    primitives::{
+        line::{self, Line},
+        triangle::{sort_yx, sort_two_x, Triangle},
+        Primitive,
+    },
+};
+
+/// Iterator over all points inside the triangle.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+pub struct FillScanlineIterator {
+    /// Left-most edge of the triangle
+    line_a: line::Points,
+
+    /// Right-most edge of the triangle
+    line_b: line::Points,
+
+    /// Bottom edge of the triangle
+    line_c: line::Points,
+
+    /// Horizontal line
+    scan_points: line::Points,
+
+    /// y
+    current_y: i32,
+}
+
+impl FillScanlineIterator {
+    pub(in crate::primitives) fn new(triangle: &Triangle) -> Self {
+        fn standing_triangle(v1: Point, v2: Point, v3: Point) -> (line::Points, line::Points, line::Points) {
+            (
+                line::Points::empty(),
+                Line::new(v1, v3).points(),
+                Line::new(v2, v3).points()
+            )
+        }
+
+        let (v1, v2, v3) = sort_yx(triangle.p1, triangle.p2, triangle.p3);
+
+        let (mut line_a, mut line_b, mut line_c) = if v1.y == v2.y {
+            standing_triangle(v1, v2, v3)
+        } else if v2.y == v3.y {
+            standing_triangle(v2, v3, v1)
+        } else if v1.y == v3.y {
+            standing_triangle(v1, v3, v2)
+        } else {
+            let line_a = Line::new(v1, v2).points();
+            let line_b = Line::new(v2, v3).points();
+            let line_c = Line::new(v1, v3).points();
+
+            (line_a, line_b, line_c)
+        };
+
+        let scan_points = if let (Some(a), Some(b)) = (
+            line_a.next().or_else(|| line_b.next()),
+            line_c.next()
+        ) {
+            Line::new(a, b).points()
+        } else {
+            line::Points::empty()
+        };
+
+        Self {
+            line_a,
+            line_b,
+            line_c,
+            scan_points,
+            current_y: v1.y,
+        }
+    }
+
+    fn update_ab(&mut self) -> Option<Point> {
+        while let Some(point) = self.line_a.next().or_else(|| self.line_b.next()) {
+            if point.y != self.current_y {
+                self.current_y = point.y;
+                return Some(point);
+            }
+        }
+        None
+    }
+
+    fn update_c(&mut self) -> Option<Point> {
+        while let Some(point) = self.line_c.next() {
+            if point.y == self.current_y {
+                return Some(point);
+            }
+        }
+        None
+    }
+
+    fn next_scanline(&mut self) -> bool {
+        let a = self.update_ab();
+        let b = self.update_c();
+
+        if let (Some(a), Some(b)) = (a, b) {
+            let (a, b) = sort_two_x(a, b);
+            self.scan_points = Line::new(a, b).points();
+            true
+        } else {
+            false
+        }
+    }
+}
+
+impl Iterator for FillScanlineIterator {
+    type Item = Point;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            if let Some(point) = self.scan_points.next() {
+                return Some(point);
+            } else {
+                if !self.next_scanline() {
+                    return None;
+                }
+            }
+        }
+    }
+}

--- a/embedded-graphics/src/primitives/triangle/fill_scanline_iterator.rs
+++ b/embedded-graphics/src/primitives/triangle/fill_scanline_iterator.rs
@@ -125,39 +125,35 @@ impl Iterator for FillScanlineIterator {
 mod tests {
     use super::*;
     use crate::{
-        drawable::Pixel, geometry::Dimensions, pixel_iterator::IntoPixels, pixelcolor::BinaryColor,
+        drawable::{Drawable, Pixel}, geometry::Dimensions, pixel_iterator::IntoPixels, pixelcolor::BinaryColor,
         primitives::ContainsPoint, style::PrimitiveStyle, transform::Transform,
+        mock_display::MockDisplay
     };
 
     #[test]
     fn points_are_part_of_triangle() {
         fn check(triangle: Triangle) {
-            assert!(triangle.all_points().all(|p| triangle.contains(p)));
-        }
+            let mut mock_display1 = MockDisplay::new();
+            let mut mock_display2 = MockDisplay::new();
 
-        check(Triangle::new(Point::new(5, 10), Point::new(15, 10), Point::new(10, 15)));
-        check(Triangle::new(Point::new(5, 10), Point::new(10, 15), Point::new(15, 10)));
+            mock_display1.set_allow_overdraw(true);
+            mock_display2.set_allow_overdraw(true);
 
-        check(Triangle::new(Point::new(5, 10), Point::new(14, 10), Point::new(8, 15)));
-        check(Triangle::new(Point::new(5, 10), Point::new(8, 15), Point::new(14, 10)));
-    }
-
-    #[test]
-    fn all_points_are_generated() {
-        fn check(triangle: Triangle) {
-            let iter_points = triangle.all_points().collect::<Vec<Point>>();
-            assert!(triangle
+            triangle
                 .bounding_box()
                 .points()
                 .filter(|&p| triangle.contains(p))
-                .all(|p| iter_points.contains(&p)));
+                .for_each(|p| Pixel(p, BinaryColor::On).draw(&mut mock_display1).unwrap());
+
+            triangle
+                .all_points()
+                .for_each(|p| Pixel(p, BinaryColor::On).draw(&mut mock_display2).unwrap());
+
+            assert_eq!(mock_display1, mock_display2, "{:?}", triangle);
         }
 
-        check(Triangle::new(Point::new(5, 10), Point::new(15, 10), Point::new(10, 15)));
         check(Triangle::new(Point::new(5, 10), Point::new(10, 15), Point::new(15, 10)));
-
-        check(Triangle::new(Point::new(5, 10), Point::new(14, 10), Point::new(8, 15)));
-        check(Triangle::new(Point::new(5, 10), Point::new(8, 15), Point::new(14, 10)));
+        check(Triangle::new(Point::new(5, 10), Point::new(15, 10), Point::new(10, 15)));
     }
 
     #[test]

--- a/embedded-graphics/src/primitives/triangle/fill_scanline_iterator.rs
+++ b/embedded-graphics/src/primitives/triangle/fill_scanline_iterator.rs
@@ -268,27 +268,18 @@ mod tests {
             Point::new(60, 15),
         ));
 
-        // this triangle was found manually, it's a case where Triangle::contains() did not
-        // match the scanline iterator.
         // this triangle fails even with the original contains() implementation
         check_iterator_and_contains(Triangle::new(
             Point::new(19, 0),
             Point::new(29, 22),
             Point::new(0, 8),
         ));
-    }
-
-    #[test]
-    #[ignore = "right now this requires a modified mock display with bigger display area"]
-    fn points_by_scanline_match_triangle_contains_regression() {
-        // this triangle was found manually, it's a case where Triangle::contains() did not
-        // match the scanline iterator.
 
         // this triangle passes with the original contains() implementation
         check_iterator_and_contains(Triangle::new(
             Point::new(37, 0),
-            Point::new(36, 68),
-            Point::new(29, 97),
+            Point::new(36, 38),
+            Point::new(29, 52),
         ));
     }
 

--- a/embedded-graphics/src/primitives/triangle/fill_scanline_iterator.rs
+++ b/embedded-graphics/src/primitives/triangle/fill_scanline_iterator.rs
@@ -3,11 +3,10 @@ use crate::{
     geometry::Point,
     primitives::{
         line::{self, Line},
-        triangle::{sort_yx, Triangle},
+        triangle::{sort_two_x, sort_yx, Triangle},
         Primitive,
     },
 };
-use crate::primitives::triangle::sort_two_x;
 
 /// Iterator over all points inside the triangle.
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]

--- a/embedded-graphics/src/primitives/triangle/fill_scanline_iterator.rs
+++ b/embedded-graphics/src/primitives/triangle/fill_scanline_iterator.rs
@@ -218,68 +218,78 @@ mod tests {
         transform::Transform,
     };
 
+    fn check_iterator_and_contains(triangle: Triangle) {
+        let mut mock_display1 = MockDisplay::new();
+        let mut mock_display2 = MockDisplay::new();
+
+        triangle
+            .bounding_box()
+            .points()
+            .filter(|&p| triangle.contains(p))
+            .for_each(|p| Pixel(p, BinaryColor::On).draw(&mut mock_display1).unwrap());
+
+        triangle
+            .points()
+            .for_each(|p| Pixel(p, BinaryColor::On).draw(&mut mock_display2).unwrap());
+
+        assert_eq!(mock_display1, mock_display2, "{:?}", triangle);
+    }
+
     #[test]
     fn points_by_scanline_match_triangle_contains() {
-        fn check(triangle: Triangle) {
-            let mut mock_display1 = MockDisplay::new();
-            let mut mock_display2 = MockDisplay::new();
-
-            triangle
-                .bounding_box()
-                .points()
-                .filter(|&p| triangle.contains(p))
-                .for_each(|p| Pixel(p, BinaryColor::On).draw(&mut mock_display1).unwrap());
-
-            triangle
-                .points()
-                .for_each(|p| Pixel(p, BinaryColor::On).draw(&mut mock_display2).unwrap());
-
-            assert_eq!(mock_display1, mock_display2, "{:?}", triangle);
-        }
-
-        check(Triangle::new(
+        check_iterator_and_contains(Triangle::new(
             Point::new(30, 0),
             Point::new(40, 10),
             Point::new(42, 10),
         ));
-        check(Triangle::new(
+        check_iterator_and_contains(Triangle::new(
             Point::new(5, 5),
             Point::new(15, 0),
             Point::new(10, 10),
         ));
-        check(Triangle::new(
+        check_iterator_and_contains(Triangle::new(
             Point::new(0, 0),
             Point::new(0, 10),
             Point::new(40, 10),
         ));
-        check(Triangle::new(
+        check_iterator_and_contains(Triangle::new(
             Point::new(0, 0),
             Point::new(0, 10),
             Point::new(40, 0),
         ));
-        check(Triangle::new(
+        check_iterator_and_contains(Triangle::new(
             Point::new(0, 0),
             Point::new(40, 10),
             Point::new(40, 0),
         ));
-        check(Triangle::new(
+        check_iterator_and_contains(Triangle::new(
             Point::new(0, 0),
             Point::new(60, 10),
             Point::new(60, 15),
         ));
 
-        // these triangles were found manually, they are cases where Triangle::contains() did not
+        // this triangle was found manually, it's a case where Triangle::contains() did not
         // match the scanline iterator.
-        let triangles = [
-            // this triangle passes with the original contains(), but not with the optimized one
-            Triangle::new(Point::new(37, 0), Point::new(36, 68), Point::new(29, 97)),
-            // this triangle fails even with the original contains()
-            Triangle::new(Point::new(19, 0), Point::new(29, 22), Point::new(0, 8)),
-        ];
+        // this triangle fails even with the original contains() implementation
+        check_iterator_and_contains(Triangle::new(
+            Point::new(19, 0),
+            Point::new(29, 22),
+            Point::new(0, 8),
+        ));
+    }
 
-        for triangle in triangles.iter() {
-            check(*triangle);
-        }
+    #[test]
+    #[ignore = "right now this requires a modified mock display with bigger display area"]
+    fn points_by_scanline_match_triangle_contains_regression() {
+        // this triangle was found manually, it's a case where Triangle::contains() did not
+        // match the scanline iterator.
+
+        // this triangle passes with the original contains() implementation
+        check_iterator_and_contains(Triangle::new(
+            Point::new(37, 0),
+            Point::new(36, 68),
+            Point::new(29, 97),
+        ));
     }
 
     #[test]

--- a/embedded-graphics/src/primitives/triangle/fill_scanline_iterator.rs
+++ b/embedded-graphics/src/primitives/triangle/fill_scanline_iterator.rs
@@ -219,7 +219,7 @@ mod tests {
     };
 
     #[test]
-    fn points_are_part_of_triangle() {
+    fn points_by_scanline_match_triangle_contains() {
         fn check(triangle: Triangle) {
             let mut mock_display1 = MockDisplay::new();
             let mut mock_display2 = MockDisplay::new();
@@ -283,7 +283,7 @@ mod tests {
     }
 
     #[test]
-    fn bug_corner_points_are_generated() {
+    fn bug_corner_points_must_be_generated() {
         assert!(
             Triangle::new(Point::new(19, 0), Point::new(29, 22), Point::new(0, 8))
                 .points()

--- a/embedded-graphics/src/primitives/triangle/fill_scanline_iterator.rs
+++ b/embedded-graphics/src/primitives/triangle/fill_scanline_iterator.rs
@@ -133,16 +133,19 @@ impl FillScanlineIterator {
 
     fn update_ab(&mut self) -> Option<(Point, Point)> {
         let mut next_a = self.next_a.take().or_else(|| self.line_ab.next())?;
-        let first = next_a;
+        // track limits to handle cases when line direction changes
+        let (mut min_x, mut max_x) = (next_a.x, next_a.x);
         while let Some(a) = self.line_ab.next() {
             if a.y == next_a.y {
+                min_x = min_x.min(a.x);
+                max_x = max_x.max(a.x);
                 next_a = a;
             } else {
                 self.next_a = Some(a);
                 break;
             }
         }
-        Some(sort_two_x(first, next_a))
+        Some((Point::new(min_x, next_a.y), Point::new(max_x, next_a.y)))
     }
 
     fn update_c(&mut self) -> Option<(Point, Point)> {

--- a/embedded-graphics/src/primitives/triangle/fill_scanline_iterator.rs
+++ b/embedded-graphics/src/primitives/triangle/fill_scanline_iterator.rs
@@ -102,7 +102,7 @@ impl FillScanlineIterator {
                 next_a = a;
             } else {
                 self.next_a = Some(a);
-                return Some((first, next_a));
+                break;
             }
         }
         Some((first, next_a))
@@ -116,7 +116,7 @@ impl FillScanlineIterator {
                 next_c = c;
             } else {
                 self.next_c = Some(c);
-                return Some((first, next_c));
+                break;
             }
         }
         Some((first, next_c))

--- a/embedded-graphics/src/primitives/triangle/fill_scanline_iterator.rs
+++ b/embedded-graphics/src/primitives/triangle/fill_scanline_iterator.rs
@@ -93,16 +93,23 @@ impl FillScanlineIterator {
         let a = self.update_ab();
         let c = self.update_c();
 
-        if let (Some((fa, la)), Some((fc, lc))) = (a, c) {
-            let mut arr = [fa, la, fc, lc];
-            arr.sort_by(|&a, &b| a.x.cmp(&b.x));
-            let [left, _, _, right] = arr;
+        match (a, c) {
+            (Some((fa, la)), Some((fc, lc))) => {
+                let mut arr = [fa, la, fc, lc];
+                arr.sort_by(|&a, &b| a.x.cmp(&b.x));
+                let [left, _, _, right] = arr;
 
-            self.scan_points = Line::new(left, right).points();
+                self.scan_points = Line::new(left, right).points();
 
-            true
-        } else {
-            false
+                true
+            }
+            (Some((l, r)), None) | (None, Some((l, r))) => {
+                let (l, r) = sort_two_x(l, r);
+                self.scan_points = Line::new(l, r).points();
+
+                true
+            }
+            (None, None) => false,
         }
     }
 }

--- a/embedded-graphics/src/primitives/triangle/fill_scanline_iterator.rs
+++ b/embedded-graphics/src/primitives/triangle/fill_scanline_iterator.rs
@@ -129,7 +129,7 @@ mod tests {
                 .for_each(|p| Pixel(p, BinaryColor::On).draw(&mut mock_display1).unwrap());
 
             triangle
-                .all_points()
+                .points()
                 .for_each(|p| Pixel(p, BinaryColor::On).draw(&mut mock_display2).unwrap());
 
             assert_eq!(mock_display1, mock_display2, "{:?}", triangle);
@@ -171,6 +171,6 @@ mod tests {
 
         assert!(off_screen
             .points()
-            .eq(on_screen.all_points().map(|p| p - Point::new(0, 35))));
+            .eq(on_screen.points().map(|p| p - Point::new(0, 35))));
     }
 }

--- a/embedded-graphics/src/primitives/triangle/fill_scanline_iterator.rs
+++ b/embedded-graphics/src/primitives/triangle/fill_scanline_iterator.rs
@@ -264,6 +264,29 @@ mod tests {
             Point::new(60, 10),
             Point::new(60, 15),
         ));
+
+        // these triangles were found manually, they are cases where Triangle::contains() did not
+        // match the scanline iterator.
+        let triangles = [
+
+            // this triangle passes with the original contains(), but not with the optimized one
+            Triangle::new(
+                Point::new(37, 0),
+                Point::new(36, 68),
+                Point::new(29, 97),
+            ),
+
+            // this triangle fails even with the original contains()
+            Triangle::new(
+                Point::new(19, 0),
+                Point::new(29, 22),
+                Point::new(0, 8),
+            ),
+        ];
+
+        for triangle in triangles.iter() {
+            check(*triangle);
+        }
     }
 
     #[test]

--- a/embedded-graphics/src/primitives/triangle/fill_scanline_iterator.rs
+++ b/embedded-graphics/src/primitives/triangle/fill_scanline_iterator.rs
@@ -1,4 +1,4 @@
-//!
+//! A scanline iterator that returns every point in a triangle once.
 use crate::{
     geometry::Point,
     primitives::{
@@ -23,10 +23,10 @@ pub struct FillScanlineIterator {
     /// Horizontal line
     scan_points: line::Points,
 
-    ///
+    /// The first point of the ab edge in the next line
     next_a: Option<Point>,
 
-    ///
+    /// The first point of the c edge in the next line
     next_c: Option<Point>,
 }
 

--- a/embedded-graphics/src/primitives/triangle/fill_scanline_iterator.rs
+++ b/embedded-graphics/src/primitives/triangle/fill_scanline_iterator.rs
@@ -29,11 +29,18 @@ pub struct FillScanlineIterator {
 
 impl FillScanlineIterator {
     pub(in crate::primitives) fn new(triangle: &Triangle) -> Self {
-
         let (v1, v2, v3) = sort_yx(triangle.p1, triangle.p2, triangle.p3);
 
-        let mut line_a = if v1.y == v2.y { line::Points::empty() } else { Line::new(v1, v2).points() };
-        let mut line_b = if v2.y == v3.y { line::Points::empty() } else { Line::new(v2, v3).points() };
+        let mut line_a = if v1.y == v2.y {
+            line::Points::empty()
+        } else {
+            Line::new(v1, v2).points()
+        };
+        let mut line_b = if v2.y == v3.y {
+            line::Points::empty()
+        } else {
+            Line::new(v2, v3).points()
+        };
         let mut line_c = Line::new(v1, v3).points();
 
         let self_ = Self {
@@ -41,7 +48,7 @@ impl FillScanlineIterator {
             line_b,
             line_c,
             scan_points: line::Points::empty(),
-            current_y: v1.y-1,
+            current_y: v1.y - 1,
         };
 
         self_
@@ -99,9 +106,14 @@ impl Iterator for FillScanlineIterator {
 mod tests {
     use super::*;
     use crate::{
-        drawable::{Drawable, Pixel}, geometry::Dimensions, pixel_iterator::IntoPixels, pixelcolor::BinaryColor,
-        primitives::ContainsPoint, style::PrimitiveStyle, transform::Transform,
-        mock_display::MockDisplay
+        drawable::{Drawable, Pixel},
+        geometry::Dimensions,
+        mock_display::MockDisplay,
+        pixel_iterator::IntoPixels,
+        pixelcolor::BinaryColor,
+        primitives::ContainsPoint,
+        style::PrimitiveStyle,
+        transform::Transform,
     };
 
     #[test]
@@ -123,9 +135,21 @@ mod tests {
             assert_eq!(mock_display1, mock_display2, "{:?}", triangle);
         }
 
-        check(Triangle::new(Point::new(5, 10), Point::new(10, 15), Point::new(15, 10)));
-        check(Triangle::new(Point::new(5, 5), Point::new(15, 0), Point::new(10, 10)));
-        check(Triangle::new(Point::new(30, 0), Point::new(40, 10), Point::new(42, 10)));
+        check(Triangle::new(
+            Point::new(5, 10),
+            Point::new(10, 15),
+            Point::new(15, 10),
+        ));
+        check(Triangle::new(
+            Point::new(5, 5),
+            Point::new(15, 0),
+            Point::new(10, 10),
+        ));
+        check(Triangle::new(
+            Point::new(30, 0),
+            Point::new(40, 10),
+            Point::new(42, 10),
+        ));
 
         /*
         for x in 10..15 {

--- a/embedded-graphics/src/primitives/triangle/fill_scanline_iterator.rs
+++ b/embedded-graphics/src/primitives/triangle/fill_scanline_iterator.rs
@@ -268,20 +268,10 @@ mod tests {
         // these triangles were found manually, they are cases where Triangle::contains() did not
         // match the scanline iterator.
         let triangles = [
-
             // this triangle passes with the original contains(), but not with the optimized one
-            Triangle::new(
-                Point::new(37, 0),
-                Point::new(36, 68),
-                Point::new(29, 97),
-            ),
-
+            Triangle::new(Point::new(37, 0), Point::new(36, 68), Point::new(29, 97)),
             // this triangle fails even with the original contains()
-            Triangle::new(
-                Point::new(19, 0),
-                Point::new(29, 22),
-                Point::new(0, 8),
-            ),
+            Triangle::new(Point::new(19, 0), Point::new(29, 22), Point::new(0, 8)),
         ];
 
         for triangle in triangles.iter() {

--- a/embedded-graphics/src/primitives/triangle/fill_scanline_iterator.rs
+++ b/embedded-graphics/src/primitives/triangle/fill_scanline_iterator.rs
@@ -59,6 +59,46 @@ impl Iterator for ChainedLines {
     }
 }
 
+/// Iterator that returns points on a horizontal line.
+///
+/// Bresenham's algo is good, but not this good.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+pub struct HorizontalLine {
+    p: Point,
+    x_max: i32,
+}
+
+impl HorizontalLine {
+    pub fn new(start: Point, end: Point) -> Self {
+        Self {
+            p: start,
+            x_max: end.x,
+        }
+    }
+
+    pub fn empty() -> Self {
+        Self {
+            p: Point::zero(),
+            x_max: -1,
+        }
+    }
+}
+
+impl Iterator for HorizontalLine {
+    type Item = Point;
+
+    #[inline(always)]
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.p.x <= self.x_max {
+            let p = Some(self.p);
+            self.p.x += 1;
+            p
+        } else {
+            None
+        }
+    }
+}
+
 /// Iterator over all points inside the triangle.
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub struct FillScanlineIterator {
@@ -68,8 +108,8 @@ pub struct FillScanlineIterator {
     /// Edges on the other side of the triangle
     line_c: line::Points,
 
-    /// Horizontal line
-    scan_points: line::Points,
+    /// Points in the current horizontal line
+    scan_points: HorizontalLine,
 
     /// The first point of the ab edge in the next line
     next_a: Option<Point>,
@@ -87,7 +127,7 @@ impl FillScanlineIterator {
             line_c: Line::new(v1, v3).points(),
             next_a: None,
             next_c: None,
-            scan_points: line::Points::empty(),
+            scan_points: HorizontalLine::empty(),
         }
     }
 
@@ -142,7 +182,7 @@ impl FillScanlineIterator {
             (None, None) => return false,
         };
 
-        self.scan_points = Line::new(left, right).points();
+        self.scan_points = HorizontalLine::new(left, right);
         true
     }
 }

--- a/embedded-graphics/src/primitives/triangle/fill_scanline_iterator.rs
+++ b/embedded-graphics/src/primitives/triangle/fill_scanline_iterator.rs
@@ -24,18 +24,18 @@ impl ChainedLines {
             // A -> B walk is unnecessary, the horizontal iterator will return those points
             Self {
                 line: Line::new(b, c).points(),
-                next_point: None
+                next_point: None,
             }
         } else if b.y == c.y {
             // B -> C walk is unnecessary, the horizontal iterator will return those points
             Self {
                 line: Line::new(a, b).points(),
-                next_point: None
+                next_point: None,
             }
         } else {
             Self {
                 line: Line::new(a, b).points(),
-                next_point: Some(c)
+                next_point: Some(c),
             }
         }
     }
@@ -92,10 +92,7 @@ impl FillScanlineIterator {
     }
 
     fn update_ab(&mut self) -> Option<(Point, Point)> {
-        let mut next_a = self
-            .next_a
-            .take()
-            .or_else(|| self.line_ab.next())?;
+        let mut next_a = self.next_a.take().or_else(|| self.line_ab.next())?;
         let first = next_a;
         while let Some(a) = self.line_ab.next() {
             if a.y == next_a.y {

--- a/embedded-graphics/src/primitives/triangle/fill_scanline_iterator.rs
+++ b/embedded-graphics/src/primitives/triangle/fill_scanline_iterator.rs
@@ -95,14 +95,11 @@ impl FillScanlineIterator {
         let c = self.update_c();
 
         if let (Some((fa, la)), Some((fc, lc))) = (a, c) {
-            let (left, l2) = sort_two_x(fa, la);
-            let (r2, right) = sort_two_x(fc, lc);
+            let mut arr = [fa, la, fc, lc];
+            arr.sort_by(|&a, &b| a.x.cmp(&b.x));
+            let [left, _, _, right] = arr;
 
-            if left.x < right.x {
-                self.scan_points = Line::new(left, right).points();
-            } else {
-                self.scan_points = Line::new(r2, l2).points();
-            }
+            self.scan_points = Line::new(left, right).points();
 
             true
         } else {
@@ -182,6 +179,11 @@ mod tests {
             Point::new(0, 0),
             Point::new(40, 10),
             Point::new(40, 0),
+        ));
+        check(Triangle::new(
+            Point::new(0, 0),
+            Point::new(60, 10),
+            Point::new(60, 15),
         ));
     }
 

--- a/embedded-graphics/src/primitives/triangle/fill_scanline_iterator.rs
+++ b/embedded-graphics/src/primitives/triangle/fill_scanline_iterator.rs
@@ -280,6 +280,25 @@ mod tests {
     }
 
     #[test]
+    fn bug_corner_points_are_generated() {
+        assert!(
+            Triangle::new(Point::new(19, 0), Point::new(29, 22), Point::new(0, 8))
+                .points()
+                .any(|p| p == Point::new(0, 8))
+        );
+        assert!(
+            Triangle::new(Point::new(19, 0), Point::new(29, 22), Point::new(0, 8))
+                .points()
+                .any(|p| p == Point::new(19, 0))
+        );
+        assert!(
+            Triangle::new(Point::new(19, 0), Point::new(29, 22), Point::new(0, 8))
+                .points()
+                .any(|p| p == Point::new(29, 22))
+        );
+    }
+
+    #[test]
     fn off_screen_still_draws_points() {
         let off_screen = Triangle::new(Point::new(10, 10), Point::new(20, 20), Point::new(30, -30));
         let on_screen = off_screen.translate(Point::new(0, 35));

--- a/embedded-graphics/src/primitives/triangle/mathematical_points.rs
+++ b/embedded-graphics/src/primitives/triangle/mathematical_points.rs
@@ -1,8 +1,7 @@
 use crate::{
     geometry::{Dimensions, Point},
-    primitives::{line, rectangle, triangle::Triangle, Primitive},
+    primitives::{rectangle, triangle::Triangle, Primitive},
 };
-use line::Line;
 
 // // TODO: Pub in crate primitives
 /// Iterator over all points inside the triangle.

--- a/embedded-graphics/src/primitives/triangle/mathematical_points.rs
+++ b/embedded-graphics/src/primitives/triangle/mathematical_points.rs
@@ -36,7 +36,8 @@ impl Iterator for MathematicalPoints {
     fn next(&mut self) -> Option<Self::Item> {
         let Self { triangle, .. } = self;
 
-        self.rect.find(|point| triangle.mathematical_contains(point))
+        self.rect
+            .find(|point| triangle.mathematical_contains(point))
     }
 }
 

--- a/embedded-graphics/src/primitives/triangle/mathematical_points.rs
+++ b/embedded-graphics/src/primitives/triangle/mathematical_points.rs
@@ -1,6 +1,6 @@
 use crate::{
     geometry::{Dimensions, Point},
-    primitives::{line, rectangle, triangle::Triangle, Primitive},
+    primitives::{line, rectangle, triangle::Triangle, ContainsPoint, Primitive},
 };
 use line::Line;
 
@@ -36,8 +36,7 @@ impl Iterator for MathematicalPoints {
     fn next(&mut self) -> Option<Self::Item> {
         let Self { triangle, .. } = self;
 
-        self.rect
-            .find(|point| triangle.mathematical_contains(point))
+        self.rect.find(|&point| triangle.contains(point))
     }
 }
 

--- a/embedded-graphics/src/primitives/triangle/mathematical_points.rs
+++ b/embedded-graphics/src/primitives/triangle/mathematical_points.rs
@@ -1,6 +1,6 @@
 use crate::{
     geometry::{Dimensions, Point},
-    primitives::{line, rectangle, triangle::Triangle, ContainsPoint, Primitive},
+    primitives::{line, rectangle, triangle::Triangle, Primitive},
 };
 use line::Line;
 
@@ -36,7 +36,7 @@ impl Iterator for MathematicalPoints {
     fn next(&mut self) -> Option<Self::Item> {
         let Self { triangle, .. } = self;
 
-        self.rect.find(|&point| triangle.contains(point))
+        self.rect.find(|point| triangle.mathematical_contains(point))
     }
 }
 

--- a/embedded-graphics/src/primitives/triangle/mod.rs
+++ b/embedded-graphics/src/primitives/triangle/mod.rs
@@ -425,16 +425,18 @@ mod tests {
         }
     }
 
+    /* // This test requires a bigger mock display. TODO: figure out what to do
     #[test]
     fn bug_triangle_contains_edge_point() {
         // This test is a regression test case found while optimizing Triangle::contains()
         assert!(Triangle::new(
-            Point::new(193, 14),
-            Point::new(192, 79),
-            Point::new(185, 111)
+            Point::new(8, 0),
+            Point::new(7, 65),
+            Point::new(0, 97)
         )
-        .contains(Point::new(192, 81)));
+        .contains(Point::new(7, 67)));
     }
+    */
 
     // FIXME: Colinear triangles are rendered as a line, so this should also return true. Why not?
     // #[test]

--- a/embedded-graphics/src/primitives/triangle/mod.rs
+++ b/embedded-graphics/src/primitives/triangle/mod.rs
@@ -196,11 +196,7 @@ impl Triangle {
     /// Point inside triangle, ignoring pixels that partially lie outside triangle lines.
     pub(self) fn mathematical_contains(&self, point: &Point) -> bool {
         // Skip expensive calculations below if point is outside the bounding box
-        if self.bounding_box().contains(*point) {
-            self.in_mathematical_triangle(point)
-        } else {
-            false
-        }
+        self.bounding_box().contains(*point) && in_mathematical_triangle(point)
     }
 
     fn in_mathematical_triangle(&self, point: &Point) -> bool {

--- a/embedded-graphics/src/primitives/triangle/mod.rs
+++ b/embedded-graphics/src/primitives/triangle/mod.rs
@@ -1,5 +1,6 @@
 //! The triangle primitive.
 
+mod fill_scanline_iterator;
 mod mathematical_points;
 mod points;
 mod scanline_iterator;
@@ -18,6 +19,7 @@ use core::{
     cmp::{max, min},
 };
 pub use mathematical_points::MathematicalPoints;
+pub use fill_scanline_iterator::FillScanlineIterator;
 pub use points::Points;
 pub use styled::StyledPixels;
 
@@ -249,6 +251,11 @@ impl Triangle {
         MathematicalPoints::new(self)
     }
 
+    /// Iterate ALL the points
+    pub fn all_points(&self) -> FillScanlineIterator {
+        FillScanlineIterator::new(self)
+    }
+
     /// Empty triangle
     pub(in crate::primitives) const fn empty() -> Self {
         Self::new(Point::zero(), Point::zero(), Point::zero())
@@ -331,6 +338,14 @@ impl Transform for Triangle {
         self.p3 += by;
 
         self
+    }
+}
+
+fn sort_two_x(p1: Point, p2: Point) -> (Point, Point) {
+    if p1.x < p2.x {
+        (p1, p2)
+    } else {
+        (p2, p1)
     }
 }
 

--- a/embedded-graphics/src/primitives/triangle/mod.rs
+++ b/embedded-graphics/src/primitives/triangle/mod.rs
@@ -111,12 +111,11 @@ impl ContainsPoint for Triangle {
         // inefficiently checks to see if the point lies on any of the border edges.
         let mut l1 = Line::new(p1, p2).points();
         let mut l2 = Line::new(p2, p3).points();
-        let mut l3 = Line::new(p1, p3).points();
+        let l3 = Line::new(p1, p3).points();
 
         // Skip first points so that they are not checked twice
         l1.next();
         l2.next();
-        l3.next();
 
         l1.chain(l2).chain(l3).any(|line_point| line_point == point)
     }

--- a/embedded-graphics/src/primitives/triangle/mod.rs
+++ b/embedded-graphics/src/primitives/triangle/mod.rs
@@ -88,8 +88,12 @@ impl Primitive for Triangle {
     }
 }
 
-fn same_signs(a: i32, b: i32) -> bool {
+fn is_inside(a: i32, b: i32) -> bool {
     (a > 0) == (b > 0)
+}
+
+fn point_on_line(point: Point, p1: Point, p2: Point) -> i32 {
+    (p2.x - p1.x) * (point.y - p1.y) - (p2.y - p1.y) * (point.x - p1.x)
 }
 
 impl ContainsPoint for Triangle {
@@ -106,23 +110,22 @@ impl ContainsPoint for Triangle {
         let (p1, p2, p3) = sort_yx(p1, p2, p3);
         let cw = Triangle::new(p1, p2, p3).area_doubled();
 
-        let edge1 = (p2.x - p1.x) * (point.y - p1.y) - (p2.y - p1.y) * (point.x - p1.x);
-        if !same_signs(edge1, cw) {
+        let edge1 = point_on_line(point, p1, p2);
+        if !is_inside(edge1, cw) {
             return Line::new(p1, p2)
                 .points()
                 .any(|line_point| line_point == point);
         }
 
-        let edge2 = (p3.x - p2.x) * (point.y - p2.y) - (p3.y - p2.y) * (point.x - p2.x);
-        if !same_signs(edge2, cw) {
+        let edge2 = point_on_line(point, p2, p3);
+        if !is_inside(edge2, cw) {
             return Line::new(p2, p3)
                 .points()
                 .any(|line_point| line_point == point);
         }
 
-        let edge3 = (p3.x - p1.x) * (point.y - p1.y) - (p3.y - p1.y) * (point.x - p1.x);
-        if same_signs(edge3, cw) {
-            // ^ missing negation is not a bug, third edge runs "backwards"
+        let edge3 = point_on_line(point, p3, p1);
+        if !is_inside(edge3, cw) {
             return Line::new(p1, p3)
                 .points()
                 .any(|line_point| line_point == point);

--- a/embedded-graphics/src/primitives/triangle/mod.rs
+++ b/embedded-graphics/src/primitives/triangle/mod.rs
@@ -112,26 +112,35 @@ impl ContainsPoint for Triangle {
 
         let edge1 = point_on_line(point, p1, p2);
         if !is_inside(edge1, cw) {
-            return Line::new(p1, p2)
+            if Line::new(p1, p2)
                 .points()
-                .any(|line_point| line_point == point);
+                .any(|line_point| line_point == point)
+            {
+                return true;
+            }
         }
 
         let edge2 = point_on_line(point, p2, p3);
         if !is_inside(edge2, cw) {
-            return Line::new(p2, p3)
+            if Line::new(p2, p3)
                 .points()
-                .any(|line_point| line_point == point);
+                .any(|line_point| line_point == point)
+            {
+                return true;
+            }
         }
 
         let edge3 = point_on_line(point, p3, p1);
         if !is_inside(edge3, cw) {
-            return Line::new(p1, p3)
+            if Line::new(p1, p3)
                 .points()
-                .any(|line_point| line_point == point);
+                .any(|line_point| line_point == point)
+            {
+                return true;
+            }
         }
 
-        true
+        is_inside(edge1, cw) && is_inside(edge2, cw) && is_inside(edge3, cw)
     }
 }
 
@@ -417,7 +426,8 @@ mod tests {
     }
 
     #[test]
-    fn contains_edge_point() {
+    fn bug_triangle_contains_edge_point() {
+        // This test is a regression test case found while optimizing Triangle::contains()
         assert!(Triangle::new(
             Point::new(193, 14),
             Point::new(192, 79),

--- a/embedded-graphics/src/primitives/triangle/mod.rs
+++ b/embedded-graphics/src/primitives/triangle/mod.rs
@@ -416,6 +416,16 @@ mod tests {
         }
     }
 
+    #[test]
+    fn contains_edge_point() {
+        assert!(Triangle::new(
+            Point::new(193, 14),
+            Point::new(192, 79),
+            Point::new(185, 111)
+        )
+        .contains(Point::new(192, 81)));
+    }
+
     // FIXME: Colinear triangles are rendered as a line, so this should also return true. Why not?
     // #[test]
     // fn colinear_never_contains() {

--- a/embedded-graphics/src/primitives/triangle/mod.rs
+++ b/embedded-graphics/src/primitives/triangle/mod.rs
@@ -195,7 +195,7 @@ impl Triangle {
 
     /// Point inside triangle, ignoring pixels that partially lie outside triangle lines.
     pub(self) fn mathematical_contains(&self, point: &Point) -> bool {
-        // Skip expensive calculations below if point is outside the bounding box
+        // Skip expensive calculations if point is outside the bounding box
         self.bounding_box().contains(*point) && self.in_mathematical_triangle(point)
     }
 

--- a/embedded-graphics/src/primitives/triangle/mod.rs
+++ b/embedded-graphics/src/primitives/triangle/mod.rs
@@ -115,6 +115,15 @@ impl ContainsPoint for Triangle {
     }
 }
 
+impl ContainsPoint for Option<Triangle> {
+    fn contains(&self, point: Point) -> bool {
+        match self {
+            None => false,
+            Some(ref triangle) => triangle.contains(point),
+        }
+    }
+}
+
 impl Dimensions for Triangle {
     fn bounding_box(&self) -> Rectangle {
         let x_min = min(min(self.p1.x, self.p2.x), self.p3.x);

--- a/embedded-graphics/src/primitives/triangle/mod.rs
+++ b/embedded-graphics/src/primitives/triangle/mod.rs
@@ -89,7 +89,7 @@ impl Primitive for Triangle {
 }
 
 fn same_signs(a: i32, b: i32) -> bool {
-    (a >= 0) == (b >= 0)
+    (a > 0) == (b > 0)
 }
 
 impl ContainsPoint for Triangle {

--- a/embedded-graphics/src/primitives/triangle/mod.rs
+++ b/embedded-graphics/src/primitives/triangle/mod.rs
@@ -251,11 +251,6 @@ impl Triangle {
         MathematicalPoints::new(self)
     }
 
-    /// Iterate ALL the points
-    pub fn all_points(&self) -> FillScanlineIterator {
-        FillScanlineIterator::new(self)
-    }
-
     /// Empty triangle
     pub(in crate::primitives) const fn empty() -> Self {
         Self::new(Point::zero(), Point::zero(), Point::zero())

--- a/embedded-graphics/src/primitives/triangle/mod.rs
+++ b/embedded-graphics/src/primitives/triangle/mod.rs
@@ -196,7 +196,7 @@ impl Triangle {
     /// Point inside triangle, ignoring pixels that partially lie outside triangle lines.
     pub(self) fn mathematical_contains(&self, point: &Point) -> bool {
         // Skip expensive calculations below if point is outside the bounding box
-        self.bounding_box().contains(*point) && in_mathematical_triangle(point)
+        self.bounding_box().contains(*point) && self.in_mathematical_triangle(point)
     }
 
     fn in_mathematical_triangle(&self, point: &Point) -> bool {

--- a/embedded-graphics/src/primitives/triangle/mod.rs
+++ b/embedded-graphics/src/primitives/triangle/mod.rs
@@ -88,8 +88,13 @@ impl Primitive for Triangle {
 
 impl ContainsPoint for Triangle {
     fn contains(&self, point: Point) -> bool {
+        // Skip expensive calculations below if point is outside the bounding box
+        if !self.bounding_box().contains(point) {
+            return false;
+        }
+
         // Skip expensive point-on-line check below if point is definitely inside triangle
-        if self.mathematical_contains(&point) {
+        if self.in_mathematical_triangle(&point) {
             return true;
         }
 
@@ -185,10 +190,14 @@ impl Triangle {
     /// Point inside triangle, ignoring pixels that partially lie outside triangle lines.
     pub(self) fn mathematical_contains(&self, point: &Point) -> bool {
         // Skip expensive calculations below if point is outside the bounding box
-        if !self.bounding_box().contains(*point) {
-            return false;
+        if self.bounding_box().contains(*point) {
+            self.in_mathematical_triangle(point)
+        } else {
+            false
         }
+    }
 
+    fn in_mathematical_triangle(&self, point: &Point) -> bool {
         let Self { p1, p2, p3 } = self;
         let p = point;
 

--- a/embedded-graphics/src/primitives/triangle/mod.rs
+++ b/embedded-graphics/src/primitives/triangle/mod.rs
@@ -426,12 +426,11 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "right now this requires a modified mock display with bigger display area"]
     fn triangle_contains_edge_point_regression() {
         // This test is a regression test case found while optimizing Triangle::contains()
         assert!(
-            Triangle::new(Point::new(8, 0), Point::new(7, 65), Point::new(0, 97))
-                .contains(Point::new(7, 67))
+            Triangle::new(Point::new(30, 30), Point::new(0, 0), Point::new(32, 33))
+                .contains(Point::new(31, 31))
         );
     }
 

--- a/embedded-graphics/src/primitives/triangle/mod.rs
+++ b/embedded-graphics/src/primitives/triangle/mod.rs
@@ -18,8 +18,8 @@ use core::{
     borrow::Borrow,
     cmp::{max, min},
 };
-pub use mathematical_points::MathematicalPoints;
 pub use fill_scanline_iterator::FillScanlineIterator;
+pub use mathematical_points::MathematicalPoints;
 pub use points::Points;
 pub use styled::StyledPixels;
 

--- a/embedded-graphics/src/primitives/triangle/mod.rs
+++ b/embedded-graphics/src/primitives/triangle/mod.rs
@@ -182,6 +182,22 @@ impl Triangle {
         }
     }
 
+    /// Create a new triangle with points sorted in a counterclockwise direction
+    pub fn sorted_counterclockwise(&self) -> Self {
+        match self.area_doubled().cmp(&0) {
+            // Triangle is already CCW, do nothing.
+            Ordering::Less => *self,
+            // Triangle is wound CW. Swap two points to make it CCW.
+            Ordering::Greater => Self::new(self.p2, self.p1, self.p3),
+            // Triangle is colinear. Sort points so they lie sequentially along the line.
+            Ordering::Equal => {
+                let (p1, p2, p3) = sort_yx(self.p1, self.p2, self.p3);
+
+                Self::new(p1, p2, p3)
+            }
+        }
+    }
+
     /// Find the center of gravity/centroid of the triangle
     pub fn centroid(&self) -> Point {
         (self.p1 + self.p2 + self.p3) / 3

--- a/embedded-graphics/src/primitives/triangle/mod.rs
+++ b/embedded-graphics/src/primitives/triangle/mod.rs
@@ -193,22 +193,6 @@ impl Triangle {
         }
     }
 
-    /// Create a new triangle with points sorted in a counterclockwise direction
-    pub fn sorted_counterclockwise(&self) -> Self {
-        match self.area_doubled().cmp(&0) {
-            // Triangle is already CCW, do nothing.
-            Ordering::Less => *self,
-            // Triangle is wound CW. Swap two points to make it CCW.
-            Ordering::Greater => Self::new(self.p2, self.p1, self.p3),
-            // Triangle is colinear. Sort points so they lie sequentially along the line.
-            Ordering::Equal => {
-                let (p1, p2, p3) = sort_yx(self.p1, self.p2, self.p3);
-
-                Self::new(p1, p2, p3)
-            }
-        }
-    }
-
     /// Find the center of gravity/centroid of the triangle
     pub fn centroid(&self) -> Point {
         (self.p1 + self.p2 + self.p3) / 3

--- a/embedded-graphics/src/primitives/triangle/mod.rs
+++ b/embedded-graphics/src/primitives/triangle/mod.rs
@@ -121,15 +121,6 @@ impl ContainsPoint for Triangle {
     }
 }
 
-impl ContainsPoint for Option<Triangle> {
-    fn contains(&self, point: Point) -> bool {
-        match self {
-            None => false,
-            Some(ref triangle) => triangle.contains(point),
-        }
-    }
-}
-
 impl Dimensions for Triangle {
     fn bounding_box(&self) -> Rectangle {
         let x_min = min(min(self.p1.x, self.p2.x), self.p3.x);

--- a/embedded-graphics/src/primitives/triangle/mod.rs
+++ b/embedded-graphics/src/primitives/triangle/mod.rs
@@ -425,18 +425,15 @@ mod tests {
         }
     }
 
-    /* // This test requires a bigger mock display. TODO: figure out what to do
     #[test]
-    fn bug_triangle_contains_edge_point() {
+    #[ignore = "right now this requires a modified mock display with bigger display area"]
+    fn triangle_contains_edge_point_regression() {
         // This test is a regression test case found while optimizing Triangle::contains()
-        assert!(Triangle::new(
-            Point::new(8, 0),
-            Point::new(7, 65),
-            Point::new(0, 97)
-        )
-        .contains(Point::new(7, 67)));
+        assert!(
+            Triangle::new(Point::new(8, 0), Point::new(7, 65), Point::new(0, 97))
+                .contains(Point::new(7, 67))
+        );
     }
-    */
 
     // FIXME: Colinear triangles are rendered as a line, so this should also return true. Why not?
     // #[test]

--- a/embedded-graphics/src/primitives/triangle/mod.rs
+++ b/embedded-graphics/src/primitives/triangle/mod.rs
@@ -109,11 +109,16 @@ impl ContainsPoint for Triangle {
         // Special case: due to the Bresenham algorithm being used to render triangles, some pixel
         // centers on a Styled<Triangle> lie outside the mathematical triangle. This check
         // inefficiently checks to see if the point lies on any of the border edges.
-        Line::new(p1, p2)
-            .points()
-            .chain(Line::new(p1, p3).points())
-            .chain(Line::new(p2, p3).points())
-            .any(|line_point| line_point == point)
+        let mut l1 = Line::new(p1, p2).points();
+        let mut l2 = Line::new(p2, p3).points();
+        let mut l3 = Line::new(p1, p3).points();
+
+        // Skip first points so that they are not checked twice
+        l1.next();
+        l2.next();
+        l3.next();
+
+        l1.chain(l2).chain(l3).any(|line_point| line_point == point)
     }
 }
 

--- a/embedded-graphics/src/primitives/triangle/points.rs
+++ b/embedded-graphics/src/primitives/triangle/points.rs
@@ -1,15 +1,15 @@
 use crate::{
     geometry::Point,
-    primitives::triangle::{scanline_iterator::ScanlineIterator, Triangle},
+    primitives::triangle::{fill_scanline_iterator::FillScanlineIterator, Triangle},
 };
 
 /// Iterator over all points inside the triangle.
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
-pub struct Points(ScanlineIterator);
+pub struct Points(FillScanlineIterator);
 
 impl Points {
     pub(in crate::primitives) fn new(triangle: &Triangle) -> Self {
-        Self(ScanlineIterator::new(triangle))
+        Self(FillScanlineIterator::new(triangle))
     }
 }
 
@@ -17,7 +17,7 @@ impl Iterator for Points {
     type Item = Point;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.0.next().map(|(_, p)| p)
+        self.0.next()
     }
 }
 

--- a/embedded-graphics/src/primitives/triangle/scanline_iterator.rs
+++ b/embedded-graphics/src/primitives/triangle/scanline_iterator.rs
@@ -163,34 +163,51 @@ impl Iterator for ScanlineIterator {
 mod tests {
     use super::*;
     use crate::{
+        drawable::{Drawable, Pixel},
         geometry::Dimensions,
-        drawable::Pixel, pixel_iterator::IntoPixels, pixelcolor::BinaryColor,
-        primitives::ContainsPoint, style::PrimitiveStyle, transform::Transform,
+        mock_display::MockDisplay,
+        pixel_iterator::IntoPixels,
+        pixelcolor::BinaryColor,
+        primitives::ContainsPoint,
+        style::PrimitiveStyle,
+        transform::Transform,
     };
 
     #[test]
     fn points_are_part_of_triangle() {
         fn check(triangle: Triangle) {
-            assert!(triangle.points().all(|p| triangle.contains(p)));
-        }
+            let mut mock_display1 = MockDisplay::new();
+            let mut mock_display2 = MockDisplay::new();
 
-        check(Triangle::new(Point::new(5, 10), Point::new(15, 10), Point::new(10, 15)));
-        check(Triangle::new(Point::new(5, 10), Point::new(10, 15), Point::new(15, 10)));
-    }
+            mock_display2.set_allow_overdraw(true);
 
-    #[test]
-    fn all_points_are_generated() {
-        fn check(triangle: Triangle) {
-            let iter_points = triangle.points().collect::<Vec<Point>>();
-            assert!(triangle
+            triangle
                 .bounding_box()
                 .points()
                 .filter(|&p| triangle.contains(p))
-                .all(|p| iter_points.contains(&p)));
+                .for_each(|p| Pixel(p, BinaryColor::On).draw(&mut mock_display1).unwrap());
+
+            ScanlineIterator::new(&triangle)
+                .for_each(|(_, p)| Pixel(p, BinaryColor::On).draw(&mut mock_display2).unwrap());
+
+            assert_eq!(mock_display1, mock_display2, "{:?}", triangle);
         }
 
-        check(Triangle::new(Point::new(5, 10), Point::new(15, 10), Point::new(10, 15)));
-        check(Triangle::new(Point::new(5, 10), Point::new(10, 15), Point::new(15, 10)));
+        check(Triangle::new(
+            Point::new(5, 10),
+            Point::new(10, 15),
+            Point::new(15, 10),
+        ));
+        check(Triangle::new(
+            Point::new(5, 5),
+            Point::new(15, 0),
+            Point::new(10, 10),
+        ));
+        check(Triangle::new(
+            Point::new(30, 0),
+            Point::new(40, 10),
+            Point::new(42, 10),
+        ));
     }
 
     #[test]

--- a/embedded-graphics/src/primitives/triangle/scanline_iterator.rs
+++ b/embedded-graphics/src/primitives/triangle/scanline_iterator.rs
@@ -174,11 +174,12 @@ mod tests {
     };
 
     #[test]
-    fn points_are_part_of_triangle() {
+    fn points_by_scanline_match_triangle_contains() {
         fn check(triangle: Triangle) {
             let mut mock_display1 = MockDisplay::new();
             let mut mock_display2 = MockDisplay::new();
 
+            // FIXME: right now, ScanlineIterator does not guarantee unique points
             mock_display2.set_allow_overdraw(true);
 
             triangle

--- a/embedded-graphics/src/primitives/triangle/scanline_iterator.rs
+++ b/embedded-graphics/src/primitives/triangle/scanline_iterator.rs
@@ -163,9 +163,35 @@ impl Iterator for ScanlineIterator {
 mod tests {
     use super::*;
     use crate::{
+        geometry::Dimensions,
         drawable::Pixel, pixel_iterator::IntoPixels, pixelcolor::BinaryColor,
-        style::PrimitiveStyle, transform::Transform,
+        primitives::ContainsPoint, style::PrimitiveStyle, transform::Transform,
     };
+
+    #[test]
+    fn points_are_part_of_triangle() {
+        fn check(triangle: Triangle) {
+            assert!(triangle.points().all(|p| triangle.contains(p)));
+        }
+
+        check(Triangle::new(Point::new(5, 10), Point::new(15, 10), Point::new(10, 15)));
+        check(Triangle::new(Point::new(5, 10), Point::new(10, 15), Point::new(15, 10)));
+    }
+
+    #[test]
+    fn all_points_are_generated() {
+        fn check(triangle: Triangle) {
+            let iter_points = triangle.points().collect::<Vec<Point>>();
+            assert!(triangle
+                .bounding_box()
+                .points()
+                .filter(|&p| triangle.contains(p))
+                .all(|p| iter_points.contains(&p)));
+        }
+
+        check(Triangle::new(Point::new(5, 10), Point::new(15, 10), Point::new(10, 15)));
+        check(Triangle::new(Point::new(5, 10), Point::new(10, 15), Point::new(15, 10)));
+    }
 
     #[test]
     fn points_iter() {

--- a/embedded-graphics/src/primitives/triangle/scanline_iterator.rs
+++ b/embedded-graphics/src/primitives/triangle/scanline_iterator.rs
@@ -228,8 +228,8 @@ mod tests {
         let off_screen = Triangle::new(Point::new(10, 10), Point::new(20, 20), Point::new(30, -30));
         let on_screen = off_screen.translate(Point::new(0, 35));
 
-        assert!(off_screen
-            .points()
-            .eq(on_screen.points().map(|p| p - Point::new(0, 35))));
+        ScanlineIterator::new(&off_screen)
+            .map(|(_, p)| p)
+            .eq(on_screen.points().map(|p| p - Point::new(0, 35)));
     }
 }


### PR DESCRIPTION
This PR reworks how the triangles in a polyline are rendered. Instead of trying to get the mathematical point rendering to work, I've instead created a fast-ish scanline iterator to draw individual triangles, and introduced a check in ThickPoints, that, for each to-be-rendered pixel checks, if it was part of a previous triangle. This check is done for the last 3 triangles to avoid overdraw on the inside of bevelled corners.

# The scanline iterator

The new scanline iterator (`FillScanlineIterator` for now) returns the points of a triangle from top to bottom, from left to right. This implementation differs from the existing `ScanlineIterator` in that it does not differentiate between edge and inside points, and also only yields unique points, thus it has no overdraw.

Basically, it walk the outside edges, determines which are the limits of a line and for each line, creates a line point iterator to generate the points.

Maybe some of it's implementation can be used to improve the `ScanlineIterator` but I haven't bothered as it was tricky enough to get this to work.

This PR replaces the implementation behind Triangle::points() to use the new `FillScanlineIterator`.

# Lookback

Right now, the lookback in `ThickPoints` contains 3 Option<Triangle> fields and for each of those, checks if the point we want to return is inside any of the 3 previous triangles. This isn't particularly efficient. It should be possible to only store the unique points and reconstruct triangles, so the memory cost can be cut down from 9 points + extra to 5 points + a little less, but the runtime cost can't be reduced this way.

There are some development options:
 - Try to solve the overdraw by tuning the bevel rendering - a lookback of 1 triangle is still necessary to avoid drawing over the
   triangle edges.
 - Try to solve edge overdraw some other way. Maybe it is possible to only track vertical information of the previous triangle and 
   abuse the fact that the scanline iterator returns points in a given order.

---------------

This PR does NOT solve the general overdraw issue.

This PR is opened agains #386 so the code is not master-quality