### PR TITLE
Make DrawTarget trait methods generic across color

### DIFF
--- a/embedded-graphics/src/draw_target/cropped.rs
+++ b/embedded-graphics/src/draw_target/cropped.rs
@@ -1,6 +1,7 @@
 use crate::{
     draw_target::{DrawTarget, DrawTargetExt, Translated},
     geometry::{Dimensions, Point, Size},
+    pixelcolor::PixelColor,
     primitives::Rectangle,
     Pixel,
 };
@@ -42,21 +43,26 @@ where
     type Color = T::Color;
     type Error = T::Error;
 
-    fn draw_iter<I>(&mut self, pixels: I) -> Result<(), Self::Error>
+    fn draw_iter<I, C>(&mut self, pixels: I) -> Result<(), Self::Error>
     where
-        I: IntoIterator<Item = Pixel<Self::Color>>,
+        I: IntoIterator<Item = Pixel<C>>,
+        C: Into<Self::Color> + PixelColor,
     {
         self.parent.draw_iter(pixels)
     }
 
-    fn fill_contiguous<I>(&mut self, area: &Rectangle, colors: I) -> Result<(), Self::Error>
+    fn fill_contiguous<I, C>(&mut self, area: &Rectangle, colors: I) -> Result<(), Self::Error>
     where
-        I: IntoIterator<Item = Self::Color>,
+        I: IntoIterator<Item = C>,
+        C: Into<Self::Color> + PixelColor,
     {
         self.parent.fill_contiguous(area, colors)
     }
 
-    fn fill_solid(&mut self, area: &Rectangle, color: Self::Color) -> Result<(), Self::Error> {
+    fn fill_solid<C>(&mut self, area: &Rectangle, color: C) -> Result<(), Self::Error>
+    where
+        C: Into<Self::Color> + PixelColor,
+    {
         self.parent.fill_solid(area, color)
     }
 }
@@ -80,7 +86,7 @@ mod tests {
 
     #[test]
     fn draw_iter() {
-        let mut display = MockDisplay::new();
+        let mut display = MockDisplay::<BinaryColor>::new();
 
         let area = Rectangle::new(Point::new(2, 3), Size::new(10, 10));
         let mut cropped = display.cropped(&area);
@@ -106,7 +112,7 @@ mod tests {
 
     #[test]
     fn fill_contiguous() {
-        let mut display = MockDisplay::new();
+        let mut display = MockDisplay::<BinaryColor>::new();
 
         let area = Rectangle::new(Point::new(3, 2), Size::new(10, 10));
         let mut cropped = display.cropped(&area);
@@ -139,7 +145,7 @@ mod tests {
 
     #[test]
     fn fill_solid() {
-        let mut display = MockDisplay::new();
+        let mut display = MockDisplay::<BinaryColor>::new();
 
         let area = Rectangle::new(Point::new(1, 3), Size::new(10, 10));
         let mut cropped = display.cropped(&area);

--- a/embedded-graphics/src/draw_target/translated.rs
+++ b/embedded-graphics/src/draw_target/translated.rs
@@ -2,6 +2,7 @@ use crate::{
     draw_target::DrawTarget,
     geometry::{Dimensions, Point},
     iterator::PixelIteratorExt,
+    pixelcolor::PixelColor,
     primitives::Rectangle,
     transform::Transform,
     Pixel,
@@ -39,28 +40,36 @@ where
     type Color = T::Color;
     type Error = T::Error;
 
-    fn draw_iter<I>(&mut self, pixels: I) -> Result<(), Self::Error>
+    fn draw_iter<I, C>(&mut self, pixels: I) -> Result<(), Self::Error>
     where
-        I: IntoIterator<Item = Pixel<Self::Color>>,
+        I: IntoIterator<Item = Pixel<C>>,
+        C: Into<Self::Color> + PixelColor,
     {
         self.parent
             .draw_iter(pixels.into_iter().translate(self.offset))
     }
 
-    fn fill_contiguous<I>(&mut self, area: &Rectangle, colors: I) -> Result<(), Self::Error>
+    fn fill_contiguous<I, C>(&mut self, area: &Rectangle, colors: I) -> Result<(), Self::Error>
     where
-        I: IntoIterator<Item = Self::Color>,
+        I: IntoIterator<Item = C>,
+        C: Into<Self::Color> + PixelColor,
     {
         let area = area.translate(self.offset);
         self.parent.fill_contiguous(&area, colors)
     }
 
-    fn fill_solid(&mut self, area: &Rectangle, color: Self::Color) -> Result<(), Self::Error> {
+    fn fill_solid<C>(&mut self, area: &Rectangle, color: C) -> Result<(), Self::Error>
+    where
+        C: Into<Self::Color> + PixelColor,
+    {
         let area = area.translate(self.offset);
         self.parent.fill_solid(&area, color)
     }
 
-    fn clear(&mut self, color: Self::Color) -> Result<(), Self::Error> {
+    fn clear<C>(&mut self, color: C) -> Result<(), Self::Error>
+    where
+        C: Into<Self::Color> + PixelColor,
+    {
         self.parent.clear(color)
     }
 }
@@ -84,7 +93,7 @@ mod tests {
 
     #[test]
     fn draw_iter() {
-        let mut display = MockDisplay::new();
+        let mut display = MockDisplay::<BinaryColor>::new();
 
         let mut translated = display.translated(Point::new(2, 3));
 
@@ -109,7 +118,7 @@ mod tests {
 
     #[test]
     fn fill_contiguous() {
-        let mut display = MockDisplay::new();
+        let mut display = MockDisplay::<BinaryColor>::new();
 
         let mut translated = display.translated(Point::new(3, 2));
 
@@ -141,7 +150,7 @@ mod tests {
 
     #[test]
     fn fill_solid() {
-        let mut display = MockDisplay::new();
+        let mut display = MockDisplay::<BinaryColor>::new();
 
         let mut translated = display.translated(Point::new(1, 3));
 
@@ -165,7 +174,7 @@ mod tests {
 
     #[test]
     fn clear() {
-        let mut display = MockDisplay::new();
+        let mut display = MockDisplay::<BinaryColor>::new();
         let mut translated = display.translated(Point::new(1, 3));
         translated.clear(BinaryColor::On).unwrap();
 
@@ -177,7 +186,7 @@ mod tests {
 
     #[test]
     fn bounding_box() {
-        let mut display: MockDisplay<BinaryColor> = MockDisplay::new();
+        let mut display: MockDisplay<BinaryColor> = MockDisplay::<BinaryColor>::new();
         let display_bb = display.bounding_box();
 
         let translated = display.translated(Point::new(1, 3));

--- a/embedded-graphics/src/mock_display.rs
+++ b/embedded-graphics/src/mock_display.rs
@@ -540,14 +540,15 @@ where
     type Color = C;
     type Error = core::convert::Infallible;
 
-    fn draw_iter<I>(&mut self, pixels: I) -> Result<(), Self::Error>
+    fn draw_iter<I, P>(&mut self, pixels: I) -> Result<(), Self::Error>
     where
-        I: IntoIterator<Item = Pixel<Self::Color>>,
+        I: IntoIterator<Item = Pixel<P>>,
+        P: Into<Self::Color> + PixelColor,
     {
         for pixel in pixels.into_iter() {
             let Pixel(point, color) = pixel;
 
-            self.draw_pixel(point, color);
+            self.draw_pixel(point, color.into());
         }
 
         Ok(())

--- a/embedded-graphics/src/pixelcolor/mod.rs
+++ b/embedded-graphics/src/pixelcolor/mod.rs
@@ -13,6 +13,7 @@
 //! ```
 //! use embedded_graphics::{
 //!     geometry::Size, prelude::*, primitives::Rectangle, style::PrimitiveStyle,
+//!     pixelcolor::PixelColor,
 //! };
 //!
 //! /// Color with 3 states.
@@ -36,12 +37,13 @@
 //!     type Color = EpdColor;
 //!     type Error = core::convert::Infallible;
 //!
-//!     fn draw_iter<I>(&mut self, pixels: I) -> Result<(), Self::Error>
+//!     fn draw_iter<I, C>(&mut self, pixels: I) -> Result<(), Self::Error>
 //!     where
-//!         I: IntoIterator<Item = Pixel<Self::Color>>,
+//!         I: IntoIterator<Item = Pixel<C>>,
+//!         C: Into<Self::Color> + PixelColor,
 //!     {
 //!         for Pixel(point, color) in pixels.into_iter() {
-//!             match color {
+//!             match color.into() {
 //!                 EpdColor::White => {} // draw white pixel at `point`
 //!                 EpdColor::Black => {} // draw black pixel at `point`
 //!                 EpdColor::Red => {}   // draw red pixel at `point`

--- a/embedded-graphics/tests/chaining.rs
+++ b/embedded-graphics/tests/chaining.rs
@@ -1,6 +1,7 @@
 extern crate embedded_graphics;
 
 use embedded_graphics::{
+    pixelcolor::PixelColor,
     prelude::*,
     primitives::{Circle, Line, Primitive, Rectangle},
     style::PrimitiveStyle,
@@ -25,9 +26,10 @@ impl DrawTarget for FakeDisplay {
     type Color = TestPixelColor;
     type Error = core::convert::Infallible;
 
-    fn draw_iter<I>(&mut self, _pixels: I) -> Result<(), Self::Error>
+    fn draw_iter<I, C>(&mut self, _pixels: I) -> Result<(), Self::Error>
     where
-        I: IntoIterator<Item = Pixel<Self::Color>>,
+        I: IntoIterator<Item = Pixel<C>>,
+        C: Into<Self::Color> + PixelColor,
     {
         Ok(())
     }

--- a/simulator/src/display.rs
+++ b/simulator/src/display.rs
@@ -102,13 +102,14 @@ where
     type Color = C;
     type Error = core::convert::Infallible;
 
-    fn draw_iter<I>(&mut self, pixels: I) -> Result<(), Self::Error>
+    fn draw_iter<I, P>(&mut self, pixels: I) -> Result<(), Self::Error>
     where
-        I: IntoIterator<Item = Pixel<Self::Color>>,
+        I: IntoIterator<Item = Pixel<P>>,
+        P: Into<Self::Color> + PixelColor,
     {
         for Pixel(point, color) in pixels.into_iter() {
             if let Some(index) = self.point_to_index(point) {
-                self.pixels[index] = color;
+                self.pixels[index] = color.into();
             }
         }
 

--- a/simulator/src/framebuffer.rs
+++ b/simulator/src/framebuffer.rs
@@ -90,13 +90,14 @@ impl DrawTarget for Framebuffer {
     type Color = Rgb888;
     type Error = core::convert::Infallible;
 
-    fn draw_iter<I>(&mut self, pixels: I) -> Result<(), Self::Error>
+    fn draw_iter<I, C>(&mut self, pixels: I) -> Result<(), Self::Error>
     where
-        I: IntoIterator<Item = Pixel<Self::Color>>,
+        I: IntoIterator<Item = Pixel<C>>,
+        C: Into<Self::Color> + PixelColor,
     {
         for Pixel(point, color) in pixels.into_iter() {
             if let Some(pixel) = self.get_pixel_mut(point) {
-                pixel.copy_from_slice(&color.to_be_bytes())
+                pixel.copy_from_slice(&color.into().to_be_bytes())
             }
         }
 

--- a/tinybmp/src/embedded_graphics.rs
+++ b/tinybmp/src/embedded_graphics.rs
@@ -38,7 +38,7 @@ where
     where
         D: DrawTarget<Color = C>,
     {
-        target.fill_contiguous(
+        target.fill_contiguous::<_, C>(
             &self.bounding_box(),
             self.bmp
                 .into_iter()

--- a/tinytga/src/lib.rs
+++ b/tinytga/src/lib.rs
@@ -314,12 +314,12 @@ where
         // TGA files with the origin in the top left corner can be drawn using `fill_contiguous`.
         // All other origins are drawn by falling back to `draw_iter`.
         if self.image_origin == ImageOrigin::TopLeft {
-            target.fill_contiguous(
+            target.fill_contiguous::<_, C>(
                 &self.bounding_box(),
                 self.raw_pixels().map(|p| C::Raw::from_u32(p.color).into()),
             )
         } else {
-            target.draw_iter(
+            target.draw_iter::<_, C>(
                 self.raw_pixels()
                     .map(|p| Pixel(p.position, C::Raw::from_u32(p.color).into())),
             )


### PR DESCRIPTION
Hi! Thank you for helping out with Embedded Graphics development! Please:

- [x] Check that you've added passing tests and documentation
- [x] Add a simulator example(s) where applicable
- [ ] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) and appropriate crate (`embedded-graphics`, `simulator`, `tinytga`, `tinybmp`) if your changes affect the **public API**
- [x] Run `rustfmt` on the project
- [x] Run `just build` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

This PR attempts to allow the `DrawTarget` trait to be generic across the color type that the trait methods can accept. This allows for crates/code that interface with displays that impl `DrawTarget` to be more agnostic as to the pixel type of said display. 

Noting that this sort of generic approach was possible pre-0.7 release because `DrawTarget<>` could be made to be generic. An example of this can be seen here: https://github.com/rust-rpi-led-matrix/rust-rpi-rgb-led-matrix/blob/5d1334a47b270a6666e310cbf4229bace04fa3d3/src/matrix.rs#L93