### PR TITLE
Authenticate CircleCI image pulls for custom image

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -1,8 +1,10 @@
-FROM circleci/rust:1.40.0
+FROM cimg/rust:1.40.0
 
-RUN sudo apt update && sudo apt install -y libsdl2-dev && sudo apt clean
+RUN sudo apt update && sudo apt install -y libsdl2-dev libssl-dev && sudo apt clean
 
-RUN cargo install cargo-readme just cargo-deadlinks
+RUN cargo install just --version ^0.6
+RUN cargo install cargo-readme --version ^3.2
+RUN cargo install cargo-deadlinks --version ^0.4
 
 RUN rustup toolchain add nightly -c rustfmt
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,9 @@
 precheck_steps: &precheck_steps
   docker:
     - image: jamwaffles/circleci-embedded-graphics:1.40.0
+      auth:
+        username: jamwaffles
+        password: $DOCKERHUB_PASSWORD
   steps:
     - checkout
     - restore_cache:
@@ -20,6 +23,9 @@ precheck_steps: &precheck_steps
 target_steps: &target_steps
   docker:
     - image: jamwaffles/circleci-embedded-graphics:1.40.0
+      auth:
+        username: jamwaffles
+        password: $DOCKERHUB_PASSWORD
   steps:
     - checkout
     - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,28 +1,28 @@
 # Check that everything (tests, benches, etc) builds in std environments
 precheck_steps: &precheck_steps
   docker:
-    - image: jamwaffles/circleci-embedded-graphics:1.40.0
+    - image: jamwaffles/circleci-embedded-graphics:1.40.0-cimg
       auth:
         username: jamwaffles
         password: $DOCKERHUB_PASSWORD
   steps:
     - checkout
     - restore_cache:
-        key: v5-embedded-graphics-{{ .Environment.CIRCLE_JOB }}-{{ checksum "embedded-graphics/Cargo.toml" }}-{{ checksum "tinybmp/Cargo.toml" }}-{{ checksum "tinytga/Cargo.toml" }}-{{ checksum "simulator/Cargo.toml" }}
+        key: v6-embedded-graphics-{{ .Environment.CIRCLE_JOB }}-{{ checksum "embedded-graphics/Cargo.toml" }}-{{ checksum "tinybmp/Cargo.toml" }}-{{ checksum "tinytga/Cargo.toml" }}-{{ checksum "simulator/Cargo.toml" }}
     - run: rustup default ${RUST_VERSION:-stable}
     - run: rustup component add rustfmt
     - run: cargo update
     - run: just build
     - save_cache:
-        key: v5-embedded-graphics-{{ .Environment.CIRCLE_JOB }}-{{ checksum "embedded-graphics/Cargo.toml" }}-{{ checksum "tinybmp/Cargo.toml" }}-{{ checksum "tinytga/Cargo.toml" }}-{{ checksum "simulator/Cargo.toml" }}
+        key: v6-embedded-graphics-{{ .Environment.CIRCLE_JOB }}-{{ checksum "embedded-graphics/Cargo.toml" }}-{{ checksum "tinybmp/Cargo.toml" }}-{{ checksum "tinytga/Cargo.toml" }}-{{ checksum "simulator/Cargo.toml" }}
         paths:
           - ./target
-          - /usr/local/cargo/registry
+          - /home/circleci/.cargo/registry
 
 # Build crates for embedded target
 target_steps: &target_steps
   docker:
-    - image: jamwaffles/circleci-embedded-graphics:1.40.0
+    - image: jamwaffles/circleci-embedded-graphics:1.40.0-cimg
       auth:
         username: jamwaffles
         password: $DOCKERHUB_PASSWORD
@@ -30,15 +30,15 @@ target_steps: &target_steps
     - checkout
     - restore_cache:
         keys:
-          - v5-embedded-graphics-{{ .Environment.CIRCLE_JOB }}-{{ checksum "embedded-graphics/Cargo.toml" }}-{{ checksum "tinybmp/Cargo.toml" }}-{{ checksum "tinytga/Cargo.toml" }}-{{ checksum "simulator/Cargo.toml" }}
+          - v6-embedded-graphics-{{ .Environment.CIRCLE_JOB }}-{{ checksum "embedded-graphics/Cargo.toml" }}-{{ checksum "tinybmp/Cargo.toml" }}-{{ checksum "tinytga/Cargo.toml" }}-{{ checksum "simulator/Cargo.toml" }}
     - run: just install-targets
     - run: cargo update
     - run: just build-targets --release
     - save_cache:
-        key: v5-embedded-graphics-{{ .Environment.CIRCLE_JOB }}-{{ checksum "embedded-graphics/Cargo.toml" }}-{{ checksum "tinybmp/Cargo.toml" }}-{{ checksum "tinytga/Cargo.toml" }}-{{ checksum "simulator/Cargo.toml" }}
+        key: v6-embedded-graphics-{{ .Environment.CIRCLE_JOB }}-{{ checksum "embedded-graphics/Cargo.toml" }}-{{ checksum "tinybmp/Cargo.toml" }}-{{ checksum "tinytga/Cargo.toml" }}-{{ checksum "simulator/Cargo.toml" }}
         paths:
           - ./target
-          - /usr/local/cargo/registry
+          - /home/circleci/.cargo/registry
 
 version: 2
 jobs:

--- a/justfile
+++ b/justfile
@@ -5,7 +5,9 @@ target_dir := "target"
 doc_dir := "doc"
 doc_assets_dir := doc_dir + "/assets"
 screenshots_dir := target_dir + "/screenshots"
-ci_build_image := "jamwaffles/circleci-embedded-graphics:1.40.0"
+# FIXME: `-cimg` suffix is temporary while moving to new CircleCI base images. Remove this suffix
+# when upgrading the tag next time.
+ci_build_image := "jamwaffles/circleci-embedded-graphics:1.40.0-cimg"
 
 #----------
 # Building


### PR DESCRIPTION
This is due to Docker Hub's new rate limits for unauthenticated pulls -
by IP address. There are still limits for authenticated pulls, but are
limited now per Docker repo, not by IP address, so we don't hit limits
when pulling from CircleCI's IP addresses.

The `DOCKERHUB_PASSWORD` env var has already been added to the CircleCI
env var secrets thing. This uses my personal account, but it's not too
hard to change it to anything else in the future as (afaik) no special
permissions are required beyond login as the image is public.

Edit: according to https://www.docker.com/pricing, we get 200 authenticated pulls per 6 hours. Previously, that would be 100 unauthed pulls per IP address, which is pretty stinky when those IPs have to service all of CircleCI.