### PR TITLE
Fix filter_readme.sed

### DIFF
--- a/embedded-graphics/README.md
+++ b/embedded-graphics/README.md
@@ -112,7 +112,7 @@ cargo run -p embedded-graphics-simulator --example hello
 Additional features can be enabled by adding the following features to your `Cargo.toml`.
 
 * `nalgebra_support` - use the [Nalgebra](https://crates.io/crates/nalgebra) crate with `no_std`
-support to enable conversions from `nalgebra::Vector2` to `Point` and `Size` 
+support to enable conversions from `nalgebra::Vector2` to `Point` and `Size`.
 
 * `fixed_point` - use fixed point arithmetic instead of floating point for all trigonometric
 calculation.
@@ -124,7 +124,7 @@ Please read [the migration guide](https://github.com/jamwaffles/embedded-graphic
 ## Implementing `embedded_graphics` support for a display driver
 
 To add support for embedded-graphics to a display driver, `DrawTarget` must be implemented.
-This allows all embedded-graphics items to be rendered by the display. See the `DrawTarget` 
+This allows all embedded-graphics items to be rendered by the display. See the `DrawTarget`
 documentation for implementation details.
 
 ## Examples

--- a/filter_readme.sed
+++ b/filter_readme.sed
@@ -9,4 +9,4 @@ s/\[(.+)\]\(.*(struct|enum|trait|type|fn|index).*\)/\1/g
 
 # Remove square braces from footer-reference-style inline links like "[`Foo`]",
 # leaving "`Foo`" in its place
-s/\[(`[^]]*`)\]([^\(:]|$)/\1 /g
+s/\[(`[^]]*`)\]([^\(:]|$)/\1\2/g

--- a/tinybmp/README.md
+++ b/tinybmp/README.md
@@ -11,7 +11,7 @@ A small BMP parser designed for embedded, no-std environments but usable anywher
 parsing the image header, no other allocations are made.
 
 To use `tinybmp` without `embedded-graphics` the raw data for individual pixels in an image
-can be accessed using the `raw_pixels` and `raw_image_data` methods provided by the `Bmp` 
+can be accessed using the `raw_pixels` and `raw_image_data` methods provided by the `Bmp`
 struct.
 
 ## Examples
@@ -35,7 +35,7 @@ image.draw(&mut display)?;
 ### Accessing the raw image data
 
 This example demonstrates how the image header and raw image data can be accessed to use
-`tinybmp` without `embedded-graphics` 
+`tinybmp` without `embedded-graphics`.
 
 ```rust
 use tinybmp::{Bmp, Bpp, Header, RawPixel};

--- a/tinytga/README.md
+++ b/tinytga/README.md
@@ -86,7 +86,7 @@ let pixels: Vec<_> = img.pixels().collect();
 
 If [embedded-graphics] is not used in the target application, the raw image data can be
 accessed with the `pixels` method on
-`RawTga`  The returned iterator produces a `u32` for each pixel value.
+`RawTga`. The returned iterator produces a `u32` for each pixel value.
 
 ```rust
 use embedded_graphics::{prelude::*, pixelcolor::Rgb888};
@@ -127,7 +127,7 @@ let pixels: Vec<_> = img.pixels().collect();
 `Tga` should by used instead of `DynamicTga` when possible to reduce the risk of
 accidentally adding unnecessary color conversions.
 
-`tinytga` uses different code paths to draw images with different `ImageOrigin` .
+`tinytga` uses different code paths to draw images with different `ImageOrigin`s.
 The performance difference between the origins will depend on the display driver, but using
 images with the origin at the top left corner will generally result in the best performance.
 


### PR DESCRIPTION
The removal of the square bracket links was slightly broken which caused colons at the end of sentences to disappear.