### PR TITLE
Detect errors in for loops in the justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -97,10 +97,14 @@ generate-readme crate: (_build-readme crate)
 
 # Generate README.md for all crates
 generate-readmes:
+    #!/usr/bin/env bash
+    set -e
     for crate in {{crates}}; do just generate-readme $crate; done
 
 # Checks README.md for all crates
 check-readmes:
+    #!/usr/bin/env bash
+    set -e
     for crate in {{crates}}; do just check-readme $crate; done
 
 # Builds README.md for a single crate
@@ -151,6 +155,8 @@ generate-example-screenshot example:
 
 # Generates screenshots of all examples
 @generate-example-screenshots:
+    #!/usr/bin/env bash
+    set -e
     for example in simulator/examples/*.rs; do \
         just generate-example-screenshot $(basename "$example" .rs); \
     done


### PR DESCRIPTION
This PR should fix #449. The problem was caused by some shell scripting weirdness: Apparently for loops in shell scripts only return the exit code of the last iteration and ignore any other errors.

If everything works as expected CI should break with this fix applied. I didn't want to include the README update in this PR, because it is also included in #450. If we merge that one before this PR no merge conflicts should exist.
