### PR TITLE
Add DynamicTga and ConvertColor

### DIFF
--- a/embedded-graphics/CHANGELOG.md
+++ b/embedded-graphics/CHANGELOG.md
@@ -35,7 +35,7 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 - [#420](https://github.com/jamwaffles/embedded-graphics/pull/420) Added support for `SubImage`s.
 - [#429](https://github.com/jamwaffles/embedded-graphics/pull/429) Added `ToBytes` trait to convert colors into byte arrays.
 - [#431](https://github.com/jamwaffles/embedded-graphics/pull/431) Added `MockDisplay::affected_area` to get the area affected by previous drawing operations.
-- [#450](https://github.com/jamwaffles/embedded-graphics/pull/450) Added `ConvertColor` and `DrawTargetExt::convert_color` to support color conversion for draw targets.
+- [#450](https://github.com/jamwaffles/embedded-graphics/pull/450) Added `ColorConverted` and `DrawTargetExt::color_converted` to support color conversion for draw targets.
 
 ### Changed
 

--- a/embedded-graphics/CHANGELOG.md
+++ b/embedded-graphics/CHANGELOG.md
@@ -35,6 +35,7 @@ Embedded Graphics is a `no_std` library for adding graphics features to display 
 - [#420](https://github.com/jamwaffles/embedded-graphics/pull/420) Added support for `SubImage`s.
 - [#429](https://github.com/jamwaffles/embedded-graphics/pull/429) Added `ToBytes` trait to convert colors into byte arrays.
 - [#431](https://github.com/jamwaffles/embedded-graphics/pull/431) Added `MockDisplay::affected_area` to get the area affected by previous drawing operations.
+- [#450](https://github.com/jamwaffles/embedded-graphics/pull/450) Added `ConvertColor` and `DrawTargetExt::convert_color` to support color conversion for draw targets.
 
 ### Changed
 

--- a/embedded-graphics/src/draw_target/color_converted.rs
+++ b/embedded-graphics/src/draw_target/color_converted.rs
@@ -6,13 +6,13 @@ use core::marker::PhantomData;
 
 /// Color conversion draw target.
 ///
-/// Created by calling [`convert_color`] on any [`DrawTarget`].
-/// See the [`convert_color`] method documentation for more information.
+/// Created by calling [`color_converted`] on any [`DrawTarget`].
+/// See the [`color_converted`] method documentation for more information.
 ///
 /// [`DrawTarget`]: trait.DrawTarget.html
-/// [`convert_color`]: trait.DrawTargetExt.html#tymethod.into_color
+/// [`color_converted`]: trait.DrawTargetExt.html#tymethod.color_converted
 #[derive(Debug)]
-pub struct ConvertColor<'a, T, C> {
+pub struct ColorConverted<'a, T, C> {
     /// The parent draw target.
     parent: &'a mut T,
 
@@ -20,7 +20,7 @@ pub struct ConvertColor<'a, T, C> {
     color_type: PhantomData<C>,
 }
 
-impl<'a, T, C> ConvertColor<'a, T, C>
+impl<'a, T, C> ColorConverted<'a, T, C>
 where
     T: DrawTarget,
     C: PixelColor + Into<T::Color>,
@@ -33,7 +33,7 @@ where
     }
 }
 
-impl<T, C> DrawTarget for ConvertColor<'_, T, C>
+impl<T, C> DrawTarget for ColorConverted<'_, T, C>
 where
     T: DrawTarget,
     C: PixelColor + Into<T::Color>,
@@ -66,7 +66,7 @@ where
     }
 }
 
-impl<T, C> Dimensions for ConvertColor<'_, T, C>
+impl<T, C> Dimensions for ColorConverted<'_, T, C>
 where
     T: DrawTarget,
 {

--- a/embedded-graphics/src/draw_target/convert_color.rs
+++ b/embedded-graphics/src/draw_target/convert_color.rs
@@ -1,0 +1,76 @@
+use crate::{
+    draw_target::DrawTarget, geometry::Dimensions, pixelcolor::PixelColor, primitives::Rectangle,
+    Pixel,
+};
+use core::marker::PhantomData;
+
+/// Color conversion draw target.
+///
+/// Created by calling [`convert_color`] on any [`DrawTarget`].
+/// See the [`convert_color`] method documentation for more information.
+///
+/// [`DrawTarget`]: trait.DrawTarget.html
+/// [`convert_color`]: trait.DrawTargetExt.html#tymethod.into_color
+#[derive(Debug)]
+pub struct ConvertColor<'a, T, C> {
+    /// The parent draw target.
+    parent: &'a mut T,
+
+    /// The input color type.
+    color_type: PhantomData<C>,
+}
+
+impl<'a, T, C> ConvertColor<'a, T, C>
+where
+    T: DrawTarget,
+    C: PixelColor + Into<T::Color>,
+{
+    pub(super) fn new(parent: &'a mut T) -> Self {
+        Self {
+            parent,
+            color_type: PhantomData,
+        }
+    }
+}
+
+impl<T, C> DrawTarget for ConvertColor<'_, T, C>
+where
+    T: DrawTarget,
+    C: PixelColor + Into<T::Color>,
+{
+    type Color = C;
+    type Error = T::Error;
+
+    fn draw_iter<I>(&mut self, pixels: I) -> Result<(), Self::Error>
+    where
+        I: IntoIterator<Item = Pixel<Self::Color>>,
+    {
+        self.parent
+            .draw_iter(pixels.into_iter().map(|Pixel(p, c)| Pixel(p, c.into())))
+    }
+
+    fn fill_contiguous<I>(&mut self, area: &Rectangle, colors: I) -> Result<(), Self::Error>
+    where
+        I: IntoIterator<Item = Self::Color>,
+    {
+        self.parent
+            .fill_contiguous(area, colors.into_iter().map(|c| c.into()))
+    }
+
+    fn fill_solid(&mut self, area: &Rectangle, color: Self::Color) -> Result<(), Self::Error> {
+        self.parent.fill_solid(area, color.into())
+    }
+
+    fn clear(&mut self, color: Self::Color) -> Result<(), Self::Error> {
+        self.parent.clear(color.into())
+    }
+}
+
+impl<T, C> Dimensions for ConvertColor<'_, T, C>
+where
+    T: DrawTarget,
+{
+    fn bounding_box(&self) -> Rectangle {
+        self.parent.bounding_box()
+    }
+}

--- a/embedded-graphics/src/draw_target/mod.rs
+++ b/embedded-graphics/src/draw_target/mod.rs
@@ -575,7 +575,7 @@ pub trait DrawTargetExt: DrawTarget + Sized {
     /// Creates a color conversion draw target.
     ///
     /// A color conversion draw target is used to draw drawables with a different color type to a
-    /// draw target. The drawable color type needs to implement `Into<C>`, where `C` is the draw
+    /// draw target. The drawable color type must implement `Into<C>`, where `C` is the draw
     /// target color type.
     ///
     /// # Performance
@@ -583,11 +583,11 @@ pub trait DrawTargetExt: DrawTarget + Sized {
     /// Color conversion can be expensive on embedded hardware and should be avoided if possible.
     /// Using the same color type for drawables and the draw target makes sure that no unnecessary
     /// color conversion is used. But in some cases color conversion will be required, for example,
-    /// to draw images.
+    /// to draw images with a color format only known at runtime.
     ///
     /// # Examples
     ///
-    /// This example draws a `BinaryColor` image to a `Rgb888` display.
+    /// This example draws a `BinaryColor` image to an `Rgb888` display.
     ///
     /// ```
     /// use embedded_graphics::{

--- a/embedded-graphics/src/draw_target/mod.rs
+++ b/embedded-graphics/src/draw_target/mod.rs
@@ -1,6 +1,7 @@
 //! A target for embedded-graphics drawing operations.
 
 mod clipped;
+mod convert_color;
 mod cropped;
 mod translated;
 
@@ -12,6 +13,7 @@ use crate::{
 };
 
 pub use clipped::Clipped;
+pub use convert_color::ConvertColor;
 pub use cropped::Cropped;
 pub use translated::Translated;
 
@@ -569,6 +571,69 @@ pub trait DrawTargetExt: DrawTarget + Sized {
     /// # Ok::<(), core::convert::Infallible>(())
     /// ```
     fn clipped(&mut self, area: &Rectangle) -> Clipped<'_, Self>;
+
+    /// Creates a color conversion draw target.
+    ///
+    /// A color conversion draw target is used to draw drawables with a different color type to a
+    /// draw target. The drawable color type needs to implement `Into<C>`, where `C` is the draw
+    /// target color type.
+    ///
+    /// # Performance
+    ///
+    /// Color conversion can be expensive on embedded hardware and should be avoided if possible.
+    /// Using the same color type for drawables and the draw target makes sure that no unnecessary
+    /// color conversion is used. But in some cases color conversion will be required, for example,
+    /// to draw images.
+    ///
+    /// # Examples
+    ///
+    /// This example draws a `BinaryColor` image to a `Rgb888` display.
+    ///
+    /// ```
+    /// use embedded_graphics::{
+    ///     prelude::*,
+    ///     mock_display::MockDisplay,
+    ///     pixelcolor::{BinaryColor, Rgb888},
+    ///     image::{Image, ImageRaw},
+    /// };
+    ///
+    /// /// The image data.
+    /// const DATA: &[u8] = &[
+    ///     0b11110000, //
+    ///     0b10010000, //
+    ///     0b10010000, //
+    ///     0b11110000, //
+    /// ];
+    ///
+    /// // Create a `BinaryColor` image from the image data.
+    /// let raw_image = ImageRaw::<BinaryColor>::new(DATA, 4, 4);
+    /// let image = Image::new(&raw_image, Point::zero());
+    ///
+    /// // Create a `Rgb888` display.
+    /// let mut display = MockDisplay::<Rgb888>::new();
+    ///
+    /// // The image can't directly be drawn to the draw target because they use different
+    /// // color type. This will fail to compile:
+    /// // image.draw(&mut display)?;
+    ///
+    /// // To fix this `convert_color` is added to enable color conversion.
+    /// image.draw(&mut display.convert_color())?;
+    /// #
+    /// # let mut expected = MockDisplay::from_pattern(&[
+    /// #     "WWWW", //
+    /// #     "WKKW", //
+    /// #     "WKKW", //
+    /// #     "WWWW", //
+    /// # ]);
+    /// #
+    /// # assert_eq!(display, expected);
+    /// #
+    /// # Ok::<(), core::convert::Infallible>(())
+    /// ```
+
+    fn convert_color<C>(&mut self) -> ConvertColor<'_, Self, C>
+    where
+        C: PixelColor + Into<Self::Color>;
 }
 
 impl<T> DrawTargetExt for T
@@ -585,5 +650,12 @@ where
 
     fn clipped(&mut self, area: &Rectangle) -> Clipped<'_, Self> {
         Clipped::new(self, area)
+    }
+
+    fn convert_color<C>(&mut self) -> ConvertColor<'_, Self, C>
+    where
+        C: PixelColor + Into<Self::Color>,
+    {
+        ConvertColor::new(self)
     }
 }

--- a/embedded-graphics/src/draw_target/mod.rs
+++ b/embedded-graphics/src/draw_target/mod.rs
@@ -1,7 +1,7 @@
 //! A target for embedded-graphics drawing operations.
 
 mod clipped;
-mod convert_color;
+mod color_converted;
 mod cropped;
 mod translated;
 
@@ -13,7 +13,7 @@ use crate::{
 };
 
 pub use clipped::Clipped;
-pub use convert_color::ConvertColor;
+pub use color_converted::ColorConverted;
 pub use cropped::Cropped;
 pub use translated::Translated;
 
@@ -616,8 +616,8 @@ pub trait DrawTargetExt: DrawTarget + Sized {
     /// // color type. This will fail to compile:
     /// // image.draw(&mut display)?;
     ///
-    /// // To fix this `convert_color` is added to enable color conversion.
-    /// image.draw(&mut display.convert_color())?;
+    /// // To fix this `color_converted` is added to enable color conversion.
+    /// image.draw(&mut display.color_converted())?;
     /// #
     /// # let mut expected = MockDisplay::from_pattern(&[
     /// #     "WWWW", //
@@ -630,8 +630,7 @@ pub trait DrawTargetExt: DrawTarget + Sized {
     /// #
     /// # Ok::<(), core::convert::Infallible>(())
     /// ```
-
-    fn convert_color<C>(&mut self) -> ConvertColor<'_, Self, C>
+    fn color_converted<C>(&mut self) -> ColorConverted<'_, Self, C>
     where
         C: PixelColor + Into<Self::Color>;
 }
@@ -652,10 +651,10 @@ where
         Clipped::new(self, area)
     }
 
-    fn convert_color<C>(&mut self) -> ConvertColor<'_, Self, C>
+    fn color_converted<C>(&mut self) -> ColorConverted<'_, Self, C>
     where
         C: PixelColor + Into<Self::Color>,
     {
-        ConvertColor::new(self)
+        ColorConverted::new(self)
     }
 }

--- a/tinybmp/README.md
+++ b/tinybmp/README.md
@@ -10,54 +10,15 @@
 A small BMP parser designed for embedded, no-std environments but usable anywhere. Beyond
 parsing the image header, no other allocations are made.
 
-To access the individual pixels in an image, the `BmpRaw` struct implements `IntoIterator`. It is
-also possible to access the raw image data by reading the `pixel_data` field.
-
-## Features
-
-* `graphics` - enables [embedded-graphics] integration.
+To use `tinybmp` without `embedded-graphics` the raw data for individual pixels in an image
+can be accessed using the `raw_pixels` and `raw_image_data` methods provided by the `Bmp` 
+struct.
 
 ## Examples
 
-### Load a BMP image and check its `Header` and returned pixels.
+### Draw a BMP image to an `embedded-graphics` draw target
 
-```rust
-use tinybmp::{BmpRaw, FileType, Header, Pixel};
-
-let bmp = BmpRaw::from_slice(include_bytes!("../tests/chessboard-8px-24bit.bmp"))
-    .expect("Failed to parse BMP image");
-
-// Read the BMP header
-assert_eq!(
-    bmp.header,
-    Header {
-        file_type: FileType::BM,
-        file_size: 314,
-        reserved_1: 0,
-        reserved_2: 0,
-        image_data_start: 122,
-        bpp: 24,
-        image_width: 8,
-        image_height: 8,
-        image_data_len: 192
-    }
-);
-
-// Check that raw image data slice is the correct length (according to parsed header)
-assert_eq!(bmp.image_data().len(), bmp.header.image_data_len as usize);
-
-// Get an iterator over the pixel coordinates and values in this image and load into a vec
-let pixels: Vec<Pixel> = bmp.into_iter().collect();
-
-// Loaded example image is 8x8px
-assert_eq!(pixels.len(), 8 * 8);
-```
-
-### Integrate with `embedded-graphics`
-
-This example loads a 16BPP image and draws it to an [embedded-graphics] compatible display.
-
-The `graphics` feature must be enabled for embedded-graphics support.
+This example loads a 16BPP image and draws it to an `embedded-graphics` compatible display.
 
 ```rust
 use embedded_graphics::{image::Image, prelude::*};
@@ -71,7 +32,41 @@ let image = Image::new(&bmp, Point::zero());
 image.draw(&mut display)?;
 ```
 
-[embedded-graphics]: https://crates.io/crates/embedded-graphics
+### Accessing the raw image data
+
+This example demonstrates how the image header and raw image data can be accessed to use
+`tinybmp` without `embedded-graphics` 
+
+```rust
+use tinybmp::{Bmp, Bpp, Header, RawPixel};
+
+let bmp = Bmp::from_slice_raw(include_bytes!("../tests/chessboard-8px-24bit.bmp"))
+    .expect("Failed to parse BMP image");
+
+// Read the BMP header
+assert_eq!(
+    bmp.header,
+    Header {
+        file_size: 314,
+        image_data_start: 122,
+        bpp: Bpp::Bits24,
+        image_width: 8,
+        image_height: 8,
+        image_data_len: 192
+    }
+);
+
+// Check that raw image data slice is the correct length (according to parsed header)
+assert_eq!(bmp.raw_image_data().len(), bmp.header.image_data_len as usize);
+
+// Get an iterator over the pixel coordinates and values in this image and load into a vec
+let pixels: Vec<RawPixel> = bmp.raw_pixels().collect();
+
+// Loaded example image is 8x8px
+assert_eq!(pixels.len(), 8 * 8);
+```
+
+[`embedded-graphics`]: https://crates.io/crates/embedded-graphics
 
 ## License
 

--- a/tinytga/CHANGELOG.md
+++ b/tinytga/CHANGELOG.md
@@ -16,7 +16,7 @@
 - **(breaking)** [#450](https://github.com/jamwaffles/embedded-graphics/pull/450) The `TgaFooter` struct was replaced by the `developer_dictionary` and `extension_area` methods in `RawTga`.
 - **(breaking)** [#430](https://github.com/jamwaffles/embedded-graphics/pull/430) `Tga::width` and `Tga::height` were replaced by `Tga::size` which requires `embedded_graphics::geometry::OriginDimensions` to be in scope (also included in the embedded-graphics `prelude`).
 - **(breaking)** [#430](https://github.com/jamwaffles/embedded-graphics/pull/430) The color map can now be accessed using the new `ColorMap` type.
-- **(breaking)** [#450](https://github.com/jamwaffles/embedded-graphics/pull/450) `Tga` no longer provides direct access to low level information like the TGA header, instead `Tga::raw` can be used to access the underlying `RawTga` instance.
+- **(breaking)** [#450](https://github.com/jamwaffles/embedded-graphics/pull/450) `Tga` no longer provides direct access to low level information like the TGA header, instead `Tga::as_raw` can be used to access the underlying `RawTga` instance.
 
 ### Added
 

--- a/tinytga/CHANGELOG.md
+++ b/tinytga/CHANGELOG.md
@@ -13,19 +13,23 @@
 - **(breaking)** [#430](https://github.com/jamwaffles/embedded-graphics/pull/430) The `graphics` feature was removed and the `embedded-graphics` dependency is now non optional.
 - **(breaking)** [#430](https://github.com/jamwaffles/embedded-graphics/pull/430) `Tga` no longer implements `IntoIterator`. Pixel iterators can now be created using the `pixels` and `raw_pixels` methods.
 - **(breaking)** [#430](https://github.com/jamwaffles/embedded-graphics/pull/430) `Tga::from_slice` now checks that the specified color type matches the bit depth of the image.
-- **(breaking)** [#430](https://github.com/jamwaffles/embedded-graphics/pull/430) The `TgaFooter` struct was replaced by the `raw_developer_dictionary` and `raw_extension_area` methods in `Tga`.
+- **(breaking)** [#450](https://github.com/jamwaffles/embedded-graphics/pull/450) The `TgaFooter` struct was replaced by the `developer_dictionary` and `extension_area` methods in `RawTga`.
 - **(breaking)** [#430](https://github.com/jamwaffles/embedded-graphics/pull/430) `Tga::width` and `Tga::height` were replaced by `Tga::size` which requires `embedded_graphics::geometry::OriginDimensions` to be in scope (also included in the embedded-graphics `prelude`).
 - **(breaking)** [#430](https://github.com/jamwaffles/embedded-graphics/pull/430) The color map can now be accessed using the new `ColorMap` type.
+- **(breaking)** [#450](https://github.com/jamwaffles/embedded-graphics/pull/450) `Tga` no longer provides direct access to low level information like the TGA header, instead `Tga::raw` can be used to access the underlying `RawTga` instance.
 
 ### Added
 
 - [#407](https://github.com/jamwaffles/embedded-graphics/pull/407) Added support for bottom-left origin images to `TgaIterator`.
 - [#430](https://github.com/jamwaffles/embedded-graphics/pull/430) The image ID can now be accessed using `Tga::image_id`.
+- [#450](https://github.com/jamwaffles/embedded-graphics/pull/450) Added `RawTga` to use `tinytga` without using a embedded-graphic color type.
+- [#450](https://github.com/jamwaffles/embedded-graphics/pull/450) Added `Tga::from_raw` to convert a `RawTga` into a `Tga` object.
+- [#450](https://github.com/jamwaffles/embedded-graphics/pull/450) Added `DynamicTga` to allow drawing of TGA images without a known color format at compile time.
 
 ### Fixed
 
 - [#407](https://github.com/jamwaffles/embedded-graphics/pull/407) Additional data in `pixel_data`, beyond `width * height` pixels, is now discarded by `TgaIterator`.
-- [#430](https://github.com/jamwaffles/embedded-graphics/pull/430) Images with unsupported BPP values in the header no longer cause panics. Instead an error is returned by `from_slice`.
+- [#430](https://github.com/jamwaffles/embedded-graphics/pull/430) Images with unsupported BPP values in the header no longer cause panics. Instead an error is returned by `Tga::from_slice`.
 - [#430](https://github.com/jamwaffles/embedded-graphics/pull/430) Errors during the execution of a pixel iterator no longer cause panics. Instead the corrupted portion of the image is filled with black pixels.
 
 ## [0.3.2] - 2020-03-20

--- a/tinytga/README.md
+++ b/tinytga/README.md
@@ -7,7 +7,7 @@
 
 ## [Documentation](https://docs.rs/tinytga)
 
-A small TGA parser designed for use with [embedded-graphics] targetting no-std environments but
+A small TGA parser designed for use with [embedded-graphics] targeting no-std environments but
 usable anywhere. Beyond parsing the image header, no other allocations are made.
 
 tinytga provides two methods of accessing the pixel data inside a TGA file. The most convenient
@@ -16,7 +16,53 @@ the TGA file. But it is also possible to directly access the raw pixel represent
 
 ## Examples
 
-### Load a Run Length Encoded (RLE) TGA image
+### Using `Tga` to draw an image
+
+This example demonstrates how a TGA image can be drawn to a [embedded-graphics] draw target.
+
+The code uses the `Tga` struct and only works if the color format inside the TGA file is known
+at compile time. While this makes the code less flexible it offers the best performance by
+making sure that no unnecessary color conversions are used.
+
+```rust
+use embedded_graphics::{image::Image, pixelcolor::Rgb888, prelude::*};
+use tinytga::Tga;
+
+// Include an image from a local path as bytes
+let data = include_bytes!("../tests/chessboard_4px_rle.tga");
+
+let tga: Tga<Rgb888> = Tga::from_slice(data).unwrap();
+
+let image = Image::new(&tga, Point::zero());
+
+image.draw(&mut display)?;
+```
+
+### Using `DynamicTga` to draw an image
+
+The previous example had the limitation that the color format needed to be known at compile
+time. In some use cases this can be a problem, for example if user supplied images should
+be displayed. To handle these cases `DynamicTga` can be used, which performs color conversion
+if necessary.
+
+```rust
+use embedded_graphics::{image::Image, pixelcolor::Rgb888, prelude::*};
+use tinytga::DynamicTga;
+
+// Include an image from a local path as bytes
+let data = include_bytes!("../tests/chessboard_4px_rle.tga");
+
+let tga = DynamicTga::from_slice(data).unwrap();
+
+let image = Image::new(&tga, Point::zero());
+
+image.draw(&mut display)?;
+```
+### Accessing pixels using an embedded-graphics color type
+
+Even if tinytga is used without using [embedded-graphics] to draw the image the color types
+provided by [embedded-graphics] can still be used to access the pixel data using the
+`pixels` method.
 
 ```rust
 use embedded_graphics::{prelude::*, pixelcolor::Rgb888};
@@ -36,41 +82,25 @@ assert_eq!(img.size(), Size::new(4, 4));
 let pixels: Vec<_> = img.pixels().collect();
 ```
 
-### Drawing an image using `embedded-graphics`
-
-This example demonstrates how a TGA image can be drawn to a [embedded-graphics] draw target.
-
-```rust
-use embedded_graphics::{image::Image, pixelcolor::Rgb888, prelude::*};
-use tinytga::Tga;
-
-// Include an image from a local path as bytes
-let data = include_bytes!("../tests/chessboard_4px_rle.tga");
-let tga: Tga<Rgb888> = Tga::from_slice(data).unwrap();
-
-let image = Image::new(&tga, Point::zero());
-
-image.draw(&mut display)?;
-```
-
 ### Accessing raw pixel data
 
 If you do not want to use the color types provided by [embedded-graphics] you can also access
-the raw image data.
+the raw image data. The iterator returned by the `pixels`
+method uses `u32` values to return the raw color value of each pixel.
 
 ```rust
 use embedded_graphics::{prelude::*, pixelcolor::Rgb888};
-use tinytga::{Bpp, ImageOrigin, ImageType, RawPixel, Tga, TgaHeader};
+use tinytga::{Bpp, ImageOrigin, ImageType, RawPixel, RawTga, TgaHeader};
 
 // Include an image from a local path as bytes.
 let data = include_bytes!("../tests/chessboard_4px_rle.tga");
 
 // Create a TGA instance from a byte slice.
-let img = Tga::from_slice_raw(data).unwrap();
+let img = RawTga::from_slice(data).unwrap();
 
 // Take a look at the raw image header.
 assert_eq!(
-    img.raw_header(),
+    img.header(),
     TgaHeader {
         id_len: 0,
         has_color_map: false,
@@ -89,10 +119,13 @@ assert_eq!(
 );
 
 // Collect raw pixels into a vector.
-let pixels: Vec<_> = img.raw_pixels().collect();
+let pixels: Vec<_> = img.pixels().collect();
 ```
 
 ## Embedded-graphics drawing performance
+
+`Tga` should by used instead of `DynamicTga` when possible to reduce the risk of
+accidentally adding unnecessary color conversions.
 
 `tinytga` uses different code paths to draw images with different `ImageOrigin` .
 The performance difference between the origins will depend on the display driver, but using

--- a/tinytga/README.md
+++ b/tinytga/README.md
@@ -60,8 +60,8 @@ image.draw(&mut display)?;
 ```
 ### Accessing pixels using an embedded-graphics color type
 
-Even if tinytga is used without using [embedded-graphics] to draw the image the color types
-provided by [embedded-graphics] can still be used to access the pixel data using the
+If [embedded-graphics] is not used to draw the TGA image, the color types provided by
+[embedded-graphics] can still be used to access the pixel data using the
 `pixels` method.
 
 ```rust
@@ -84,9 +84,9 @@ let pixels: Vec<_> = img.pixels().collect();
 
 ### Accessing raw pixel data
 
-If you do not want to use the color types provided by [embedded-graphics] you can also access
-the raw image data. The iterator returned by the `pixels`
-method uses `u32` values to return the raw color value of each pixel.
+If [embedded-graphics] is not used in the target application, the raw image data can be
+accessed with the `pixels` method on
+`RawTga`  The returned iterator produces a `u32` for each pixel value.
 
 ```rust
 use embedded_graphics::{prelude::*, pixelcolor::Rgb888};

--- a/tinytga/src/dynamic_tga.rs
+++ b/tinytga/src/dynamic_tga.rs
@@ -1,0 +1,92 @@
+use core::marker::PhantomData;
+use embedded_graphics::{
+    pixelcolor::{Gray8, Rgb555, Rgb888},
+    prelude::*,
+};
+
+use crate::{parse_error::ParseError, raw_tga::RawTga, Bpp};
+
+/// Dynamic TGA image.
+///
+/// `DynamicTga` can be used to draw images that don't have a known color type
+/// at compile time, for example user supplied images. If the color type is
+/// known at compile time consider using the [`Tga`] for improved performance.
+///
+/// `DynamicTga` works with all draw targets that use a color type that implements
+/// `From` for `Gray8`, `Rgb555` and `Rgb888`.
+///
+/// [`Tga`]: struct.Tga.html
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+pub struct DynamicTga<'a, C> {
+    raw: RawTga<'a>,
+    color_type: ColorType,
+    target_color_type: PhantomData<C>,
+}
+
+impl<'a, C> DynamicTga<'a, C>
+where
+    C: PixelColor + From<Gray8> + From<Rgb555> + From<Rgb888>,
+{
+    /// Parses a TGA image from a byte slice.
+    pub fn from_slice(data: &'a [u8]) -> Result<Self, ParseError> {
+        let raw = RawTga::from_slice(data)?;
+
+        let color_type = match (raw.color_bpp(), raw.image_type().is_monochrome()) {
+            (Bpp::Bits8, true) => ColorType::Gray8,
+            (Bpp::Bits16, false) => ColorType::Rgb555,
+            (Bpp::Bits24, false) => ColorType::Rgb888,
+            _ => {
+                return Err(ParseError::UnsupportedDynamicTgaType(
+                    raw.image_type(),
+                    raw.color_bpp(),
+                ))
+            }
+        };
+
+        Ok(Self {
+            raw,
+            color_type,
+            target_color_type: PhantomData,
+        })
+    }
+
+    /// Returns a reference to the raw TGA image.
+    ///
+    /// The [`RawTga`] object can be used to access lower level details about the TGA file.
+    ///
+    /// [`RawTga`]: struct.RawTga.html
+    pub fn raw(&self) -> &RawTga<'a> {
+        &self.raw
+    }
+}
+
+impl<C> OriginDimensions for DynamicTga<'_, C> {
+    fn size(&self) -> Size {
+        self.raw.size()
+    }
+}
+
+impl<C> ImageDrawable for DynamicTga<'_, C>
+where
+    C: PixelColor + From<Gray8> + From<Rgb555> + From<Rgb888>,
+{
+    type Color = C;
+
+    fn draw<D>(&self, target: &mut D) -> Result<(), D::Error>
+    where
+        D: DrawTarget<Color = Self::Color>,
+    {
+        match self.color_type {
+            ColorType::Gray8 => self.raw.draw(&mut target.convert_color::<Gray8>()),
+            ColorType::Rgb555 => self.raw.draw(&mut target.convert_color::<Rgb555>()),
+            ColorType::Rgb888 => self.raw.draw(&mut target.convert_color::<Rgb888>()),
+        }
+    }
+}
+
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+enum ColorType {
+    Gray8,
+    Rgb555,
+    Rgb888,
+}

--- a/tinytga/src/dynamic_tga.rs
+++ b/tinytga/src/dynamic_tga.rs
@@ -55,7 +55,7 @@ where
     /// The [`RawTga`] object can be used to access lower level details about the TGA file.
     ///
     /// [`RawTga`]: struct.RawTga.html
-    pub fn raw(&self) -> &RawTga<'a> {
+    pub fn as_raw(&self) -> &RawTga<'a> {
         &self.raw
     }
 }

--- a/tinytga/src/dynamic_tga.rs
+++ b/tinytga/src/dynamic_tga.rs
@@ -77,9 +77,9 @@ where
         D: DrawTarget<Color = Self::Color>,
     {
         match self.color_type {
-            ColorType::Gray8 => self.raw.draw(&mut target.convert_color::<Gray8>()),
-            ColorType::Rgb555 => self.raw.draw(&mut target.convert_color::<Rgb555>()),
-            ColorType::Rgb888 => self.raw.draw(&mut target.convert_color::<Rgb888>()),
+            ColorType::Gray8 => self.raw.draw(&mut target.color_converted::<Gray8>()),
+            ColorType::Rgb555 => self.raw.draw(&mut target.color_converted::<Rgb555>()),
+            ColorType::Rgb888 => self.raw.draw(&mut target.color_converted::<Rgb888>()),
         }
     }
 }

--- a/tinytga/src/header.rs
+++ b/tinytga/src/header.rs
@@ -105,6 +105,14 @@ impl ImageType {
             _ => false,
         }
     }
+
+    /// Returns `true` when the image is monochrome.
+    pub fn is_monochrome(self) -> bool {
+        match self {
+            ImageType::Monochrome | ImageType::RleMonochrome => true,
+            _ => false,
+        }
+    }
 }
 
 /// Image origin
@@ -138,7 +146,9 @@ impl ImageOrigin {
     }
 }
 
-/// TGA header structure, referenced from <https://www.fileformat.info/format/tga/egff.htm>
+/// TGA header.
+///
+/// See <https://www.fileformat.info/format/tga/egff.htm> for a detailed description of the fields.
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub struct TgaHeader {
     /// Image ID field length

--- a/tinytga/src/lib.rs
+++ b/tinytga/src/lib.rs
@@ -57,8 +57,8 @@
 //! ```
 //! ## Accessing pixels using an embedded-graphics color type
 //!
-//! Even if tinytga is used without using [embedded-graphics] to draw the image the color types
-//! provided by [embedded-graphics] can still be used to access the pixel data using the
+//! If [embedded-graphics] is not used to draw the TGA image, the color types provided by 
+//! [embedded-graphics] can still be used to access the pixel data using the 
 //! [`pixels`](struct.Tga.html#method.pixels) method.
 //!
 //! ```rust

--- a/tinytga/src/lib.rs
+++ b/tinytga/src/lib.rs
@@ -57,8 +57,8 @@
 //! ```
 //! ## Accessing pixels using an embedded-graphics color type
 //!
-//! If [embedded-graphics] is not used to draw the TGA image, the color types provided by 
-//! [embedded-graphics] can still be used to access the pixel data using the 
+//! If [embedded-graphics] is not used to draw the TGA image, the color types provided by
+//! [embedded-graphics] can still be used to access the pixel data using the
 //! [`pixels`](struct.Tga.html#method.pixels) method.
 //!
 //! ```rust
@@ -221,7 +221,7 @@ where
     /// The [`RawTga`] object can be used to access lower level details about the TGA file.
     ///
     /// [`RawTga`]: struct.RawTga.html
-    pub fn raw(&self) -> &RawTga<'a> {
+    pub fn as_raw(&self) -> &RawTga<'a> {
         &self.raw
     }
 

--- a/tinytga/src/lib.rs
+++ b/tinytga/src/lib.rs
@@ -81,9 +81,9 @@
 //!
 //! ## Accessing raw pixel data
 //!
-//! If you do not want to use the color types provided by [embedded-graphics] you can also access
-//! the raw image data. The iterator returned by the [`pixels`](struct.RawTga.html#method.pixels)
-//! method uses `u32` values to return the raw color value of each pixel.
+//! If [embedded-graphics] is not used in the target application, the raw image data can be
+//! accessed with the [`pixels`](struct.RawTga.html#method.pixels) method on
+//! [`RawTga`]. The returned iterator produces a `u32` for each pixel value.
 //!
 //! ```rust
 //! use embedded_graphics::{prelude::*, pixelcolor::Rgb888};
@@ -131,6 +131,7 @@
 //! [`ImageOrigin`]: enum.ImageOrigin.html
 //! [embedded-graphics]: https://docs.rs/embedded-graphics
 //! [`Tga`]: ./struct.Tga.html
+//! [`RawTga`]: ./struct.RawTga.html
 //! [`DynamicTga`]: ./struct.DynamicTga.html
 //! [`image_type`]: ./struct.TgaHeader.html#structfield.image_type
 //! [`pixel_data`]: ./struct.Tga.html#structfield.pixel_data

--- a/tinytga/src/parse_error.rs
+++ b/tinytga/src/parse_error.rs
@@ -1,3 +1,5 @@
+use crate::header::{Bpp, ImageType};
+
 /// Possible parse errors
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 #[non_exhaustive]
@@ -24,4 +26,7 @@ pub enum ParseError {
     ///
     /// [`Tga::from_slice`]: struct.Tga.html#method.from_slice
     MismatchedBpp(u8),
+
+    /// The image type and bits per pixel combination isn't supported by `DynamicTga`.
+    UnsupportedDynamicTgaType(ImageType, Bpp),
 }

--- a/tinytga/src/pixels.rs
+++ b/tinytga/src/pixels.rs
@@ -1,15 +1,25 @@
-use crate::RawPixels;
+use core::marker::PhantomData;
 use embedded_graphics::prelude::*;
 
-/// Iterator over individual TGA pixels
+use crate::RawPixels;
+
+/// Iterator over individual TGA pixels.
+///
+/// See the [`pixels`] method for additional information.
+///
+/// [`pixels`]: struct.Tga.html#method.pixels
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub struct Pixels<'a, 'b, C> {
-    raw: RawPixels<'a, 'b, C>,
+    raw: RawPixels<'a, 'b>,
+    color_type: PhantomData<C>,
 }
 
 impl<'a, 'b, C> Pixels<'a, 'b, C> {
-    pub(crate) fn new(raw: RawPixels<'a, 'b, C>) -> Self {
-        Self { raw }
+    pub(crate) fn new(raw: RawPixels<'a, 'b>) -> Self {
+        Self {
+            raw,
+            color_type: PhantomData,
+        }
     }
 }
 

--- a/tinytga/src/raw_tga.rs
+++ b/tinytga/src/raw_tga.rs
@@ -1,0 +1,205 @@
+use embedded_graphics::{prelude::*, primitives::Rectangle};
+use nom::{bytes::complete::take, IResult};
+
+use crate::{
+    color_map::ColorMap,
+    footer::TgaFooter,
+    header::{Bpp, ImageOrigin, ImageType, TgaHeader},
+    parse_error::ParseError,
+    pixels::Pixels,
+    raw_pixels::RawPixels,
+};
+
+/// Raw TGA image.
+///
+/// `RawTga` can be used to access lower level information about a TGA file and to access the
+/// raw pixel data. It can be created directly by using the [`from_slice`] constructor or accessed
+/// by calling [`raw`] method of a [`Tga`] object.
+///
+/// [`from_slice`]: #method.from_slice
+/// [`Tga`]: struct.Tga.html
+/// [`raw`]: struct.Tga.html#method.raw
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+pub struct RawTga<'a> {
+    /// Image data
+    data: &'a [u8],
+
+    /// Color map
+    color_map: Option<ColorMap<'a>>,
+
+    /// Image pixel data
+    pixel_data: &'a [u8],
+
+    /// Image size
+    size: Size,
+
+    /// Image type
+    image_type: ImageType,
+
+    /// Bits per pixel
+    bpp: Bpp,
+
+    /// Image origin
+    image_origin: ImageOrigin,
+}
+
+impl<'a> RawTga<'a> {
+    /// Parse a TGA image from a byte slice.
+    pub fn from_slice(data: &'a [u8]) -> Result<Self, ParseError> {
+        let input = data;
+        let (input, header) = TgaHeader::parse(input).map_err(|_| ParseError::Header)?;
+        let (input, _image_id) = parse_image_id(input, &header).map_err(|_| ParseError::Header)?;
+        let (input, color_map) = ColorMap::parse(input, &header)?;
+
+        let footer_length = TgaFooter::parse(data).map_or(0, |footer| footer.length(data));
+
+        // Use saturating_sub to make sure this can't panic
+        let pixel_data = &input[0..input.len().saturating_sub(footer_length)];
+
+        let size = Size::new(u32::from(header.width), u32::from(header.height));
+
+        Ok(Self {
+            data,
+            color_map,
+            pixel_data,
+            size,
+            bpp: header.pixel_depth,
+            image_origin: header.image_origin,
+            image_type: header.image_type,
+        })
+    }
+
+    /// Returns the dimensions of this image.
+    pub fn size(&self) -> Size {
+        self.size
+    }
+
+    /// Returns the color map.
+    ///
+    /// `None` is returned if the image contains no color map.
+    pub fn color_map(&self) -> Option<&ColorMap<'a>> {
+        self.color_map.as_ref()
+    }
+
+    /// Returns the color bit depth (BPP) of this image.
+    ///
+    /// This function always returns the bit depth of the decoded pixels, regardless of how they are
+    /// stored in the TGA file. Use [`image_data_bpp`] to get the number of bits used to store one
+    /// pixel in the image data.
+    ///
+    /// [`image_data_bpp`]: #method.image_data_bpp
+    pub fn color_bpp(&self) -> Bpp {
+        if let Some(color_map) = &self.color_map {
+            color_map.entry_bpp()
+        } else {
+            self.bpp
+        }
+    }
+
+    /// Returns the image origin.
+    pub fn image_origin(&self) -> ImageOrigin {
+        self.image_origin
+    }
+
+    /// Returns the image type.
+    pub fn image_type(&self) -> ImageType {
+        self.image_type
+    }
+
+    /// Returns the raw image data contained in this image.
+    pub fn image_data(&self) -> &'a [u8] {
+        self.pixel_data
+    }
+
+    /// Returns the size of a single pixel in bits.
+    ///
+    /// This function returns the number of bits used to store a single pixel in the image data.
+    ///
+    /// For true color and grayscale images, where the colors are stored directly in the image data,
+    /// the returned value will match the value returned by [`color_bpp`].
+    ///
+    /// For color mapped images, where the image data consists of color indices, the returned value
+    /// describes the bit depth of the indices and may differ from the depth returned by
+    /// [`color_bpp`].
+    ///
+    /// [`color_bpp`]: #method.color_bpp
+    pub fn image_data_bpp(&self) -> Bpp {
+        self.bpp
+    }
+
+    /// Returns an iterator over the raw pixels in this image.
+    pub fn pixels<'b>(&'b self) -> RawPixels<'b, 'a> {
+        RawPixels::new(self)
+    }
+
+    /// Returns the TGA header.
+    ///
+    /// The returned object is a direct representation of the header contained
+    /// in the TGA file. Most of the information contained in the header is also
+    /// available using other methods, which are the preferred way of accessing
+    /// them.
+    ///
+    /// # Performance
+    ///
+    /// To save memory the header is parsed every time this method is called.
+    pub fn header(&self) -> TgaHeader {
+        // unwrap can't fail because the header was checked when self was created
+        TgaHeader::parse(self.data).unwrap().1
+    }
+
+    /// Returns the developer directory.
+    ///
+    /// # Performance
+    ///
+    /// To save memory the footer is parsed every time this method is called.
+    pub fn developer_directory(&self) -> Option<&[u8]> {
+        TgaFooter::parse(self.data).and_then(|footer| footer.developer_directory(self.data))
+    }
+
+    /// Returns the extension area.
+    ///
+    /// # Performance
+    ///
+    /// To save memory the footer is parsed every time this method is called.
+    pub fn extension_area(&self) -> Option<&[u8]> {
+        TgaFooter::parse(self.data).and_then(|footer| footer.extension_area(self.data))
+    }
+
+    /// Returns the content of the image ID.
+    ///
+    /// If the TGA file doesn't contain an image ID `None` is returned.
+    ///
+    /// # Performance
+    ///
+    /// To save memory the header is parsed every time this method is called.
+    pub fn image_id(&self) -> Option<&[u8]> {
+        let (input, header) = TgaHeader::parse(self.data).ok()?;
+
+        parse_image_id(input, &header)
+            .ok()
+            .map(|(_input, id)| id)
+            .filter(|id| !id.is_empty())
+    }
+
+    pub(crate) fn draw<D>(&self, target: &mut D) -> Result<(), D::Error>
+    where
+        D: DrawTarget,
+        D::Color: From<<D::Color as PixelColor>::Raw>,
+    {
+        let pixels = Pixels::<D::Color>::new(self.pixels());
+
+        // TGA files with the origin in the top left corner can be drawn using `fill_contiguous`.
+        // All other origins are drawn by falling back to `draw_iter`.
+        if self.image_origin() == ImageOrigin::TopLeft {
+            let bounding_box = Rectangle::new(Point::zero(), self.size);
+
+            target.fill_contiguous(&bounding_box, pixels.map(|Pixel(_, color)| color))
+        } else {
+            target.draw_iter(pixels)
+        }
+    }
+}
+
+fn parse_image_id<'a>(input: &'a [u8], header: &TgaHeader) -> IResult<&'a [u8], &'a [u8]> {
+    take(header.id_len)(input)
+}

--- a/tinytga/tests/cbw8.rs
+++ b/tinytga/tests/cbw8.rs
@@ -1,16 +1,16 @@
-use tinytga::{Bpp, ImageOrigin, ImageType, Tga, TgaHeader};
+use tinytga::{Bpp, ImageOrigin, ImageType, RawTga, TgaHeader};
 
 #[test]
 fn cbw8() {
     let data = include_bytes!("./cbw8.tga");
 
-    let img = Tga::from_slice_raw(data).unwrap();
+    let img = RawTga::from_slice(data).unwrap();
 
-    println!("{:#?}", img.raw_header());
-    println!("Raw image data len {:#?}", img.raw_image_data().len());
+    println!("{:#?}", img.header());
+    println!("Raw image data len {:#?}", img.image_data().len());
 
     assert_eq!(
-        img.raw_header(),
+        img.header(),
         TgaHeader {
             id_len: 26,
             has_color_map: false,
@@ -30,12 +30,12 @@ fn cbw8() {
 
     const TGA_FOOTER_LENGTH: usize = 26;
     assert_eq!(
-        img.raw_extension_area(),
+        img.extension_area(),
         Some(&data[8238..data.len() - TGA_FOOTER_LENGTH])
     );
-    assert_eq!(img.raw_developer_directory(), None);
+    assert_eq!(img.developer_directory(), None);
 
-    let pixels = img.raw_pixels().collect::<Vec<_>>();
+    let pixels = img.pixels().collect::<Vec<_>>();
 
     assert_eq!(pixels.len(), 128 * 128);
 }

--- a/tinytga/tests/chequerboard-uncompressed-topleft.rs
+++ b/tinytga/tests/chequerboard-uncompressed-topleft.rs
@@ -1,20 +1,20 @@
-use tinytga::{Bpp, ImageOrigin, ImageType, Tga, TgaHeader};
+use tinytga::{Bpp, ImageOrigin, ImageType, RawTga, TgaHeader};
 
 #[test]
 fn chequerboard_uncompressed_topleft() {
     let data = include_bytes!("./chequerboard-uncompressed-topleft.tga");
 
-    let img = Tga::from_slice_raw(data).unwrap();
+    let img = RawTga::from_slice(data).unwrap();
 
-    println!("{:#?}", img.raw_header());
-    println!("Raw image data len {:#?}", img.raw_image_data().len());
+    println!("{:#?}", img.header());
+    println!("Raw image data len {:#?}", img.image_data().len());
 
-    let header = img.raw_header();
+    let header = img.header();
     let image_data_len = header.width * header.height * header.pixel_depth.bytes() as u16;
 
     // Source image is 8x8px, uncompressed, 8BPP color
     assert_eq!(
-        img.raw_header(),
+        img.header(),
         TgaHeader {
             id_len: 0,
             has_color_map: false,
@@ -33,8 +33,8 @@ fn chequerboard_uncompressed_topleft() {
     );
 
     // Footer is empty for this image
-    assert_eq!(img.raw_extension_area(), None);
-    assert_eq!(img.raw_developer_directory(), None);
+    assert_eq!(img.extension_area(), None);
+    assert_eq!(img.developer_directory(), None);
 
-    assert_eq!(img.raw_image_data().len(), image_data_len as usize);
+    assert_eq!(img.image_data().len(), image_data_len as usize);
 }

--- a/tinytga/tests/chessboard_4px_raw.rs
+++ b/tinytga/tests/chessboard_4px_raw.rs
@@ -1,17 +1,17 @@
-use tinytga::{Bpp, ImageOrigin, ImageType, Tga, TgaHeader};
+use tinytga::{Bpp, ImageOrigin, ImageType, RawTga, TgaHeader};
 
 #[test]
 fn chessboard_4px_raw() {
     let data = include_bytes!("./chessboard_4px_raw.tga");
 
-    let img = Tga::from_slice_raw(data).unwrap();
+    let img = RawTga::from_slice(data).unwrap();
 
-    println!("{:#?}", img.raw_header());
-    println!("Raw image data len {:#?}", img.raw_image_data().len());
-    println!("Raw image data {:#?}", img.raw_image_data());
+    println!("{:#?}", img.header());
+    println!("Raw image data len {:#?}", img.image_data().len());
+    println!("Raw image data {:#?}", img.image_data());
 
     assert_eq!(
-        img.raw_header(),
+        img.header(),
         TgaHeader {
             id_len: 0,
             has_color_map: false,
@@ -29,10 +29,10 @@ fn chessboard_4px_raw() {
         }
     );
 
-    assert_eq!(img.raw_extension_area(), None);
-    assert_eq!(img.raw_developer_directory(), None);
+    assert_eq!(img.extension_area(), None);
+    assert_eq!(img.developer_directory(), None);
 
-    let pixels = img.raw_pixels().map(|p| p.color).collect::<Vec<u32>>();
+    let pixels = img.pixels().map(|p| p.color).collect::<Vec<u32>>();
 
     dbg!(&pixels);
 

--- a/tinytga/tests/chessboard_4px_rle.rs
+++ b/tinytga/tests/chessboard_4px_rle.rs
@@ -1,17 +1,17 @@
-use tinytga::{Bpp, ImageOrigin, ImageType, Tga, TgaHeader};
+use tinytga::{Bpp, ImageOrigin, ImageType, RawTga, TgaHeader};
 
 #[test]
 fn chessboard_4px_rle() {
     let data = include_bytes!("./chessboard_4px_rle.tga");
 
-    let img = Tga::from_slice_raw(data).unwrap();
+    let img = RawTga::from_slice(data).unwrap();
 
-    println!("{:#?}", img.raw_header());
-    println!("Raw image data len {:#?}", img.raw_image_data().len());
-    println!("Raw image data {:#?}", img.raw_image_data());
+    println!("{:#?}", img.header());
+    println!("Raw image data len {:#?}", img.image_data().len());
+    println!("Raw image data {:#?}", img.image_data());
 
     assert_eq!(
-        img.raw_header(),
+        img.header(),
         TgaHeader {
             id_len: 0,
             has_color_map: false,
@@ -29,10 +29,10 @@ fn chessboard_4px_rle() {
         }
     );
 
-    assert_eq!(img.raw_extension_area(), None);
-    assert_eq!(img.raw_developer_directory(), None);
+    assert_eq!(img.extension_area(), None);
+    assert_eq!(img.developer_directory(), None);
 
-    let pixels = img.raw_pixels().map(|p| p.color).collect::<Vec<u32>>();
+    let pixels = img.pixels().map(|p| p.color).collect::<Vec<u32>>();
 
     // dbg!(&pixels);
 

--- a/tinytga/tests/chessboard_rle.rs
+++ b/tinytga/tests/chessboard_rle.rs
@@ -1,17 +1,17 @@
-use tinytga::{Bpp, ImageOrigin, ImageType, Tga, TgaHeader};
+use tinytga::{Bpp, ImageOrigin, ImageType, RawTga, TgaHeader};
 
 #[test]
 fn chessboard_rle() {
     let data = include_bytes!("./chessboard_rle.tga");
 
-    let img = Tga::from_slice_raw(data).unwrap();
+    let img = RawTga::from_slice(data).unwrap();
 
-    println!("{:#?}", img.raw_header());
-    println!("Raw image data len {:#?}", img.raw_image_data().len());
-    println!("Raw image data {:#?}", img.raw_image_data());
+    println!("{:#?}", img.header());
+    println!("Raw image data len {:#?}", img.image_data().len());
+    println!("Raw image data {:#?}", img.image_data());
 
     assert_eq!(
-        img.raw_header(),
+        img.header(),
         TgaHeader {
             id_len: 0,
             has_color_map: false,
@@ -29,10 +29,10 @@ fn chessboard_rle() {
         }
     );
 
-    assert_eq!(img.raw_extension_area(), None);
-    assert_eq!(img.raw_developer_directory(), None);
+    assert_eq!(img.extension_area(), None);
+    assert_eq!(img.developer_directory(), None);
 
-    let pixels = img.raw_pixels().map(|p| p.color).collect::<Vec<u32>>();
+    let pixels = img.pixels().map(|p| p.color).collect::<Vec<u32>>();
 
     dbg!(&pixels);
 

--- a/tinytga/tests/chessboard_uncompressed.rs
+++ b/tinytga/tests/chessboard_uncompressed.rs
@@ -1,17 +1,17 @@
-use tinytga::{Bpp, ImageOrigin, ImageType, Tga, TgaHeader};
+use tinytga::{Bpp, ImageOrigin, ImageType, RawTga, TgaHeader};
 
 #[test]
 fn chessboard_uncompressed() {
     let data = include_bytes!("./chessboard_uncompressed.tga");
 
-    let img = Tga::from_slice_raw(data).unwrap();
+    let img = RawTga::from_slice(data).unwrap();
 
-    println!("{:#?}", img.raw_header());
-    println!("Raw image data len {:#?}", img.raw_image_data().len());
-    println!("Raw image data {:#?}", img.raw_image_data());
+    println!("{:#?}", img.header());
+    println!("Raw image data len {:#?}", img.image_data().len());
+    println!("Raw image data {:#?}", img.image_data());
 
     assert_eq!(
-        img.raw_header(),
+        img.header(),
         TgaHeader {
             id_len: 0,
             has_color_map: false,
@@ -29,10 +29,10 @@ fn chessboard_uncompressed() {
         }
     );
 
-    assert_eq!(img.raw_extension_area(), None);
-    assert_eq!(img.raw_developer_directory(), None);
+    assert_eq!(img.extension_area(), None);
+    assert_eq!(img.developer_directory(), None);
 
-    let pixels = img.raw_pixels().map(|p| p.color).collect::<Vec<u32>>();
+    let pixels = img.pixels().map(|p| p.color).collect::<Vec<u32>>();
 
     assert_eq!(pixels.len(), 8 * 8);
     assert_eq!(

--- a/tinytga/tests/coordinates.rs
+++ b/tinytga/tests/coordinates.rs
@@ -1,18 +1,18 @@
 use embedded_graphics::prelude::*;
-use tinytga::{Bpp, ImageOrigin, ImageType, Tga, TgaHeader};
+use tinytga::{Bpp, ImageOrigin, ImageType, RawTga, TgaHeader};
 
 #[test]
 fn coordinates() {
     let data = include_bytes!("./chessboard_4px_raw.tga");
 
-    let img = Tga::from_slice_raw(data).unwrap();
+    let img = RawTga::from_slice(data).unwrap();
 
-    println!("{:#?}", img.raw_header());
-    println!("Raw image data len {:#?}", img.raw_image_data().len());
-    println!("Raw image data {:#?}", img.raw_image_data());
+    println!("{:#?}", img.header());
+    println!("Raw image data len {:#?}", img.image_data().len());
+    println!("Raw image data {:#?}", img.image_data());
 
     assert_eq!(
-        img.raw_header(),
+        img.header(),
         TgaHeader {
             id_len: 0,
             has_color_map: false,
@@ -30,10 +30,10 @@ fn coordinates() {
         }
     );
 
-    assert_eq!(img.raw_extension_area(), None);
-    assert_eq!(img.raw_developer_directory(), None);
+    assert_eq!(img.extension_area(), None);
+    assert_eq!(img.developer_directory(), None);
 
-    let coords: Vec<_> = img.raw_pixels().map(|p| p.position).collect();
+    let coords: Vec<_> = img.pixels().map(|p| p.position).collect();
 
     assert_eq!(coords.len(), 4 * 4);
     assert_eq!(

--- a/tinytga/tests/image_id.rs
+++ b/tinytga/tests/image_id.rs
@@ -1,11 +1,11 @@
-use tinytga::Tga;
+use tinytga::RawTga;
 
 #[test]
 fn has_image_id() {
     // image_id.tga contains the image ID: "e-g"
     let data = include_bytes!("./image_id.tga");
 
-    let img = Tga::from_slice_raw(data).unwrap();
+    let img = RawTga::from_slice(data).unwrap();
 
     assert_eq!(img.image_id(), Some("e-g".as_bytes()));
 }
@@ -15,7 +15,7 @@ fn no_image_id() {
     // type1_24bpp_bl.tga does not contain an image ID
     let data = include_bytes!("./type1_24bpp_bl.tga");
 
-    let img = Tga::from_slice_raw(data).unwrap();
+    let img = RawTga::from_slice(data).unwrap();
 
     assert_eq!(img.image_id(), None);
 }

--- a/tinytga/tests/issue_216.rs
+++ b/tinytga/tests/issue_216.rs
@@ -1,12 +1,16 @@
-use tinytga::Tga;
+use tinytga::RawTga;
 
+/// Test for issue #216
+///
+/// RLE compressed images caused an integer overflow if `number_of_pixels * bytes_per_pixel` in a
+/// RLE packet was larger than 255.
 #[test]
 fn issue_216() {
-    let uncompressed = Tga::from_slice_raw(include_bytes!("issue_216_uncompressed.tga")).unwrap();
-    let compressed = Tga::from_slice_raw(include_bytes!("issue_216_compressed.tga")).unwrap();
+    let uncompressed = RawTga::from_slice(include_bytes!("issue_216_uncompressed.tga")).unwrap();
+    let compressed = RawTga::from_slice(include_bytes!("issue_216_compressed.tga")).unwrap();
 
-    let uncompressed_header = uncompressed.raw_header();
-    let compressed_header = uncompressed.raw_header();
+    let uncompressed_header = uncompressed.header();
+    let compressed_header = uncompressed.header();
 
     assert_eq!(uncompressed_header.width, compressed_header.width);
     assert_eq!(uncompressed_header.height, compressed_header.height);
@@ -15,5 +19,5 @@ fn issue_216() {
         compressed_header.pixel_depth
     );
 
-    assert!(uncompressed.raw_pixels().eq(compressed.raw_pixels()));
+    assert!(uncompressed.pixels().eq(compressed.pixels()));
 }

--- a/tinytga/tests/types.rs
+++ b/tinytga/tests/types.rs
@@ -1,4 +1,4 @@
-use tinytga::{Bpp, ImageOrigin, ImageType, Tga, TgaHeader};
+use tinytga::{Bpp, ImageOrigin, ImageType, RawTga, TgaHeader};
 
 const HEADER_DEFAULT: TgaHeader = TgaHeader {
     id_len: 0,
@@ -18,10 +18,10 @@ const HEADER_DEFAULT: TgaHeader = TgaHeader {
 
 #[test]
 fn type1_16bpp_bl() {
-    let tga = Tga::from_slice_raw(include_bytes!("../tests/type1_16bpp_bl.tga")).unwrap();
+    let tga = RawTga::from_slice(include_bytes!("../tests/type1_16bpp_bl.tga")).unwrap();
 
     assert_eq!(
-        tga.raw_header(),
+        tga.header(),
         TgaHeader {
             has_color_map: true,
             image_type: ImageType::ColorMapped,
@@ -31,17 +31,19 @@ fn type1_16bpp_bl() {
             ..HEADER_DEFAULT
         }
     );
-    assert_eq!(tga.raw_developer_directory(), None);
-    assert_eq!(tga.raw_extension_area(), None);
+    assert_eq!(tga.developer_directory(), None);
+    assert_eq!(tga.extension_area(), None);
+
     assert_eq!(tga.color_bpp(), Bpp::Bits16);
+    assert_eq!(tga.image_data_bpp(), Bpp::Bits8);
 }
 
 #[test]
 fn type1_24bpp_bl() {
-    let tga = Tga::from_slice_raw(include_bytes!("../tests/type1_24bpp_bl.tga")).unwrap();
+    let tga = RawTga::from_slice(include_bytes!("../tests/type1_24bpp_bl.tga")).unwrap();
 
     assert_eq!(
-        tga.raw_header(),
+        tga.header(),
         TgaHeader {
             has_color_map: true,
             image_type: ImageType::ColorMapped,
@@ -51,17 +53,19 @@ fn type1_24bpp_bl() {
             ..HEADER_DEFAULT
         }
     );
-    assert_eq!(tga.raw_developer_directory(), None);
-    assert_eq!(tga.raw_extension_area(), None);
+    assert_eq!(tga.developer_directory(), None);
+    assert_eq!(tga.extension_area(), None);
+
     assert_eq!(tga.color_bpp(), Bpp::Bits24);
+    assert_eq!(tga.image_data_bpp(), Bpp::Bits8);
 }
 
 #[test]
 fn type1_16bpp_tl() {
-    let tga = Tga::from_slice_raw(include_bytes!("../tests/type1_16bpp_tl.tga")).unwrap();
+    let tga = RawTga::from_slice(include_bytes!("../tests/type1_16bpp_tl.tga")).unwrap();
 
     assert_eq!(
-        tga.raw_header(),
+        tga.header(),
         TgaHeader {
             has_color_map: true,
             image_type: ImageType::ColorMapped,
@@ -72,17 +76,19 @@ fn type1_16bpp_tl() {
             ..HEADER_DEFAULT
         }
     );
-    assert_eq!(tga.raw_developer_directory(), None);
-    assert_eq!(tga.raw_extension_area(), None);
+    assert_eq!(tga.developer_directory(), None);
+    assert_eq!(tga.extension_area(), None);
+
     assert_eq!(tga.color_bpp(), Bpp::Bits16);
+    assert_eq!(tga.image_data_bpp(), Bpp::Bits8);
 }
 
 #[test]
 fn type1_24bpp_tl() {
-    let tga = Tga::from_slice_raw(include_bytes!("../tests/type1_24bpp_tl.tga")).unwrap();
+    let tga = RawTga::from_slice(include_bytes!("../tests/type1_24bpp_tl.tga")).unwrap();
 
     assert_eq!(
-        tga.raw_header(),
+        tga.header(),
         TgaHeader {
             has_color_map: true,
             image_type: ImageType::ColorMapped,
@@ -93,51 +99,57 @@ fn type1_24bpp_tl() {
             ..HEADER_DEFAULT
         }
     );
-    assert_eq!(tga.raw_developer_directory(), None);
-    assert_eq!(tga.raw_extension_area(), None);
+    assert_eq!(tga.developer_directory(), None);
+    assert_eq!(tga.extension_area(), None);
+
     assert_eq!(tga.color_bpp(), Bpp::Bits24);
+    assert_eq!(tga.image_data_bpp(), Bpp::Bits8);
 }
 
 #[test]
 fn type2_16bpp_bl() {
-    let tga = Tga::from_slice_raw(include_bytes!("../tests/type2_16bpp_bl.tga")).unwrap();
+    let tga = RawTga::from_slice(include_bytes!("../tests/type2_16bpp_bl.tga")).unwrap();
 
     assert_eq!(
-        tga.raw_header(),
+        tga.header(),
         TgaHeader {
             image_type: ImageType::Truecolor,
             pixel_depth: Bpp::Bits16,
             ..HEADER_DEFAULT
         }
     );
-    assert_eq!(tga.raw_developer_directory(), None);
-    assert_eq!(tga.raw_extension_area(), None);
+    assert_eq!(tga.developer_directory(), None);
+    assert_eq!(tga.extension_area(), None);
+
     assert_eq!(tga.color_bpp(), Bpp::Bits16);
+    assert_eq!(tga.image_data_bpp(), Bpp::Bits16);
 }
 
 #[test]
 fn type2_24bpp_bl() {
-    let tga = Tga::from_slice_raw(include_bytes!("../tests/type2_24bpp_bl.tga")).unwrap();
+    let tga = RawTga::from_slice(include_bytes!("../tests/type2_24bpp_bl.tga")).unwrap();
 
     assert_eq!(
-        tga.raw_header(),
+        tga.header(),
         TgaHeader {
             image_type: ImageType::Truecolor,
             pixel_depth: Bpp::Bits24,
             ..HEADER_DEFAULT
         }
     );
-    assert_eq!(tga.raw_developer_directory(), None);
-    assert_eq!(tga.raw_extension_area(), None);
+    assert_eq!(tga.developer_directory(), None);
+    assert_eq!(tga.extension_area(), None);
+
     assert_eq!(tga.color_bpp(), Bpp::Bits24);
+    assert_eq!(tga.image_data_bpp(), Bpp::Bits24);
 }
 
 #[test]
 fn type2_16bpp_tl() {
-    let tga = Tga::from_slice_raw(include_bytes!("../tests/type2_16bpp_tl.tga")).unwrap();
+    let tga = RawTga::from_slice(include_bytes!("../tests/type2_16bpp_tl.tga")).unwrap();
 
     assert_eq!(
-        tga.raw_header(),
+        tga.header(),
         TgaHeader {
             image_type: ImageType::Truecolor,
             pixel_depth: Bpp::Bits16,
@@ -145,17 +157,19 @@ fn type2_16bpp_tl() {
             ..HEADER_DEFAULT
         }
     );
-    assert_eq!(tga.raw_developer_directory(), None);
-    assert_eq!(tga.raw_extension_area(), None);
+    assert_eq!(tga.developer_directory(), None);
+    assert_eq!(tga.extension_area(), None);
+
     assert_eq!(tga.color_bpp(), Bpp::Bits16);
+    assert_eq!(tga.image_data_bpp(), Bpp::Bits16);
 }
 
 #[test]
 fn type2_24bpp_tl() {
-    let tga = Tga::from_slice_raw(include_bytes!("../tests/type2_24bpp_tl.tga")).unwrap();
+    let tga = RawTga::from_slice(include_bytes!("../tests/type2_24bpp_tl.tga")).unwrap();
 
     assert_eq!(
-        tga.raw_header(),
+        tga.header(),
         TgaHeader {
             image_type: ImageType::Truecolor,
             pixel_depth: Bpp::Bits24,
@@ -163,50 +177,56 @@ fn type2_24bpp_tl() {
             ..HEADER_DEFAULT
         }
     );
-    assert_eq!(tga.raw_developer_directory(), None);
-    assert_eq!(tga.raw_extension_area(), None);
+    assert_eq!(tga.developer_directory(), None);
+    assert_eq!(tga.extension_area(), None);
+
     assert_eq!(tga.color_bpp(), Bpp::Bits24);
+    assert_eq!(tga.image_data_bpp(), Bpp::Bits24);
 }
 
 #[test]
 fn type3_bl() {
-    let tga = Tga::from_slice_raw(include_bytes!("../tests/type3_bl.tga")).unwrap();
+    let tga = RawTga::from_slice(include_bytes!("../tests/type3_bl.tga")).unwrap();
 
     assert_eq!(
-        tga.raw_header(),
+        tga.header(),
         TgaHeader {
             image_type: ImageType::Monochrome,
             ..HEADER_DEFAULT
         }
     );
-    assert_eq!(tga.raw_developer_directory(), None);
-    assert_eq!(tga.raw_extension_area(), None);
+    assert_eq!(tga.developer_directory(), None);
+    assert_eq!(tga.extension_area(), None);
+
     assert_eq!(tga.color_bpp(), Bpp::Bits8);
+    assert_eq!(tga.image_data_bpp(), Bpp::Bits8);
 }
 
 #[test]
 fn type3_tl() {
-    let tga = Tga::from_slice_raw(include_bytes!("../tests/type3_tl.tga")).unwrap();
+    let tga = RawTga::from_slice(include_bytes!("../tests/type3_tl.tga")).unwrap();
 
     assert_eq!(
-        tga.raw_header(),
+        tga.header(),
         TgaHeader {
             image_type: ImageType::Monochrome,
             image_origin: ImageOrigin::TopLeft,
             ..HEADER_DEFAULT
         }
     );
-    assert_eq!(tga.raw_developer_directory(), None);
-    assert_eq!(tga.raw_extension_area(), None);
+    assert_eq!(tga.developer_directory(), None);
+    assert_eq!(tga.extension_area(), None);
+
     assert_eq!(tga.color_bpp(), Bpp::Bits8);
+    assert_eq!(tga.image_data_bpp(), Bpp::Bits8);
 }
 
 #[test]
 fn type9_16bpp() {
-    let tga = Tga::from_slice_raw(include_bytes!("../tests/type9_16bpp_bl.tga")).unwrap();
+    let tga = RawTga::from_slice(include_bytes!("../tests/type9_16bpp_bl.tga")).unwrap();
 
     assert_eq!(
-        tga.raw_header(),
+        tga.header(),
         TgaHeader {
             has_color_map: true,
             image_type: ImageType::RleColorMapped,
@@ -216,17 +236,19 @@ fn type9_16bpp() {
             ..HEADER_DEFAULT
         }
     );
-    assert_eq!(tga.raw_developer_directory(), None);
-    assert_eq!(tga.raw_extension_area(), None);
+    assert_eq!(tga.developer_directory(), None);
+    assert_eq!(tga.extension_area(), None);
+
     assert_eq!(tga.color_bpp(), Bpp::Bits16);
+    assert_eq!(tga.image_data_bpp(), Bpp::Bits8);
 }
 
 #[test]
 fn type9_24bpp_bl() {
-    let tga = Tga::from_slice_raw(include_bytes!("../tests/type9_24bpp_bl.tga")).unwrap();
+    let tga = RawTga::from_slice(include_bytes!("../tests/type9_24bpp_bl.tga")).unwrap();
 
     assert_eq!(
-        tga.raw_header(),
+        tga.header(),
         TgaHeader {
             has_color_map: true,
             image_type: ImageType::RleColorMapped,
@@ -236,17 +258,19 @@ fn type9_24bpp_bl() {
             ..HEADER_DEFAULT
         }
     );
-    assert_eq!(tga.raw_developer_directory(), None);
-    assert_eq!(tga.raw_extension_area(), None);
+    assert_eq!(tga.developer_directory(), None);
+    assert_eq!(tga.extension_area(), None);
+
     assert_eq!(tga.color_bpp(), Bpp::Bits24);
+    assert_eq!(tga.image_data_bpp(), Bpp::Bits8);
 }
 
 #[test]
 fn type9_16bpp_tl() {
-    let tga = Tga::from_slice_raw(include_bytes!("../tests/type9_16bpp_tl.tga")).unwrap();
+    let tga = RawTga::from_slice(include_bytes!("../tests/type9_16bpp_tl.tga")).unwrap();
 
     assert_eq!(
-        tga.raw_header(),
+        tga.header(),
         TgaHeader {
             has_color_map: true,
             image_type: ImageType::RleColorMapped,
@@ -257,17 +281,19 @@ fn type9_16bpp_tl() {
             ..HEADER_DEFAULT
         }
     );
-    assert_eq!(tga.raw_developer_directory(), None);
-    assert_eq!(tga.raw_extension_area(), None);
+    assert_eq!(tga.developer_directory(), None);
+    assert_eq!(tga.extension_area(), None);
+
     assert_eq!(tga.color_bpp(), Bpp::Bits16);
+    assert_eq!(tga.image_data_bpp(), Bpp::Bits8);
 }
 
 #[test]
 fn type9_24bpp_tl() {
-    let tga = Tga::from_slice_raw(include_bytes!("../tests/type9_24bpp_tl.tga")).unwrap();
+    let tga = RawTga::from_slice(include_bytes!("../tests/type9_24bpp_tl.tga")).unwrap();
 
     assert_eq!(
-        tga.raw_header(),
+        tga.header(),
         TgaHeader {
             has_color_map: true,
             image_type: ImageType::RleColorMapped,
@@ -278,51 +304,57 @@ fn type9_24bpp_tl() {
             ..HEADER_DEFAULT
         }
     );
-    assert_eq!(tga.raw_developer_directory(), None);
-    assert_eq!(tga.raw_extension_area(), None);
+    assert_eq!(tga.developer_directory(), None);
+    assert_eq!(tga.extension_area(), None);
+
     assert_eq!(tga.color_bpp(), Bpp::Bits24);
+    assert_eq!(tga.image_data_bpp(), Bpp::Bits8);
 }
 
 #[test]
 fn type10_16bpp_bl() {
-    let tga = Tga::from_slice_raw(include_bytes!("../tests/type10_16bpp_bl.tga")).unwrap();
+    let tga = RawTga::from_slice(include_bytes!("../tests/type10_16bpp_bl.tga")).unwrap();
 
     assert_eq!(
-        tga.raw_header(),
+        tga.header(),
         TgaHeader {
             image_type: ImageType::RleTruecolor,
             pixel_depth: Bpp::Bits16,
             ..HEADER_DEFAULT
         }
     );
-    assert_eq!(tga.raw_developer_directory(), None);
-    assert_eq!(tga.raw_extension_area(), None);
+    assert_eq!(tga.developer_directory(), None);
+    assert_eq!(tga.extension_area(), None);
+
     assert_eq!(tga.color_bpp(), Bpp::Bits16);
+    assert_eq!(tga.image_data_bpp(), Bpp::Bits16);
 }
 
 #[test]
 fn type10_24bpp_bl() {
-    let tga = Tga::from_slice_raw(include_bytes!("../tests/type10_24bpp_bl.tga")).unwrap();
+    let tga = RawTga::from_slice(include_bytes!("../tests/type10_24bpp_bl.tga")).unwrap();
 
     assert_eq!(
-        tga.raw_header(),
+        tga.header(),
         TgaHeader {
             image_type: ImageType::RleTruecolor,
             pixel_depth: Bpp::Bits24,
             ..HEADER_DEFAULT
         }
     );
-    assert_eq!(tga.raw_developer_directory(), None);
-    assert_eq!(tga.raw_extension_area(), None);
+    assert_eq!(tga.developer_directory(), None);
+    assert_eq!(tga.extension_area(), None);
+
     assert_eq!(tga.color_bpp(), Bpp::Bits24);
+    assert_eq!(tga.image_data_bpp(), Bpp::Bits24);
 }
 
 #[test]
 fn type10_16bpp_tl() {
-    let tga = Tga::from_slice_raw(include_bytes!("../tests/type10_16bpp_tl.tga")).unwrap();
+    let tga = RawTga::from_slice(include_bytes!("../tests/type10_16bpp_tl.tga")).unwrap();
 
     assert_eq!(
-        tga.raw_header(),
+        tga.header(),
         TgaHeader {
             image_type: ImageType::RleTruecolor,
             pixel_depth: Bpp::Bits16,
@@ -330,17 +362,19 @@ fn type10_16bpp_tl() {
             ..HEADER_DEFAULT
         }
     );
-    assert_eq!(tga.raw_developer_directory(), None);
-    assert_eq!(tga.raw_extension_area(), None);
+    assert_eq!(tga.developer_directory(), None);
+    assert_eq!(tga.extension_area(), None);
+
     assert_eq!(tga.color_bpp(), Bpp::Bits16);
+    assert_eq!(tga.image_data_bpp(), Bpp::Bits16);
 }
 
 #[test]
 fn type10_24bpp_tl() {
-    let tga = Tga::from_slice_raw(include_bytes!("../tests/type10_24bpp_tl.tga")).unwrap();
+    let tga = RawTga::from_slice(include_bytes!("../tests/type10_24bpp_tl.tga")).unwrap();
 
     assert_eq!(
-        tga.raw_header(),
+        tga.header(),
         TgaHeader {
             image_type: ImageType::RleTruecolor,
             pixel_depth: Bpp::Bits24,
@@ -348,40 +382,46 @@ fn type10_24bpp_tl() {
             ..HEADER_DEFAULT
         }
     );
-    assert_eq!(tga.raw_developer_directory(), None);
-    assert_eq!(tga.raw_extension_area(), None);
+    assert_eq!(tga.developer_directory(), None);
+    assert_eq!(tga.extension_area(), None);
+
     assert_eq!(tga.color_bpp(), Bpp::Bits24);
+    assert_eq!(tga.image_data_bpp(), Bpp::Bits24);
 }
 
 #[test]
 fn type11_bl() {
-    let tga = Tga::from_slice_raw(include_bytes!("../tests/type11_bl.tga")).unwrap();
+    let tga = RawTga::from_slice(include_bytes!("../tests/type11_bl.tga")).unwrap();
 
     assert_eq!(
-        tga.raw_header(),
+        tga.header(),
         TgaHeader {
             image_type: ImageType::RleMonochrome,
             ..HEADER_DEFAULT
         }
     );
-    assert_eq!(tga.raw_developer_directory(), None);
-    assert_eq!(tga.raw_extension_area(), None);
+    assert_eq!(tga.developer_directory(), None);
+    assert_eq!(tga.extension_area(), None);
+
     assert_eq!(tga.color_bpp(), Bpp::Bits8);
+    assert_eq!(tga.image_data_bpp(), Bpp::Bits8);
 }
 
 #[test]
 fn type11_tl() {
-    let tga = Tga::from_slice_raw(include_bytes!("../tests/type11_tl.tga")).unwrap();
+    let tga = RawTga::from_slice(include_bytes!("../tests/type11_tl.tga")).unwrap();
 
     assert_eq!(
-        tga.raw_header(),
+        tga.header(),
         TgaHeader {
             image_type: ImageType::RleMonochrome,
             image_origin: ImageOrigin::TopLeft,
             ..HEADER_DEFAULT
         }
     );
-    assert_eq!(tga.raw_developer_directory(), None);
-    assert_eq!(tga.raw_extension_area(), None);
+    assert_eq!(tga.developer_directory(), None);
+    assert_eq!(tga.extension_area(), None);
+
     assert_eq!(tga.color_bpp(), Bpp::Bits8);
+    assert_eq!(tga.image_data_bpp(), Bpp::Bits8);
 }

--- a/tinytga/tests/ubw8.rs
+++ b/tinytga/tests/ubw8.rs
@@ -1,16 +1,16 @@
-use tinytga::{Bpp, ImageOrigin, ImageType, Tga, TgaHeader};
+use tinytga::{Bpp, ImageOrigin, ImageType, RawTga, TgaHeader};
 
 #[test]
 fn ubw8() {
     let data = include_bytes!("./ubw8.tga");
 
-    let img = Tga::from_slice_raw(data).unwrap();
+    let img = RawTga::from_slice(data).unwrap();
 
-    println!("{:#?}", img.raw_header());
-    println!("Raw image data len {:#?}", img.raw_image_data().len());
+    println!("{:#?}", img.header());
+    println!("Raw image data len {:#?}", img.image_data().len());
 
     assert_eq!(
-        img.raw_header(),
+        img.header(),
         TgaHeader {
             id_len: 26,
             has_color_map: false,
@@ -30,12 +30,12 @@ fn ubw8() {
 
     const TGA_FOOTER_LENGTH: usize = 26;
     assert_eq!(
-        img.raw_extension_area(),
+        img.extension_area(),
         Some(&data[20526..data.len() - TGA_FOOTER_LENGTH])
     );
-    assert_eq!(img.raw_developer_directory(), None);
+    assert_eq!(img.developer_directory(), None);
 
-    let pixels: Vec<_> = img.raw_pixels().collect();
+    let pixels: Vec<_> = img.pixels().collect();
 
     assert_eq!(pixels.len(), 128 * 128);
 }


### PR DESCRIPTION
Hi! Thank you for helping out with Embedded Graphics development! Please:

- [ ] Check that you've added passing tests and documentation
- [ ] Add a simulator example(s) where applicable
- [ ] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) and appropriate crate (`embedded-graphics`, `simulator`, `tinytga`, `tinybmp`) if your changes affect the **public API**
- [ ] Run `rustfmt` on the project
- [ ] Run `just build` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

This PR adds `DynamicTga` which is the first part of #424. The implementation depends on the color conversion suggested in #446, so I've also included that in this PR.

I've also decided to revert a change I made in #430, where I merged `Tga` and `TgaRaw`. Keeping them separate results in a cleaner API and I'm not sure why I decided to change that in the first place.